### PR TITLE
CI: publish to npm from GitHub Actions on release (Trusted Publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish to npm
+
+# Publishes to npm whenever a GitHub Release is published. Auth is via npm
+# Trusted Publishing (OIDC) — no tokens stored in the repo. The published
+# version is whatever is in package.json at the released tag, so bump the
+# version and tag before cutting the release:
+#   npm version patch && git push --follow-tags
+# then create a GitHub Release for that tag.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write # required for OIDC Trusted Publishing + provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      # Trusted Publishing (OIDC) needs npm >= 11.5.1; Node 20 ships an older npm.
+      - run: npm install -g npm@latest
+      # No dependencies / build step — publish the repo as-is. --provenance and
+      # the OIDC token are supplied automatically by Trusted Publishing.
+      - run: npm publish --provenance --access public

--- a/README.md
+++ b/README.md
@@ -110,6 +110,28 @@ create-wp-local-dev-agent-sandbox /tmp/try-it
 npm unlink -g create-wp-local-dev-agent-sandbox   # when done
 ```
 
+## Releasing a new version
+
+Releases are published to npm **automatically by GitHub Actions** when a GitHub
+Release is published — see [`.github/workflows/publish.yml`](.github/workflows/publish.yml).
+Auth is npm [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC),
+so there are no tokens in the repo and the package ships with build provenance.
+
+**Do not run `npm publish` locally.** To cut a release, from a clean `master`:
+
+```bash
+npm version patch          # or `minor` / `major` — bumps package.json, commits, and tags vX.Y.Z
+git push --follow-tags     # push the commit and the new tag
+gh release create "v$(node -p "require('./package.json').version")" --generate-notes
+```
+
+Publishing the GitHub Release triggers the workflow, which publishes the version
+currently in `package.json` to npm. Watch it with `gh run watch`.
+
+> One-time account setup (already configured): the package's **Trusted Publisher**
+> on npmjs.com must point at this repo and `.github/workflows/publish.yml`.
+> The very first `0.1.0` publish was done manually to create the package.
+
 ## License
 
 GPL-2.0-or-later


### PR DESCRIPTION
## Summary
Adds `.github/workflows/publish.yml` so future npm releases happen from CI instead of a laptop. Triggered when a **GitHub Release is published**, it authenticates via npm **Trusted Publishing (OIDC)** — no npm token stored in the repo — and publishes with build **provenance**.

- Upgrades npm in the runner (`npm install -g npm@latest`) because Trusted Publishing requires npm ≥ 11.5.1, newer than what Node 20 ships.
- No `npm ci`/build step — the package has no dependencies; it publishes the repo as-is.
- `id-token: write` permission is what enables OIDC + provenance.

## Release flow after this merges
```
npm version patch   # or minor/major — commits + tags
git push --follow-tags
```
Then cut a GitHub Release for that tag → CI publishes the version in `package.json`.

## ⚠️ Required one-time setup (won't publish until done)
On npmjs.com → the package → **Settings → Trusted Publisher**, add:
- Repository: `soflyy/create-wp-local-dev-agent-sandbox`
- Workflow: `.github/workflows/publish.yml`

Until that's configured, the workflow run will fail at the publish step (expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)