### PR TITLE
Install Root for Agents from GitHub; drop the 'ai' default plugin

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -58,7 +58,6 @@ The plugins installed during `npm run setup` are declared in `sandbox.config.jso
 ```json
 {
   "plugins": [
-    { "source": "ai", "activate": true },
     { "source": "https://github.com/WordPress/mcp-adapter/releases/download/v0.5.0/mcp-adapter.zip", "activate": true }
   ]
 }

--- a/templates/sandbox.config.json
+++ b/templates/sandbox.config.json
@@ -1,6 +1,5 @@
 {
   "plugins": [
-    { "source": "ai", "activate": true },
     { "source": "https://github.com/WordPress/mcp-adapter/releases/download/v0.5.0/mcp-adapter.zip", "activate": true }
   ]
 }

--- a/templates/scripts/include-root-for-agents.sh
+++ b/templates/scripts/include-root-for-agents.sh
@@ -2,8 +2,8 @@
 #
 # Enable Root for Agents (https://github.com/soflyy/root-for-agents) for this
 # sandbox. The plugin registers root-equivalent WordPress abilities (file ops,
-# env-inspect, and — behind extra gates — shell + PHP eval) that the mcp-adapter
-# plugin surfaces to agents. Run via `npm run setup`. Idempotent.
+# env-inspect, shell, PHP eval) that the mcp-adapter plugin surfaces to agents.
+# Run via `npm run setup`. Idempotent.
 #
 set -euo pipefail
 
@@ -11,22 +11,17 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 echo "→ Enabling Root for Agents…"
-# Each ability is gated by a wp-config.php constant and only registers when its
-# gate is true. We enable all of them — this is a trusted, throwaway dev sandbox
-# (Claude already runs here with --dangerously-skip-permissions, and the plugin
-# itself refuses to run on a production environment type):
-#   ROOT_FOR_AGENTS_ENABLED     — master gate; file ops + env-inspect
-#   ROOT_FOR_AGENTS_ALLOW_SHELL — shell-exec + process-exec
-#   ROOT_FOR_AGENTS_ALLOW_EVAL  — php-eval
-# Drop a line if you'd rather not expose that capability.
-docker compose exec -T workspace sh -c '
-  wp config set ROOT_FOR_AGENTS_ENABLED     true --raw --type=constant
-  wp config set ROOT_FOR_AGENTS_ALLOW_SHELL true --raw --type=constant
-  wp config set ROOT_FOR_AGENTS_ALLOW_EVAL  true --raw --type=constant
-' >/dev/null
+# A single wp-config.php constant gates all of the plugin's abilities. We enable
+# it — this is a trusted, throwaway dev sandbox (Claude already runs here with
+# --dangerously-skip-permissions, and the plugin itself refuses to run on a
+# production environment type).
+docker compose exec -T workspace wp config set ROOT_FOR_AGENTS_ENABLED true --raw --type=constant >/dev/null
 
-# Root for Agents isn't on wordpress.org yet. Once it is, uncomment to install +
-# activate it (slug: root-for-agents) — the constant above is its master gate:
-# docker compose exec -T workspace wp plugin install root-for-agents --activate
+# Root for Agents isn't on wordpress.org — install it from GitHub (latest master).
+# --force makes re-running setup reinstall cleanly; --activate switches it on
+# (the constant above is its gate).
+docker compose exec -T workspace wp plugin install \
+  https://github.com/soflyy/root-for-agents/archive/refs/heads/master.zip \
+  --force --activate
 
 echo "✓ Root for Agents enabled (file ops, env-inspect, shell, PHP eval)."


### PR DESCRIPTION
## Summary
- **Install Root for Agents.** `include-root-for-agents.sh` now actually installs the plugin instead of leaving a commented-out wordpress.org stub — it isn't on wordpress.org, so it's pulled from the latest `master` archive on GitHub with `--force --activate` (idempotent across `npm run setup` re-runs, picks up merged-but-unreleased changes automatically).
- **One gate, not three.** The plugin now gates all of its abilities behind the single `ROOT_FOR_AGENTS_ENABLED` constant; `ALLOW_SHELL` / `ALLOW_EVAL` no longer do anything, so they're dropped and the `sh -c` wrapper collapses to one `wp config set`.
- **Drop the `ai` default plugin.** Removed from `sandbox.config.json` (and the matching README example). `mcp-adapter` is now the only default plugin — still all that's needed for the WordPress MCP connection.

## Notes
- `connect-mcp.sh` keys off `mcp-adapter` being active, so removing `ai` doesn't affect MCP-over-HTTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)