### PR TITLE
Auto-install WordPress + plugins on initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Scaffold a local **WordPress + AI-agent** development environment (Docker Compose) — WordPress + MariaDB plus an isolated **workspace** container with Node, [Claude Code](https://claude.com/claude-code), PHP, and WP-CLI ready to go.
 
-It only **scaffolds files**; it never runs Docker. The generated project ships npm scripts (`npm run start`, `npm run bash`, `npm run claude`, …) for that.
+It scaffolds the project **and runs the initial setup** for you — `docker compose up`, then installs WordPress and the configured plugins — so you land on a working site. Pass `--scaffold-only` to just write files and skip Docker. The generated project ships npm scripts (`npm run start`, `npm run bash`, `npm run claude`, …) for everyday use.
 
 ## Usage
 
@@ -15,15 +15,16 @@ npx create-wp-local-dev-agent-sandbox my-site
 
 # choose a host port (default 8080):
 npx create-wp-local-dev-agent-sandbox my-site --port=8090
+
+# just write files, don't touch Docker:
+npx create-wp-local-dev-agent-sandbox my-site --scaffold-only
 ```
 
-Then:
+Docker must be running. When it finishes you have a live site at **http://localhost:8080** — log in at `/wp-admin` with `admin` / `password`. Then:
 
 ```bash
 cd my-site
-npm run setup      # first run: build, start & install WordPress (Docker must be running)
-# open http://localhost:8080  → log in at /wp-admin with admin / password
-npm run start      # subsequent runs: just bring the containers up
+npm run start      # bring the stack up next time (it stays up otherwise)
 npm run bash       # shell into the workspace container
 npm run claude     # launch Claude Code in the workspace
 ```
@@ -56,7 +57,7 @@ The two things you edit:
 - **`index.js`** — the CLI logic (arg parsing, file copying, substitutions)
 - **`templates/`** — the files that get scaffolded (compose file, Dockerfile, the project's `package.json` scripts, etc.)
 
-The scaffolder is a *file generator* — it never runs Docker, and it creates no `wp/`/`db/`/`workspace/` data. Those only appear when Docker runs inside a *generated* project.
+By default the scaffolder also runs `npm run setup` in the generated project (docker compose up + WordPress/plugin install). Use `--scaffold-only` to just generate files — then it creates no `wp/`/`db/`/`workspace/` data, which only appears once Docker runs inside a *generated* project.
 
 ### Test a change end to end
 
@@ -64,14 +65,15 @@ The scaffolder is a *file generator* — it never runs Docker, and it creates no
 cd <this-repo>
 
 # 1. Scaffold into a throwaway dir (use a port that won't clash with other instances)
-node index.js /tmp/try-it --port=8090
+#    Drop --scaffold-only to also build + boot + install in one go (Docker must be running).
+node index.js /tmp/try-it --port=8090 --scaffold-only
 
 # 2. Inspect the generated config files
 ls /tmp/try-it
 
-# 3. Actually boot it (Docker must be running)
+# 3. Boot + provision it (Docker must be running)
 cd /tmp/try-it
-npm run setup            # up -d --build, then auto-installs WordPress
+npm run setup            # up -d --build, then installs WordPress + plugins
 #   → open http://localhost:8090 and log in at /wp-admin with admin / password
 #   (after the first run, `npm run start` is all you need)
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Then:
 
 ```bash
 cd my-site
-npm run start      # build + start (Docker must be running)
-# open http://localhost:8080
+npm run setup      # first run: build, start & install WordPress (Docker must be running)
+# open http://localhost:8080  → log in at /wp-admin with admin / password
+npm run start      # subsequent runs: just bring the containers up
 npm run bash       # shell into the workspace container
 npm run claude     # launch Claude Code in the workspace
 ```
@@ -35,7 +36,9 @@ my-site/
 ├── workspace.Dockerfile    # Node + Claude Code + PHP + WP-CLI (runs as non-root)
 ├── .env                    # DB creds + WP_PORT
 ├── .gitignore              # ignores the bind-mounted data dirs
-├── package.json            # the npm-scripts UX (start/stop/bash/claude/wp/reset)
+├── package.json            # the npm-scripts UX (setup/start/stop/bash/claude/wp/reset)
+├── sandbox.config.json     # plugins to install on `npm run setup` (+ future params)
+├── scripts/                # initial-setup.sh → install-wp.sh + install-plugins.sh
 └── README.md
 ```
 
@@ -68,8 +71,9 @@ ls /tmp/try-it
 
 # 3. Actually boot it (Docker must be running)
 cd /tmp/try-it
-npm run start            # docker compose up -d --build
-#   → open http://localhost:8090 and finish the WordPress installer
+npm run setup            # up -d --build, then auto-installs WordPress
+#   → open http://localhost:8090 and log in at /wp-admin with admin / password
+#   (after the first run, `npm run start` is all you need)
 
 # 4. Get into the workspace container to test it (lands you in /wp)
 npm run bash

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const RENAME = {
 };
 
 // Key files we refuse to clobber if the target already has them.
-const GUARD = ['docker-compose.yml', 'package.json', '.env', 'workspace.Dockerfile'];
+const GUARD = ['docker-compose.yml', 'package.json', '.env', 'workspace.Dockerfile', 'sandbox.config.json'];
 
 function parseArgs(argv) {
   const out = { dir: null, port: '8080' };
@@ -95,8 +95,9 @@ async function main() {
   console.log(`\n✔ Scaffolded WordPress + agent sandbox in ${targetDir}\n`);
   console.log('Next steps:');
   console.log(`  cd ${cd}`);
-  console.log('  npm run start        # build + start containers (Docker must be running)');
+  console.log('  npm run setup        # first run: build, start & install WordPress (admin / password)');
   console.log(`  open http://localhost:${args.port}`);
+  console.log('  npm run start        # subsequent runs: just bring the containers up');
   console.log('  npm run bash         # shell into the workspace container');
   console.log('  npm run claude       # launch Claude Code in the workspace');
   console.log('');

--- a/index.js
+++ b/index.js
@@ -3,17 +3,18 @@
  * create-wp-local-dev-agent-sandbox
  *
  * Scaffolds a local WordPress + AI-agent dev environment (Docker Compose) into
- * a target directory. Does NOT run Docker — the scaffolded project ships npm
- * scripts (npm run start / bash / claude / …) for that.
+ * a target directory, then runs `npm run setup` (docker compose up + WordPress
+ * and plugin install). Pass --scaffold-only to write files and skip Docker.
  *
  * Usage:
- *   npm create wp-local-dev-agent-sandbox -- [dir] [--port=8080]
- *   npx create-wp-local-dev-agent-sandbox [dir] [--port=8080]
+ *   npm create wp-local-dev-agent-sandbox -- [dir] [--port=8080] [--scaffold-only]
+ *   npx create-wp-local-dev-agent-sandbox [dir] [--port=8080] [--scaffold-only]
  */
 
 import { readdir, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES = join(HERE, 'templates');
@@ -28,9 +29,10 @@ const RENAME = {
 const GUARD = ['docker-compose.yml', 'package.json', '.env', 'workspace.Dockerfile', 'sandbox.config.json'];
 
 function parseArgs(argv) {
-  const out = { dir: null, port: '8080' };
+  const out = { dir: null, port: '8080', setup: true };
   for (const a of argv) {
     if (a.startsWith('--port=')) out.port = a.slice('--port='.length);
+    else if (a === '--scaffold-only') out.setup = false;
     else if (a === '-h' || a === '--help') out.help = true;
     else if (!a.startsWith('-') && out.dir === null) out.dir = a;
   }
@@ -43,12 +45,15 @@ function usage() {
 Scaffold a local WordPress + AI-agent Docker dev environment.
 
 Usage:
-  npm create wp-local-dev-agent-sandbox -- [dir] [--port=8080]
-  npx create-wp-local-dev-agent-sandbox [dir] [--port=8080]
+  npm create wp-local-dev-agent-sandbox -- [dir] [--port=8080] [--scaffold-only]
+  npx create-wp-local-dev-agent-sandbox [dir] [--port=8080] [--scaffold-only]
 
 Arguments:
-  dir            Target directory (default: current directory)
-  --port=NNNN    Host port for WordPress (default: 8080)
+  dir              Target directory (default: current directory)
+
+Options:
+  --port=NNNN      Host port for WordPress (default: 8080)
+  --scaffold-only  Only write files; skip the automatic \`npm run setup\`
 `);
 }
 
@@ -93,13 +98,33 @@ async function main() {
 
   const cd = args.dir ? args.dir : '.';
   console.log(`\n✔ Scaffolded WordPress + agent sandbox in ${targetDir}\n`);
-  console.log('Next steps:');
+
+  if (!args.setup) {
+    console.log('Next steps:');
+    console.log(`  cd ${cd}`);
+    console.log('  npm run setup        # build, start & install WordPress + plugins (Docker must be running)');
+    console.log(`  open http://localhost:${args.port}   # then log in at /wp-admin with admin / password`);
+    console.log('  npm run start        # subsequent runs: just bring the containers up');
+    console.log('  npm run claude       # launch Claude Code in the workspace');
+    return;
+  }
+
+  console.log('→ Running initial setup (Docker must be running)…\n');
+  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const res = spawnSync(npm, ['run', 'setup'], { cwd: targetDir, stdio: 'inherit' });
+  if (res.error || res.status !== 0) {
+    console.error('\n✖ Initial setup did not finish (is Docker running?).');
+    console.error('  Your files are scaffolded — retry once Docker is up:');
+    console.error(`    cd ${cd} && npm run setup\n`);
+    process.exit(res.status ?? 1);
+  }
+
+  console.log('\nReady. Next steps:');
+  console.log(`  open http://localhost:${args.port}   # log in at /wp-admin with admin / password`);
   console.log(`  cd ${cd}`);
-  console.log('  npm run setup        # first run: build, start & install WordPress (admin / password)');
-  console.log(`  open http://localhost:${args.port}`);
-  console.log('  npm run start        # subsequent runs: just bring the containers up');
-  console.log('  npm run bash         # shell into the workspace container');
+  console.log('  npm run start        # bring the stack up next time (it stays up otherwise)');
   console.log('  npm run claude       # launch Claude Code in the workspace');
+  console.log('  npm run bash         # shell into the workspace container');
   console.log('');
 }
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -17,14 +17,28 @@ All data lives in bind-mounted folders in this directory (`db/`, `wp/`, `workspa
 
 ## Usage
 
+First time:
+
 ```bash
-npm run start     # build + start everything (first run pulls images & installs WordPress)
+npm run setup     # build, start, and install WordPress
 ```
 
-Then open **http://localhost:__WP_PORT__** and finish the WordPress installer.
+`npm run setup` brings the stack up, installs WordPress, and installs/activates the plugins listed in [`sandbox.config.json`](#plugins-sandboxconfigjson). It's idempotent — safe to re-run.
+
+Then open **http://localhost:__WP_PORT__**. WordPress is already installed — log in at **/wp-admin** with:
+
+- **Username:** `admin`
+- **Password:** `password`
+
+Day to day, just bring the containers up:
+
+```bash
+npm run start     # build + start containers
+```
 
 | Script | What it does |
 | --- | --- |
+| `npm run setup` | First-run: start the stack, install WordPress (`admin` / `password`), install plugins |
 | `npm run start` | `docker compose up -d --build` |
 | `npm run stop` | Stop containers (keep data) |
 | `npm run down` | Stop + remove containers (data preserved in `db/`, `wp/`, `workspace/`) |
@@ -35,6 +49,25 @@ Then open **http://localhost:__WP_PORT__** and finish the WordPress installer.
 | `npm run claude` | Launch Claude Code in the workspace (`--dangerously-skip-permissions`, safe because it's contained) |
 | `npm run wp` | Run WP-CLI, e.g. `npm run wp -- plugin list` |
 | `npm run reset` | ⚠️ Wipe all data and rebuild from scratch |
+
+## Plugins (`sandbox.config.json`)
+
+The plugins installed during `npm run setup` are declared in `sandbox.config.json`:
+
+```json
+{
+  "plugins": [
+    { "source": "ai", "activate": true },
+    { "source": "https://github.com/WordPress/mcp-adapter/releases/download/v0.5.0/mcp-adapter.zip", "activate": true }
+  ]
+}
+```
+
+- **`source`** — a [wordpress.org](https://wordpress.org/plugins/) slug (e.g. `"ai"`) or a URL/path to a plugin `.zip`.
+- **`activate`** — activate after install (default `true`).
+- **`version`** — optional, wordpress.org slugs only (e.g. `"5.3"`).
+
+A bare string is shorthand for `{ "source": "<string>", "activate": true }`. After editing, re-run `npm run setup` (it's idempotent — already-installed plugins are skipped), or apply just the plugin step with `bash scripts/install-plugins.sh`.
 
 ## Notes
 

--- a/templates/package.json
+++ b/templates/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "description": "Local WordPress + AI-agent dev sandbox (Docker).",
   "scripts": {
+    "setup": "bash scripts/initial-setup.sh",
     "start": "docker compose up -d --build",
     "stop": "docker compose stop",
     "down": "docker compose down",
@@ -13,6 +14,6 @@
     "bash": "docker compose exec workspace bash",
     "claude": "docker compose exec workspace claude --dangerously-skip-permissions",
     "wp": "docker compose exec workspace wp",
-    "reset": "docker compose down && rm -rf db wp workspace && docker compose up -d --build"
+    "reset": "docker compose down && rm -rf db wp workspace && bash scripts/initial-setup.sh"
   }
 }

--- a/templates/sandbox.config.json
+++ b/templates/sandbox.config.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    { "source": "ai", "activate": true },
+    { "source": "https://github.com/WordPress/mcp-adapter/releases/download/v0.5.0/mcp-adapter.zip", "activate": true }
+  ]
+}

--- a/templates/scripts/initial-setup.sh
+++ b/templates/scripts/initial-setup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# One-time setup: build & start the stack, wait for it to be ready, then run the
+# provisioning steps. Re-runnable — every step is idempotent.
+#
+# Day to day you just use `npm run start`; this is only for the first bring-up
+# (or after `npm run reset`).
+#
+set -euo pipefail
+
+# This script lives in scripts/ — operate from the project root.
+cd "$(dirname "$0")/.."
+
+echo "→ Building and starting containers…"
+docker compose up -d --build
+
+echo "→ Waiting for WordPress files and the database…"
+tries=0
+until docker compose exec -T workspace bash -c '[ -f /wp/wp-config.php ] && wp db query "SELECT 1;"' >/dev/null 2>&1; do
+  tries=$((tries + 1))
+  if [ "$tries" -gt 60 ]; then
+    echo "✖ Timed out waiting for the stack to come up." >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+# Provisioning steps — each is an idempotent host-side script that runs WP-CLI
+# in the workspace container. Add more steps here as setup grows.
+bash scripts/install-wp.sh
+bash scripts/install-plugins.sh
+
+echo ""
+echo "✓ Initial setup complete."

--- a/templates/scripts/install-plugins.sh
+++ b/templates/scripts/install-plugins.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Install & activate the plugins declared in sandbox.config.json (run via
+# `npm run setup`). Idempotent: WP-CLI skips plugins that are already installed.
+# Assumes the stack is up and WordPress is installed.
+#
+# sandbox.config.json format:
+#   { "plugins": [
+#       "ai",                                  // shorthand: wordpress.org slug
+#       { "source": "akismet", "activate": false, "version": "5.3" },
+#       { "source": "https://example.com/plugin.zip", "activate": true }
+#   ]}
+# "source" is a wordpress.org slug or a URL/path to a plugin zip. "activate"
+# defaults to true; "version" is optional (wordpress.org slugs only).
+#
+set -euo pipefail
+
+# This script lives in scripts/ — operate from the project root.
+cd "$(dirname "$0")/.."
+
+CONFIG="sandbox.config.json"
+if [ ! -f "$CONFIG" ]; then
+  echo "→ No $CONFIG — skipping plugins."
+  exit 0
+fi
+
+# Flatten the plugins array to tab-separated rows: source<TAB>activate<TAB>version.
+rows="$(node -e '
+  const fs = require("fs");
+  const cfg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  for (const p of cfg.plugins ?? []) {
+    const e = typeof p === "string" ? { source: p } : (p || {});
+    if (!e.source) continue;
+    const activate = e.activate === false ? "0" : "1";
+    process.stdout.write([e.source, activate, e.version ?? ""].join("\t") + "\n");
+  }
+' "$CONFIG")"
+
+if [ -z "$rows" ]; then
+  echo "→ No plugins listed in $CONFIG."
+  exit 0
+fi
+
+printf '%s\n' "$rows" | while IFS=$'\t' read -r source activate version; do
+  [ -n "$source" ] || continue
+  args=(plugin install "$source")
+  label="$source${version:+ @$version}"
+  if [ -n "$version" ]; then args+=(--version="$version"); fi
+  if [ "$activate" = "1" ]; then args+=(--activate); label="$label (activate)"; fi
+  echo "→ Plugin: $label"
+  # </dev/null so `docker compose exec` doesn't swallow the loop's remaining rows.
+  docker compose exec -T workspace wp "${args[@]}" </dev/null
+done
+
+echo "✓ Plugins processed."

--- a/templates/scripts/install-wp.sh
+++ b/templates/scripts/install-wp.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Install WordPress (admin / password) via WP-CLI in the workspace container
+# (run via `npm run setup`). Idempotent: no-ops if WordPress is already
+# installed. Assumes the stack is up.
+#
+set -euo pipefail
+
+# This script lives in scripts/ — operate from the project root.
+cd "$(dirname "$0")/.."
+
+# Load .env for the host port, used as the site URL.
+if [ -f .env ]; then
+  set -a; . ./.env; set +a
+fi
+WP_PORT="${WP_PORT:-8080}"
+
+if docker compose exec -T workspace wp core is-installed >/dev/null 2>&1; then
+  echo "✓ WordPress is already installed — nothing to do."
+  exit 0
+fi
+
+echo "→ Installing WordPress…"
+docker compose exec -T workspace wp core install \
+  --url="http://localhost:${WP_PORT}" \
+  --title="WordPress Dev" \
+  --admin_user="admin" \
+  --admin_password="password" \
+  --admin_email="admin@example.com" \
+  --skip-email
+
+cat <<EOF
+✓ WordPress installed.
+    Site:     http://localhost:${WP_PORT}
+    Admin:    http://localhost:${WP_PORT}/wp-admin/  (admin / password)
+EOF


### PR DESCRIPTION
## What & why

Today the scaffolded project doesn't actually install WordPress, and there's no way to declare plugins. This PR makes `create` turnkey: one command scaffolds the project, boots it, installs WordPress, and activates the configured plugins — you land on a working, logged-in-ready site.

## Two parts

### 1. One-time provisioning: `npm run setup`

A one-time bring-up, separate from the daily `npm run start` (unchanged). It builds + starts the stack, waits for it to be ready, installs WordPress, then installs/activates plugins. Idempotent — safe to re-run.

Provisioning lives in `scripts/`, all host-side scripts that drive WP-CLI in the workspace container:

- `initial-setup.sh` — orchestrator: `up -d --build`, waits for `wp-config.php` + DB, then runs the step scripts. **Add future setup steps by appending one `bash scripts/…` line here.**
- `install-wp.sh` — `wp core install` with `admin` / `password` (hardcoded, not configurable for now). No-ops if already installed.
- `install-plugins.sh` — reads `sandbox.config.json` and installs/activates each plugin.

**`sandbox.config.json`** (project root, git-tracked, guarded against re-scaffold clobber):

```json
{
  "plugins": [
    { "source": "ai", "activate": true },
    { "source": "https://github.com/WordPress/mcp-adapter/releases/download/v0.5.0/mcp-adapter.zip", "activate": true }
  ]
}
```

- `source` = wordpress.org slug **or** zip URL/path; `activate` (default true); `version` (optional, slugs only). Bare string = `{ "source": …, "activate": true }`.

`reset` now reprovisions via `initial-setup.sh`.

### 2. `create` runs setup automatically

`node index.js <dir>` (and `npm create` / `npx`) now runs `npm run setup` in the generated project by default, so create → working site is a single command. Pass **`--scaffold-only`** to just write files and skip Docker. If setup fails (e.g. Docker not running), the scaffolded files are kept and a retry hint is printed.

This reverses the old "scaffolder never runs Docker" stance; the READMEs are updated to match.

## Notes on plugin sources

- **`mcp-adapter`**: uses the pinned **v0.5.0 release zip** (the packaged distribution; ships its own autoloader, so no `composer install`). Requires WP 6.9+, which `wordpress:latest` satisfies. Bump the version in the config for newer releases.
- Fixed a stdin bug in the plugin loop: `docker compose exec` reads stdin, which swallowed remaining config rows so only the first plugin installed — fixed with `</dev/null`.

## Verification

- `node index.js <dir> --port=8093` (default path): builds, boots, installs WordPress, activates `ai 1.0.1` + `mcp-adapter 0.5.0`; site returns HTTP 200; prints "Ready".
- `--scaffold-only`: writes files only, no containers created.
- `npm run setup` re-run: fully idempotent (WordPress + already-installed plugins skipped cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
