### PR TITLE
Terminal usage polish: require empty dir + show WP login details last

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,12 @@ const RENAME = {
   'gitignore': '.gitignore',
 };
 
-// Key files we refuse to clobber if the target already has them.
-const GUARD = ['docker-compose.yml', 'package.json', '.env', 'workspace.Dockerfile', 'sandbox.config.json'];
+// When checking that the target dir is empty, these harmless entries don't count.
+const ALLOWED_EXISTING = new Set([
+  '.git', '.gitignore', '.gitkeep', '.hg', '.svn',
+  '.DS_Store', 'Thumbs.db', '.idea', '.vscode',
+  'LICENSE', 'LICENSE.md', 'README.md',
+]);
 
 function parseArgs(argv) {
   const out = { dir: null, port: '8080', setup: true };
@@ -87,10 +91,12 @@ async function main() {
   await mkdir(targetDir, { recursive: true });
 
   const existing = await readdir(targetDir).catch(() => []);
-  const collisions = existing.filter((f) => GUARD.includes(f));
-  if (collisions.length) {
-    console.error(`\n✖ Refusing to overwrite existing files in ${targetDir}:`);
-    console.error(`  ${collisions.join(', ')}\n`);
+  const blocking = existing.filter((f) => !ALLOWED_EXISTING.has(f));
+  if (blocking.length) {
+    const shown = blocking.slice(0, 5).join(', ') + (blocking.length > 5 ? ', …' : '');
+    console.error(`\n✖ ${targetDir} is not empty (found: ${shown}).`);
+    console.error('  This scaffolder needs an empty directory. Point it at a new one, e.g.:');
+    console.error('    npm create wp-local-dev-agent-sandbox@latest my-site\n');
     process.exit(1);
   }
 
@@ -103,9 +109,10 @@ async function main() {
     console.log('Next steps:');
     console.log(`  cd ${cd}`);
     console.log('  npm run setup        # build, start & install WordPress + plugins (Docker must be running)');
-    console.log(`  open http://localhost:${args.port}   # then log in at /wp-admin with admin / password`);
     console.log('  npm run start        # subsequent runs: just bring the containers up');
     console.log('  npm run claude       # launch Claude Code in the workspace');
+    console.log('');
+    console.log(`Once setup finishes, your site is at http://localhost:${args.port} — log in at /wp-admin with admin / password.`);
     return;
   }
 
@@ -119,12 +126,19 @@ async function main() {
     process.exit(res.status ?? 1);
   }
 
-  console.log('\nReady. Next steps:');
-  console.log(`  open http://localhost:${args.port}   # log in at /wp-admin with admin / password`);
+  console.log('\nEveryday commands:');
   console.log(`  cd ${cd}`);
   console.log('  npm run start        # bring the stack up next time (it stays up otherwise)');
   console.log('  npm run claude       # launch Claude Code in the workspace');
   console.log('  npm run bash         # shell into the workspace container');
+  console.log('');
+  console.log('───────────────────────────────────────────────');
+  console.log('  Your WordPress site is ready:');
+  console.log(`    Site:     http://localhost:${args.port}`);
+  console.log(`    Admin:    http://localhost:${args.port}/wp-admin`);
+  console.log('    Username: admin');
+  console.log('    Password: password');
+  console.log('───────────────────────────────────────────────');
   console.log('');
 }
 


### PR DESCRIPTION
Two small CLI UX fixes for `index.js`.

## 1. Refuse to scaffold into a non-empty directory
Previously the CLI only refused to overwrite a hardcoded list of files (`GUARD`), so running it in a directory that happened to contain *other* files would scatter the scaffold among them. Now it requires the target directory to be **empty**, ignoring benign entries (`.git`, `.gitignore`, `.gitkeep`, `.hg`, `.svn`, `.DS_Store`, `Thumbs.db`, `.idea`, `.vscode`, `LICENSE`, `LICENSE.md`, `README.md`).

This matches the create-vite / create-next-app convention: a target dir is still allowed (defaults to `.`), but it must be empty. Misuse now fails fast with a clear message:

```
✖ /path/to/dir is not empty (found: somefile.txt).
  This scaffolder needs an empty directory. Point it at a new one, e.g.:
    npm create wp-local-dev-agent-sandbox@latest my-site
```

## 2. Show the WordPress login details last
After `npm run setup`, the login URL + credentials were printed *first* in the "next steps" block, then buried under `cd` / `npm run start` / etc. Now everyday commands print first and the site URL + admin credentials are the **last** thing on screen (in a boxed block), so users see what they need to log in:

```
───────────────────────────────────────────────
  Your WordPress site is ready:
    Site:     http://localhost:8080
    Admin:    http://localhost:8080/wp-admin
    Username: admin
    Password: password
───────────────────────────────────────────────
```

The `--scaffold-only` next-steps text is reordered to match (site/login line last).

## Testing
Verified locally with `--scaffold-only`:
- empty dir → scaffolds, site/login info printed last ✓
- dir containing only `README.md` → treated as empty, scaffolds ✓
- dir containing an unrelated file → errors, exit 1, **nothing written** ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)