### PR TITLE
Give Claude Playwright via a prebaked MCP service

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm run claude     # launch Claude Code in the workspace
 
 ```
 my-site/
-├── docker-compose.yml      # db + wordpress + workspace services
+├── docker-compose.yml      # db + wordpress + workspace + playwright services
 ├── workspace.Dockerfile    # Node + Claude Code + PHP + WP-CLI (runs as non-root)
 ├── .env                    # DB creds + WP_PORT
 ├── .gitignore              # ignores the bind-mounted data dirs

--- a/templates/README.md
+++ b/templates/README.md
@@ -2,11 +2,12 @@
 
 Local WordPress + AI-agent development sandbox, running on Docker.
 
-Three services:
+Four services:
 
 - **db** — MariaDB
 - **wordpress** — WordPress on `http://localhost:__WP_PORT__`
 - **workspace** — an isolated dev container (Node + Claude Code + PHP + WP-CLI) that mounts the same WordPress files and reaches the site/DB over the Docker network
+- **playwright** — a [Playwright MCP](https://github.com/microsoft/playwright-mcp) server (headless Chromium) that Claude drives to browse the site
 
 All data lives in bind-mounted folders in this directory (`db/`, `wp/`, `workspace/`), so it survives restarts and is browsable on your machine. They're git-ignored.
 
@@ -74,4 +75,6 @@ A bare string is shorthand for `{ "source": "<string>", "activate": true }`. Aft
 - **Working on a plugin/theme?** It lives at `wp/wp-content/plugins/…` (or `themes/…`). Edit it on your machine or from inside the workspace container — same files, served live.
 - **First Claude run:** inside the workspace, run `npm run claude` and use `/login` once. Your login persists in `workspace/` across rebuilds.
 - **WP-CLI** talks to the database automatically over the Docker network.
-- **MCP:** `npm run setup` connects Claude to WordPress's MCP server (from the [`mcp-adapter`](https://github.com/WordPress/mcp-adapter) plugin) automatically. It uses the stdio transport via WP-CLI — Claude runs `wp mcp-adapter serve` locally in the workspace, so no application password, HTTP, or proxy is involved. The server is registered at user scope (`claude mcp list` shows it); re-add or tweak it with `bash scripts/connect-mcp.sh`.
+- **MCP:** `npm run setup` connects Claude to two MCP servers automatically (registered at user scope — `claude mcp list` shows them; re-add or tweak with `bash scripts/connect-mcp.sh`):
+  - **wordpress** — WordPress's own MCP server (from the [`mcp-adapter`](https://github.com/WordPress/mcp-adapter) plugin), over stdio via WP-CLI. Claude runs `wp mcp-adapter serve` locally in the workspace, so no application password, HTTP, or proxy is involved.
+  - **playwright** — the [Playwright MCP](https://github.com/microsoft/playwright-mcp) server (a separate container with headless Chromium), over HTTP. Claude uses it to navigate, click, and screenshot the site. **From the browser, the site is `http://wordpress`** (the Docker-network address), not `localhost:__WP_PORT__` — the site URL is derived from the request host so both work without redirects.

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -18,6 +18,16 @@ services:
       WORDPRESS_DB_PASSWORD: ${MARIADB_PASSWORD}
       # Marks the site as local so e.g. Application Passwords work over plain HTTP.
       WP_ENVIRONMENT_TYPE: local
+      # Derive the site URL from the request host so the site works without
+      # redirects both from your machine (localhost:${WP_PORT}) and from inside
+      # the Docker network (http://wordpress — used by the Playwright browser).
+      # ($$ is escaped to a literal $ for the generated wp-config.php.)
+      WORDPRESS_CONFIG_EXTRA: |
+        if ( ! empty( $$_SERVER['HTTP_HOST'] ) ) {
+            $$scheme = ( ! empty( $$_SERVER['HTTPS'] ) && $$_SERVER['HTTPS'] !== 'off' ) ? 'https' : 'http';
+            define( 'WP_HOME', $$scheme . '://' . $$_SERVER['HTTP_HOST'] );
+            define( 'WP_SITEURL', $$scheme . '://' . $$_SERVER['HTTP_HOST'] );
+        }
     ports:
       - "${WP_PORT}:80"
     volumes:
@@ -40,3 +50,13 @@ services:
     volumes:
       - ./workspace:/home/node   # the node user's home — persists Claude login, shell history
       - ./wp:/wp                 # WordPress files (top-level path, not nested in home)
+
+  # Playwright MCP server (prebaked image, headless Chromium). Claude in the
+  # workspace connects to it over HTTP at http://playwright:8931/mcp and drives a
+  # browser against the site at http://wordpress. --allowed-hosts must list the
+  # host:port Claude uses (the server otherwise only accepts localhost).
+  playwright:
+    image: mcr.microsoft.com/playwright/mcp:latest
+    restart: unless-stopped
+    init: true
+    command: ["--port", "8931", "--host", "0.0.0.0", "--allowed-hosts", "playwright:8931"]

--- a/templates/scripts/connect-mcp.sh
+++ b/templates/scripts/connect-mcp.sh
@@ -1,30 +1,36 @@
 #!/usr/bin/env bash
 #
-# Connect Claude Code (in the workspace) to the WordPress MCP server exposed by
-# the mcp-adapter plugin, over stdio via WP-CLI — no HTTP, application password,
-# or proxy needed, since Claude and WP-CLI share the same container and the same
-# /wp files + database. Registered at user scope, so it persists in workspace/
-# across rebuilds. Idempotent; skips if mcp-adapter isn't active.
+# Connect Claude Code (in the workspace) to the MCP servers in this sandbox, at
+# user scope so they persist in workspace/ across rebuilds. Idempotent
+# (remove-then-add). Run via `npm run setup`.
 #
-# Run via `npm run setup`. Assumes WordPress is installed and plugins are in.
+#   - wordpress: the mcp-adapter plugin's server, over stdio via WP-CLI — no HTTP,
+#     application password, or proxy needed, since Claude and WP-CLI share the
+#     same container and the same /wp files + database.
+#   - playwright: the prebaked Playwright MCP service, over HTTP, for driving a
+#     headless browser against the site at http://wordpress.
 #
 set -euo pipefail
 
 # This script lives in scripts/ — operate from the project root.
 cd "$(dirname "$0")/.."
 
-NAME="wordpress"
-SERVER="mcp-adapter-default-server"
-
-if ! docker compose exec -T workspace wp plugin is-active mcp-adapter >/dev/null 2>&1; then
-  echo "→ mcp-adapter plugin not active — skipping MCP connection."
-  exit 0
+# WordPress MCP server (skipped if mcp-adapter isn't active).
+if docker compose exec -T workspace wp plugin is-active mcp-adapter >/dev/null 2>&1; then
+  echo "→ Connecting Claude to the WordPress MCP server…"
+  docker compose exec -T workspace sh -c "
+    claude mcp remove wordpress --scope user >/dev/null 2>&1 || true
+    claude mcp add wordpress --scope user -- wp --path=/wp mcp-adapter serve --server=mcp-adapter-default-server --user=admin
+  "
+else
+  echo "→ mcp-adapter plugin not active — skipping the WordPress MCP server."
 fi
 
-echo "→ Connecting Claude to the WordPress MCP server…"
-# remove-then-add keeps the registration current (and idempotent) on re-runs.
+# Playwright MCP server (the playwright compose service, reached over HTTP).
+echo "→ Connecting Claude to the Playwright MCP server…"
 docker compose exec -T workspace sh -c "
-  claude mcp remove '$NAME' --scope user >/dev/null 2>&1 || true
-  claude mcp add '$NAME' --scope user -- wp --path=/wp mcp-adapter serve --server='$SERVER' --user=admin
+  claude mcp remove playwright --scope user >/dev/null 2>&1 || true
+  claude mcp add playwright --scope user --transport http http://playwright:8931/mcp
 "
-echo "✓ Claude is connected to the '$NAME' MCP server — run 'npm run claude' and use it right away."
+
+echo "✓ MCP servers registered — run 'npm run claude' and use them right away."


### PR DESCRIPTION
## What & why

Gives Claude (in the workspace) a browser via the **Playwright MCP server**, so it can navigate, click, fill forms, and screenshot the WordPress site it's working on.

Per the "use a prebaked image, don't roll our own" steer: this uses Microsoft's prebaked **`mcr.microsoft.com/playwright/mcp`** image (headless Chromium, ~433MB, runs as non-root `node`) as its own service — **as-is, no custom Dockerfile**. The workspace image is untouched (no Chromium, no system deps, no browser/MCP version-matching).

## How it works

- New **`playwright`** service runs the MCP server on the Docker network in HTTP mode. Its entrypoint already supplies `--headless --browser chromium --no-sandbox`; we append `--port 8931 --host 0.0.0.0 --allowed-hosts playwright:8931`.
  - `--allowed-hosts` is **required**: the server has DNS-rebinding protection and otherwise 403s anything whose `Host` isn't `localhost` (we reach it as `playwright:8931`).
- **`connect-mcp.sh`** registers it with Claude over HTTP (`claude mcp add playwright --transport http http://playwright:8931/mcp`), user scope, idempotent — alongside the existing `wordpress` server.
- **Site URL fix (`WORDPRESS_CONFIG_EXTRA`):** WordPress's `siteurl`/`home` are `localhost:PORT` (host-facing), so a request to `http://wordpress` (the in-network address the browser must use) hit a canonical redirect to an unreachable `wordpress:PORT`. We now derive `WP_HOME`/`WP_SITEURL` from the request host, so the site loads without redirects from **both** the host (`localhost:PORT`) and inside the network (`http://wordpress`). WP-CLI (no HTTP host) falls back to the DB option.

## Topology note

The browser runs in the `playwright` container and reaches the site at **`http://wordpress`** — not `localhost:PORT` (that's the host's published port, unreachable container-to-container). Documented in the project README.

## Verification (fresh scaffold + `npm run setup`)

- `claude mcp list` → `wordpress: ✓ Connected`, `playwright: ✓ Connected`.
- Generated `wp-config.php` env eval'd correctly (single `$`, not `$$`); `curl http://wordpress/` → `200` (was `301 → wordpress:PORT`).
- Drove the Playwright MCP server to `browser_navigate` `http://wordpress` → **Page URL `http://wordpress/`, Page Title "WordPress Dev"** — real headless-Chromium load, no redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
