### PR TITLE
Enable all Root for Agents gates (shell + eval); simplify skill

### DIFF
--- a/templates/scripts/include-root-for-agents.sh
+++ b/templates/scripts/include-root-for-agents.sh
@@ -10,15 +10,23 @@ set -euo pipefail
 # This script lives in scripts/ — operate from the project root.
 cd "$(dirname "$0")/.."
 
-echo "→ Enabling Root for Agents (ROOT_FOR_AGENTS_ENABLED)…"
-# Master gate. Unlocks the file + env-inspect abilities. Shell + PHP eval are
-# behind extra gates — uncomment if you want them (trusted dev sandbox only):
-#   docker compose exec -T workspace wp config set ROOT_FOR_AGENTS_ALLOW_SHELL true --raw --type=constant
-#   docker compose exec -T workspace wp config set ROOT_FOR_AGENTS_ALLOW_EVAL  true --raw --type=constant
-docker compose exec -T workspace wp config set ROOT_FOR_AGENTS_ENABLED true --raw --type=constant >/dev/null
+echo "→ Enabling Root for Agents…"
+# Each ability is gated by a wp-config.php constant and only registers when its
+# gate is true. We enable all of them — this is a trusted, throwaway dev sandbox
+# (Claude already runs here with --dangerously-skip-permissions, and the plugin
+# itself refuses to run on a production environment type):
+#   ROOT_FOR_AGENTS_ENABLED     — master gate; file ops + env-inspect
+#   ROOT_FOR_AGENTS_ALLOW_SHELL — shell-exec + process-exec
+#   ROOT_FOR_AGENTS_ALLOW_EVAL  — php-eval
+# Drop a line if you'd rather not expose that capability.
+docker compose exec -T workspace sh -c '
+  wp config set ROOT_FOR_AGENTS_ENABLED     true --raw --type=constant
+  wp config set ROOT_FOR_AGENTS_ALLOW_SHELL true --raw --type=constant
+  wp config set ROOT_FOR_AGENTS_ALLOW_EVAL  true --raw --type=constant
+' >/dev/null
 
 # Root for Agents isn't on wordpress.org yet. Once it is, uncomment to install +
 # activate it (slug: root-for-agents) — the constant above is its master gate:
 # docker compose exec -T workspace wp plugin install root-for-agents --activate
 
-echo "✓ Root for Agents enabled (ROOT_FOR_AGENTS_ENABLED = true)."
+echo "✓ Root for Agents enabled (file ops, env-inspect, shell, PHP eval)."

--- a/templates/skills/wordpress-dev/SKILL.md
+++ b/templates/skills/wordpress-dev/SKILL.md
@@ -27,17 +27,11 @@ login is `admin` / `password`.
 
 [Root for Agents](https://github.com/soflyy/root-for-agents) gives you
 root-equivalent operational access to this install through the `wordpress` MCP
-server. When the plugin is installed and active, its abilities show up as MCP
-tools — prefer them for operating on the site directly:
+server — shell commands, PHP eval in the live WordPress runtime, arbitrary file
+read/write/delete/list, and environment inspection.
 
-- `root-for-agents/file-read`, `file-write`, `file-delete`, `file-list` — read/write
-  any file in the install.
-- `root-for-agents/env-inspect` — WP/PHP versions, paths, active plugins/theme,
-  available CLI tools.
-- `root-for-agents/shell-exec`, `process-exec`, `php-eval` — run shell commands or
-  evaluate PHP in the live WordPress runtime.
-
-It's gated by constants in `wp-config.php`. `ROOT_FOR_AGENTS_ENABLED` (set during
-setup) unlocks the file + env-inspect abilities; the shell and PHP-eval abilities
-additionally need `ROOT_FOR_AGENTS_ALLOW_SHELL` / `ROOT_FOR_AGENTS_ALLOW_EVAL`.
-If an ability isn't listed by the MCP server, its gate isn't set.
+Treat it as a fallback, not a first resort: if a task can't be done through the
+regular MCP tools and WP-CLI would be too cumbersome, reach for Root for Agents.
+Its abilities aren't top-level MCP tools — discover them with
+`mcp-adapter-discover-abilities` and run one (by name, e.g.
+`root-for-agents/shell-exec`) via `mcp-adapter-execute-ability`.


### PR DESCRIPTION
## What & why

Follow-up to #7. That PR set only `ROOT_FOR_AGENTS_ENABLED`, which — as you found — meant Root for Agents exposed **no usable abilities for shell/eval**. `mcp-adapter` only registers an RFA ability when its wp-config **gate** is set: `ENABLED` alone unlocks file ops + env-inspect, but `shell-exec`, `process-exec`, and `php-eval` need `ROOT_FOR_AGENTS_ALLOW_SHELL` / `ROOT_FOR_AGENTS_ALLOW_EVAL` too.

This enables all three gates so the full ability set registers. Fitting for a trusted, throwaway dev sandbox (Claude already runs with `--dangerously-skip-permissions`), and the plugin still self-guards against a production environment type.

## Changes

- **`scripts/include-root-for-agents.sh`** — set `ROOT_FOR_AGENTS_ENABLED` + `ALLOW_SHELL` + `ALLOW_EVAL` in `wp-config.php` (was just `ENABLED`). Idempotent. Plugin install stays commented out (not on wordpress.org yet).
- **`skills/wordpress-dev/SKILL.md`** — per your steer, dropped the constants/gates detail (the gates are always set now) and reframed Root for Agents as a **fallback**: use it when the regular MCP tools aren't enough and WP-CLI would be too cumbersome. Kept the note that abilities are reached via `mcp-adapter-discover-abilities` / `mcp-adapter-execute-ability`.

## Verification

- Live sandbox (plugin present): with only `ENABLED`, discovery listed file ops + env-inspect; after adding the two gates, all **8** abilities appeared (incl. `shell-exec`, `process-exec`, `php-eval`).
- Fresh scaffold: all three constants land in `wp-config.php`; idempotent on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
