### PR TITLE
Add a php.ini drop-in for the wordpress container (fix upload limit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ my-site/
 ├── .gitignore              # ignores the bind-mounted data dirs
 ├── package.json            # the npm-scripts UX (setup/start/stop/bash/claude/wp/reset)
 ├── sandbox.config.json     # plugins to install on `npm run setup` (+ future params)
+├── php/php.ini             # custom PHP overrides for the wordpress container (upload limits, etc.)
 ├── scripts/                # initial-setup.sh → install-wp / install-plugins / connect-mcp / install-skills
 ├── skills/                 # Claude skills installed into the workspace (e.g. wordpress-dev)
 └── README.md

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - "${WP_PORT}:80"
     volumes:
       - ./wp:/var/www/html
+      - ./php/php.ini:/usr/local/etc/php/conf.d/php.ini:ro   # custom PHP overrides (upload limits, etc.)
 
   # Isolated dev container: Node + Claude Code + PHP + WP-CLI. This is where you
   # run agents. It mounts the same WordPress files at /wp and reaches the site

--- a/templates/php/php.ini
+++ b/templates/php/php.ini
@@ -1,0 +1,13 @@
+; Custom PHP settings for the wordpress container. This is a conf.d drop-in that
+; overrides the image's php.ini defaults — add any directives you need here.
+
+; Larger uploads so plugin/theme zips (and media) work in wp-admin (defaults: 2M / 8M).
+upload_max_filesize = 128M
+post_max_size = 128M
+
+; Generous headroom for builders, imports, and big operations (PHP default is 128M).
+; This is a per-request ceiling, not a reservation — raise it freely on a dev box.
+memory_limit = 512M
+
+max_execution_time = 300
+max_input_time = 300


### PR DESCRIPTION
## What & why

Uploading a plugin/theme zip in wp-admin failed with **"The uploaded file exceeds the upload_max_filesize directive in php.ini."** The `wordpress` image ships PHP defaults of `upload_max_filesize = 2M` / `post_max_size = 8M`, and these are `PHP_INI_PERDIR` — they can't be raised from `wp-config.php` at runtime, so they need a php.ini drop-in.

## Change

- **`templates/php/php.ini`** — a `conf.d` drop-in that overrides the image's PHP defaults. Seeded with:
  - `upload_max_filesize = 128M`, `post_max_size = 128M` (the upload fix)
  - `memory_limit = 512M` (a per-request ceiling, not a reservation — generous headroom for builders/imports on a dev box; WordPress's `wp_raise_memory_limit()` only raises, so this sticks even in admin)
  - `max_execution_time` / `max_input_time = 300`
  - It's a **general** override file — add any PHP directives here, not just uploads.
- **`docker-compose.yml`** — mounts `./php/php.ini` at `/usr/local/etc/php/conf.d/php.ini` (read-only). Single-file mount at a non-nested path, so it's reliable.
- **README** — noted `php/php.ini` in the scaffold listing.

## Verification

Fresh scaffold: the drop-in lands at `/usr/local/etc/php/conf.d/php.ini` and the limits take effect — `upload_max_filesize => 128M`, `post_max_size => 128M`, `memory_limit => 512M` (was `2M` / `8M` / `128M`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
