### PR TITLE
Ship a wordpress-dev Claude skill into the sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ my-site/
 ├── .gitignore              # ignores the bind-mounted data dirs
 ├── package.json            # the npm-scripts UX (setup/start/stop/bash/claude/wp/reset)
 ├── sandbox.config.json     # plugins to install on `npm run setup` (+ future params)
-├── scripts/                # initial-setup.sh → install-wp.sh + install-plugins.sh + connect-mcp.sh
+├── scripts/                # initial-setup.sh → install-wp / install-plugins / connect-mcp / install-skills
+├── skills/                 # Claude skills installed into the workspace (e.g. wordpress-dev)
 └── README.md
 ```
 

--- a/templates/scripts/initial-setup.sh
+++ b/templates/scripts/initial-setup.sh
@@ -30,6 +30,7 @@ done
 bash scripts/install-wp.sh
 bash scripts/install-plugins.sh
 bash scripts/connect-mcp.sh
+bash scripts/install-skills.sh
 
 echo ""
 echo "✓ Initial setup complete."

--- a/templates/scripts/install-skills.sh
+++ b/templates/scripts/install-skills.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Install the sandbox's Claude skills (the project's skills/ dir) into the
+# workspace's personal skills dir, ~/.claude/skills. We copy rather than
+# bind-mount because a bind mount nested inside the ./workspace mount is
+# unreliable on Docker Desktop. Re-run safe (overwrites). Run via `npm run setup`.
+#
+# ./workspace is the workspace container's /home/node, so writing here lands at
+# /home/node/.claude/skills where Claude loads personal skills.
+#
+set -euo pipefail
+
+# This script lives in scripts/ — operate from the project root.
+cd "$(dirname "$0")/.."
+
+if [ -d skills ] && [ -n "$(ls -A skills 2>/dev/null)" ]; then
+  mkdir -p workspace/.claude/skills
+  cp -R skills/. workspace/.claude/skills/
+  echo "✓ Skills installed into the workspace (~/.claude/skills)."
+else
+  echo "→ No skills/ to install — skipping."
+fi

--- a/templates/skills/wordpress-dev/SKILL.md
+++ b/templates/skills/wordpress-dev/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: wordpress-dev
+description: >-
+  The sandbox's Docker containers (workspace, db, wordpress, playwright) and how
+  to reach the WordPress site — http://wordpress from inside the network, not
+  localhost. Load when working with this WordPress install or browsing it.
+---
+
+This WordPress install is split across Docker containers on a shared network:
+
+- **workspace** — where you (Claude) run. Holds the WordPress files at `/wp`
+  (shared with the `wordpress` container) plus WP-CLI, Node, and Claude Code. No
+  web server runs here, but WP-CLI talks to the `db` container directly, so
+  `wp …` works.
+- **db** — MariaDB database (reachable on the network as host `db`).
+- **wordpress** — the Apache/PHP web server serving the site at `http://wordpress/`.
+- **playwright** — a headless-Chromium Playwright MCP server; point its browser
+  at `http://wordpress/`.
+
+**Reaching the site:** from inside any container (including the Playwright
+browser) use `http://wordpress/`, e.g. `http://wordpress/wp-login.php`.
+`http://localhost:__WP_PORT__` only works from the user's browser on the host —
+it's a host port mapping, not reachable container-to-container. The wp-admin
+login is `admin` / `password`.


### PR DESCRIPTION
## What & why

Ships a personal Claude **skill** into every generated sandbox, so the agent you run with `npm run claude` starts out knowing its environment instead of having to rediscover it.

`skills/wordpress-dev/SKILL.md` covers:
- the four containers and what each does (`workspace` / `db` / `wordpress` / `playwright`),
- that the site is **`http://wordpress`** from inside the Docker network (not `localhost:PORT`, which only works from the host),
- the `admin` / `password` login, and that WP-CLI on `/wp` talks to the DB directly.

## How it's delivered

- **`templates/skills/wordpress-dev/SKILL.md`** — the skill, with the port templated as `__WP_PORT__` so it matches `--port`.
- **`scripts/install-skills.sh`** — copies `skills/` into the workspace's `~/.claude/skills` during `npm run setup` (idempotent; re-created after `npm run reset`).
- **`initial-setup.sh`** — runs it after the MCP step.

### Why copy instead of bind-mount

I first tried mounting `./skills` at `/home/node/.claude/skills` (one line, no script). But that path is **nested inside the `./workspace` mount**, and on Docker Desktop for macOS nested bind-mounts of two separate host dirs are unreliable — it worked in an isolated test, then in a full run the container saw an empty `~/.claude/skills` (Docker had created a stray empty mountpoint on the host). Copying into the single `./workspace` mount is deterministic, so that's what this does.

## Verification

Fresh scaffold (`node index.js <dir> --port=8098`): setup prints "Skills installed", and `skills/wordpress-dev/SKILL.md` lands reliably at `/home/node/.claude/skills/wordpress-dev/SKILL.md` with the right port. (Final confirmation that `/wordpress-dev` surfaces is a quick check in an authed `npm run claude` session — personal skills load from `~/.claude/skills`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
