### PR TITLE
Auto-connect Claude to the WordPress MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ my-site/
 ├── .gitignore              # ignores the bind-mounted data dirs
 ├── package.json            # the npm-scripts UX (setup/start/stop/bash/claude/wp/reset)
 ├── sandbox.config.json     # plugins to install on `npm run setup` (+ future params)
-├── scripts/                # initial-setup.sh → install-wp.sh + install-plugins.sh
+├── scripts/                # initial-setup.sh → install-wp.sh + install-plugins.sh + connect-mcp.sh
 └── README.md
 ```
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -74,4 +74,4 @@ A bare string is shorthand for `{ "source": "<string>", "activate": true }`. Aft
 - **Working on a plugin/theme?** It lives at `wp/wp-content/plugins/…` (or `themes/…`). Edit it on your machine or from inside the workspace container — same files, served live.
 - **First Claude run:** inside the workspace, run `npm run claude` and use `/login` once. Your login persists in `workspace/` across rebuilds.
 - **WP-CLI** talks to the database automatically over the Docker network.
-- **MCP:** if you use the WordPress MCP stack, point agents at `http://wordpress/wp-json/...` from inside the workspace container (the host port `__WP_PORT__` is not reachable between containers).
+- **MCP:** `npm run setup` connects Claude to WordPress's MCP server (from the [`mcp-adapter`](https://github.com/WordPress/mcp-adapter) plugin) automatically. It uses the stdio transport via WP-CLI — Claude runs `wp mcp-adapter serve` locally in the workspace, so no application password, HTTP, or proxy is involved. The server is registered at user scope (`claude mcp list` shows it); re-add or tweak it with `bash scripts/connect-mcp.sh`.

--- a/templates/scripts/connect-mcp.sh
+++ b/templates/scripts/connect-mcp.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Connect Claude Code (in the workspace) to the WordPress MCP server exposed by
+# the mcp-adapter plugin, over stdio via WP-CLI — no HTTP, application password,
+# or proxy needed, since Claude and WP-CLI share the same container and the same
+# /wp files + database. Registered at user scope, so it persists in workspace/
+# across rebuilds. Idempotent; skips if mcp-adapter isn't active.
+#
+# Run via `npm run setup`. Assumes WordPress is installed and plugins are in.
+#
+set -euo pipefail
+
+# This script lives in scripts/ — operate from the project root.
+cd "$(dirname "$0")/.."
+
+NAME="wordpress"
+SERVER="mcp-adapter-default-server"
+
+if ! docker compose exec -T workspace wp plugin is-active mcp-adapter >/dev/null 2>&1; then
+  echo "→ mcp-adapter plugin not active — skipping MCP connection."
+  exit 0
+fi
+
+echo "→ Connecting Claude to the WordPress MCP server…"
+# remove-then-add keeps the registration current (and idempotent) on re-runs.
+docker compose exec -T workspace sh -c "
+  claude mcp remove '$NAME' --scope user >/dev/null 2>&1 || true
+  claude mcp add '$NAME' --scope user -- wp --path=/wp mcp-adapter serve --server='$SERVER' --user=admin
+"
+echo "✓ Claude is connected to the '$NAME' MCP server — run 'npm run claude' and use it right away."

--- a/templates/scripts/initial-setup.sh
+++ b/templates/scripts/initial-setup.sh
@@ -29,6 +29,7 @@ done
 # in the workspace container. Add more steps here as setup grows.
 bash scripts/install-wp.sh
 bash scripts/install-plugins.sh
+bash scripts/connect-mcp.sh
 
 echo ""
 echo "✓ Initial setup complete."

--- a/templates/scripts/install-plugins.sh
+++ b/templates/scripts/install-plugins.sh
@@ -45,6 +45,11 @@ printf '%s\n' "$rows" | while IFS=$'\t' read -r source activate version; do
   [ -n "$source" ] || continue
   args=(plugin install "$source")
   label="$source${version:+ @$version}"
+  # wordpress.org slugs are idempotent (already-installed exits 0), but a zip URL
+  # errors on reinstall ("destination folder already exists") — --force fixes it.
+  case "$source" in
+    *://*) args+=(--force) ;;
+  esac
   if [ -n "$version" ]; then args+=(--version="$version"); fi
   if [ "$activate" = "1" ]; then args+=(--activate); label="$label (activate)"; fi
   echo "→ Plugin: $label"


### PR DESCRIPTION
## What & why

`npm run setup` now connects Claude Code (in the workspace) to WordPress's MCP server automatically, so the agent can use WordPress abilities the moment you run `npm run claude`.

## How it connects: stdio via WP-CLI (not HTTP/app-password)

The topology makes this simple. WP-CLI runs **in the workspace**, against the bind-mounted `/wp` files and the `db` host — it's the same WordPress install the browser hits, just a different front door. So Claude can spawn the MCP server as a local subprocess and talk over stdin/stdout:

```json
"wordpress": {
  "command": "wp",
  "args": ["--path=/wp", "mcp-adapter", "serve", "--server=mcp-adapter-default-server", "--user=admin"]
}
```

No application password, JWT, HTTP, or `@automattic/mcp-wordpress-remote` proxy. That proxy is for clients that *can't* run WP-CLI and must reach a remote site over REST with Application Password auth — not our case, and it's tied to the deprecated Automattic plugin lineage.

## Changes

- **`scripts/connect-mcp.sh`** — `claude mcp add wordpress --scope user -- wp --path=/wp mcp-adapter serve --server=mcp-adapter-default-server --user=admin`. User scope persists in `workspace/` across rebuilds. Remove-then-add makes it idempotent. Skips cleanly if `mcp-adapter` isn't active.
- **`initial-setup.sh`** — runs `connect-mcp.sh` after the plugin step.
- **Fix (install-plugins.sh):** zip-URL sources now install with `--force`. Without it, `wp plugin install <url>` errors with "destination folder already exists" on reinstall (wordpress.org slugs don't — they exit 0), which aborted any re-run of `npm run setup` under `set -e` *before* `connect-mcp` could run. Slugs keep the cheap already-installed skip; only URLs get `--force`.
- Docs: MCP note in the project README + scaffold listing.

## Verification

On a clean scaffold (`node index.js <dir> --port=8094`):

- `connect-mcp` ran; `/home/node/.claude.json` updated.
- `claude mcp list` → `wordpress: ✓ Connected`.
- `wp mcp-adapter serve … tools/list` returns the adapter's tools over stdio.
- Re-ran `npm run setup`: plugins reinstall in place (`Plugin updated successfully`), MCP re-registers, still `✓ Connected` — confirms the `--force` fix and overall idempotency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
