### PR TITLE
Expose create(preset) engine for 3rd-party create-<brand> packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,55 @@ WordPress data, the database, and the workspace home are bind-mounted into `wp/`
 - Node.js >= 18 (to run the CLI and the project's npm scripts)
 - Docker with Compose v2 (to actually run the environment)
 
+## Build your own `npm create` command
+
+This package is also a library. If you ship a WordPress plugin (or a stack of them), you can publish your **own** `create-<brand>` command that scaffolds this same sandbox with your plugins pre-installed — no fork, you just depend on this package.
+
+1. Create a package named `create-<brand>` and add this one as a dependency:
+
+   ```bash
+   mkdir create-oxygen-wp && cd create-oxygen-wp
+   npm init -y
+   npm install create-wp-local-dev-agent-sandbox
+   ```
+
+2. Point its `bin` at a one-file script that calls `create()` with a preset. A preset adds plugins — each entry is a wordpress.org slug, or `{ source, activate?, version? }` where `source` is a slug or a URL/path to a `.zip` (the same format the generated project's `sandbox.config.json` uses):
+
+   ```js
+   #!/usr/bin/env node
+   import { create } from 'create-wp-local-dev-agent-sandbox';
+
+   create({
+     preset: {
+       name: 'oxygen-wp', // so messages read `npm create oxygen-wp`
+       plugins: [
+         { source: 'https://example.com/oxygen.zip', activate: true },
+       ],
+     },
+   });
+   ```
+
+   ```json
+   {
+     "name": "create-oxygen-wp",
+     "type": "module",
+     "bin": { "create-oxygen-wp": "index.js" },
+     "dependencies": { "create-wp-local-dev-agent-sandbox": "^0.3.0" }
+   }
+   ```
+
+3. Publish it. Now anyone can run:
+
+   ```bash
+   npm create oxygen-wp my-site
+   ```
+
+   They get the full sandbox (WordPress + Claude Code + the WordPress & Playwright MCP servers + Root for Agents) **plus your plugins**, installed and activated on the first `npm run setup`.
+
+Your preset's plugins are **appended** to the defaults, so `mcp-adapter` and `root-for-agents` are always present. Everything else — templates, Docker setup, the `npm run …` UX — is inherited from this package, so improvements here flow to every `create-<brand>` that depends on it.
+
+> **Premium plugins:** a *public* `create-<brand>` can only bake in a `.zip` URL that's publicly reachable. For licensed plugins, point at a gated endpoint you control, or have your wrapper read the URL from a prompt or an env var instead of hardcoding it.
+
 ## Contributing
 
 Working on the scaffolder itself, or cutting a release? See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/engine.js
+++ b/engine.js
@@ -1,0 +1,166 @@
+/**
+ * create-wp-local-dev-agent-sandbox — scaffolding engine.
+ *
+ * `create()` is the reusable entry point. The bundled CLI (index.js) calls it
+ * with no preset; downstream `create-<brand>` packages depend on this package
+ * and call it with a preset to add their own plugins. See the README section
+ * "Build your own npm create command".
+ */
+
+import { readdir, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const TEMPLATES = join(HERE, 'templates');
+
+// Template filename -> output filename (dotfiles can't ship as dotfiles in npm).
+const RENAME = {
+  'env.example': '.env',
+  'gitignore': '.gitignore',
+};
+
+// When checking that the target dir is empty, these harmless entries don't count.
+const ALLOWED_EXISTING = new Set([
+  '.git', '.gitignore', '.gitkeep', '.hg', '.svn',
+  '.DS_Store', 'Thumbs.db', '.idea', '.vscode',
+  'LICENSE', 'LICENSE.md', 'README.md',
+]);
+
+function parseArgs(argv) {
+  const out = { dir: null, port: '8080', setup: true };
+  for (const a of argv) {
+    if (a.startsWith('--port=')) out.port = a.slice('--port='.length);
+    else if (a === '--scaffold-only') out.setup = false;
+    else if (a === '-h' || a === '--help') out.help = true;
+    else if (!a.startsWith('-') && out.dir === null) out.dir = a;
+  }
+  return out;
+}
+
+function usage(pkg, create) {
+  console.log(`${pkg}
+
+Scaffold a local WordPress + AI-agent Docker dev environment.
+
+Usage:
+  npm ${create} -- [dir] [--port=8080] [--scaffold-only]
+  npx ${pkg} [dir] [--port=8080] [--scaffold-only]
+
+Arguments:
+  dir              Target directory (default: current directory)
+
+Options:
+  --port=NNNN      Host port for WordPress (default: 8080)
+  --scaffold-only  Only write files; skip the automatic \`npm run setup\`
+`);
+}
+
+async function copyTemplates(srcDir, destDir, vars) {
+  for (const entry of await readdir(srcDir, { withFileTypes: true })) {
+    const src = join(srcDir, entry.name);
+    const dest = join(destDir, RENAME[entry.name] ?? entry.name);
+    if (entry.isDirectory()) {
+      await mkdir(dest, { recursive: true });
+      await copyTemplates(src, dest, vars);
+    } else {
+      const rendered = (await readFile(src, 'utf8'))
+        .replaceAll('__PROJECT_NAME__', vars.projectName)
+        .replaceAll('__WP_PORT__', vars.port);
+      await mkdir(dirname(dest), { recursive: true });
+      await writeFile(dest, rendered);
+    }
+  }
+}
+
+// Append a preset's plugins to the scaffolded sandbox.config.json. Each entry is
+// the same shape install-plugins.sh understands: a wordpress.org slug string, or
+// { source, activate?, version? } where source is a slug or a URL/path to a .zip.
+async function applyPreset(targetDir, preset) {
+  if (!preset.plugins?.length) return;
+  const cfgPath = join(targetDir, 'sandbox.config.json');
+  const cfg = JSON.parse(await readFile(cfgPath, 'utf8'));
+  cfg.plugins = [...(cfg.plugins ?? []), ...preset.plugins];
+  await writeFile(cfgPath, JSON.stringify(cfg, null, 2) + '\n');
+}
+
+/**
+ * Scaffold the sandbox into a target directory and (unless --scaffold-only) run
+ * `npm run setup`.
+ *
+ * @param {object} [options]
+ * @param {object} [options.preset]          Derivative config. MVP: { name?, plugins? }.
+ * @param {string} [options.preset.name]     Short name, e.g. "oxygen-wp" — only used to
+ *                                           print the right `npm create <name>` in messages.
+ * @param {Array}  [options.preset.plugins]  Extra plugins appended to the defaults.
+ * @param {string[]} [options.argv]          CLI args (default: process.argv.slice(2)).
+ */
+export async function create({ preset = {}, argv = process.argv.slice(2) } = {}) {
+  // What to call this command in help/error text — wrappers pass preset.name.
+  const slug = preset.name ?? 'wp-local-dev-agent-sandbox';
+  const pkg = `create-${slug}`;
+
+  const args = parseArgs(argv);
+  if (args.help) {
+    usage(pkg, `create ${slug}`);
+    return;
+  }
+
+  const targetDir = resolve(args.dir ?? '.');
+  const projectName = basename(targetDir);
+
+  await mkdir(targetDir, { recursive: true });
+
+  const existing = await readdir(targetDir).catch(() => []);
+  const blocking = existing.filter((f) => !ALLOWED_EXISTING.has(f));
+  if (blocking.length) {
+    const shown = blocking.slice(0, 5).join(', ') + (blocking.length > 5 ? ', …' : '');
+    console.error(`\n✖ ${targetDir} is not empty (found: ${shown}).`);
+    console.error('  This scaffolder needs an empty directory. Point it at a new one, e.g.:');
+    console.error(`    npm create ${slug}@latest my-site\n`);
+    process.exit(1);
+  }
+
+  await copyTemplates(TEMPLATES, targetDir, { projectName, port: String(args.port) });
+  await applyPreset(targetDir, preset);
+
+  const cd = args.dir ? args.dir : '.';
+  console.log(`\n✔ Scaffolded WordPress + agent sandbox in ${targetDir}\n`);
+
+  if (!args.setup) {
+    console.log('Next steps:');
+    console.log(`  cd ${cd}`);
+    console.log('  npm run setup        # build, start & install WordPress + plugins (Docker must be running)');
+    console.log('  npm run start        # subsequent runs: just bring the containers up');
+    console.log('  npm run claude       # launch Claude Code in the workspace');
+    console.log('');
+    console.log(`Once setup finishes, your site is at http://localhost:${args.port} — log in at /wp-admin with admin / password.`);
+    return;
+  }
+
+  console.log('→ Running initial setup (Docker must be running)…\n');
+  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const res = spawnSync(npm, ['run', 'setup'], { cwd: targetDir, stdio: 'inherit' });
+  if (res.error || res.status !== 0) {
+    console.error('\n✖ Initial setup did not finish (is Docker running?).');
+    console.error('  Your files are scaffolded — retry once Docker is up:');
+    console.error(`    cd ${cd} && npm run setup\n`);
+    process.exit(res.status ?? 1);
+  }
+
+  console.log('\nEveryday commands:');
+  console.log(`  cd ${cd}`);
+  console.log('  npm run start        # bring the stack up next time (it stays up otherwise)');
+  console.log('  npm run claude       # launch Claude Code in the workspace');
+  console.log('  npm run bash         # shell into the workspace container');
+  console.log('');
+  console.log('───────────────────────────────────────────────');
+  console.log('  Your WordPress site is ready:');
+  console.log(`    Site:     http://localhost:${args.port}`);
+  console.log(`    Admin:    http://localhost:${args.port}/wp-admin`);
+  console.log('    Username: admin');
+  console.log('    Password: password');
+  console.log('───────────────────────────────────────────────');
+  console.log('');
+}

--- a/index.js
+++ b/index.js
@@ -9,140 +9,14 @@
  * Usage:
  *   npm create wp-local-dev-agent-sandbox -- [dir] [--port=8080] [--scaffold-only]
  *   npx create-wp-local-dev-agent-sandbox [dir] [--port=8080] [--scaffold-only]
+ *
+ * The scaffolding logic lives in engine.js, which is also exported for
+ * downstream `create-<brand>` packages — see the README.
  */
 
-import { readdir, mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname, join, resolve, basename } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { spawnSync } from 'node:child_process';
+import { create } from './engine.js';
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const TEMPLATES = join(HERE, 'templates');
-
-// Template filename -> output filename (dotfiles can't ship as dotfiles in npm).
-const RENAME = {
-  'env.example': '.env',
-  'gitignore': '.gitignore',
-};
-
-// When checking that the target dir is empty, these harmless entries don't count.
-const ALLOWED_EXISTING = new Set([
-  '.git', '.gitignore', '.gitkeep', '.hg', '.svn',
-  '.DS_Store', 'Thumbs.db', '.idea', '.vscode',
-  'LICENSE', 'LICENSE.md', 'README.md',
-]);
-
-function parseArgs(argv) {
-  const out = { dir: null, port: '8080', setup: true };
-  for (const a of argv) {
-    if (a.startsWith('--port=')) out.port = a.slice('--port='.length);
-    else if (a === '--scaffold-only') out.setup = false;
-    else if (a === '-h' || a === '--help') out.help = true;
-    else if (!a.startsWith('-') && out.dir === null) out.dir = a;
-  }
-  return out;
-}
-
-function usage() {
-  console.log(`create-wp-local-dev-agent-sandbox
-
-Scaffold a local WordPress + AI-agent Docker dev environment.
-
-Usage:
-  npm create wp-local-dev-agent-sandbox -- [dir] [--port=8080] [--scaffold-only]
-  npx create-wp-local-dev-agent-sandbox [dir] [--port=8080] [--scaffold-only]
-
-Arguments:
-  dir              Target directory (default: current directory)
-
-Options:
-  --port=NNNN      Host port for WordPress (default: 8080)
-  --scaffold-only  Only write files; skip the automatic \`npm run setup\`
-`);
-}
-
-async function copyTemplates(srcDir, destDir, vars) {
-  for (const entry of await readdir(srcDir, { withFileTypes: true })) {
-    const src = join(srcDir, entry.name);
-    const dest = join(destDir, RENAME[entry.name] ?? entry.name);
-    if (entry.isDirectory()) {
-      await mkdir(dest, { recursive: true });
-      await copyTemplates(src, dest, vars);
-    } else {
-      const rendered = (await readFile(src, 'utf8'))
-        .replaceAll('__PROJECT_NAME__', vars.projectName)
-        .replaceAll('__WP_PORT__', vars.port);
-      await mkdir(dirname(dest), { recursive: true });
-      await writeFile(dest, rendered);
-    }
-  }
-}
-
-async function main() {
-  const args = parseArgs(process.argv.slice(2));
-  if (args.help) {
-    usage();
-    return;
-  }
-
-  const targetDir = resolve(args.dir ?? '.');
-  const projectName = basename(targetDir);
-
-  await mkdir(targetDir, { recursive: true });
-
-  const existing = await readdir(targetDir).catch(() => []);
-  const blocking = existing.filter((f) => !ALLOWED_EXISTING.has(f));
-  if (blocking.length) {
-    const shown = blocking.slice(0, 5).join(', ') + (blocking.length > 5 ? ', …' : '');
-    console.error(`\n✖ ${targetDir} is not empty (found: ${shown}).`);
-    console.error('  This scaffolder needs an empty directory. Point it at a new one, e.g.:');
-    console.error('    npm create wp-local-dev-agent-sandbox@latest my-site\n');
-    process.exit(1);
-  }
-
-  await copyTemplates(TEMPLATES, targetDir, { projectName, port: String(args.port) });
-
-  const cd = args.dir ? args.dir : '.';
-  console.log(`\n✔ Scaffolded WordPress + agent sandbox in ${targetDir}\n`);
-
-  if (!args.setup) {
-    console.log('Next steps:');
-    console.log(`  cd ${cd}`);
-    console.log('  npm run setup        # build, start & install WordPress + plugins (Docker must be running)');
-    console.log('  npm run start        # subsequent runs: just bring the containers up');
-    console.log('  npm run claude       # launch Claude Code in the workspace');
-    console.log('');
-    console.log(`Once setup finishes, your site is at http://localhost:${args.port} — log in at /wp-admin with admin / password.`);
-    return;
-  }
-
-  console.log('→ Running initial setup (Docker must be running)…\n');
-  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-  const res = spawnSync(npm, ['run', 'setup'], { cwd: targetDir, stdio: 'inherit' });
-  if (res.error || res.status !== 0) {
-    console.error('\n✖ Initial setup did not finish (is Docker running?).');
-    console.error('  Your files are scaffolded — retry once Docker is up:');
-    console.error(`    cd ${cd} && npm run setup\n`);
-    process.exit(res.status ?? 1);
-  }
-
-  console.log('\nEveryday commands:');
-  console.log(`  cd ${cd}`);
-  console.log('  npm run start        # bring the stack up next time (it stays up otherwise)');
-  console.log('  npm run claude       # launch Claude Code in the workspace');
-  console.log('  npm run bash         # shell into the workspace container');
-  console.log('');
-  console.log('───────────────────────────────────────────────');
-  console.log('  Your WordPress site is ready:');
-  console.log(`    Site:     http://localhost:${args.port}`);
-  console.log(`    Admin:    http://localhost:${args.port}/wp-admin`);
-  console.log('    Username: admin');
-  console.log('    Password: password');
-  console.log('───────────────────────────────────────────────');
-  console.log('');
-}
-
-main().catch((err) => {
+create().catch((err) => {
   console.error(err);
   process.exit(1);
 });

--- a/package.json
+++ b/package.json
@@ -6,8 +6,12 @@
   "bin": {
     "create-wp-local-dev-agent-sandbox": "index.js"
   },
+  "exports": {
+    ".": "./engine.js"
+  },
   "files": [
     "index.js",
+    "engine.js",
     "templates"
   ],
   "engines": {


### PR DESCRIPTION
## Summary
Turn the scaffolder into a reusable library so anyone shipping a WordPress plugin can publish their own `create-<brand>` command (e.g. `npm create oxygen-wp`) that scaffolds this same sandbox with their plugins pre-installed — **no fork**, they just depend on this package.

- **`engine.js`** (new): holds the scaffolding logic and exports `create({ preset, argv })`. A preset (MVP: `{ name?, plugins? }`) **appends** its plugins to the scaffolded `sandbox.config.json`, so downstream packages get the full sandbox plus their own plugins. `preset.name` is used only to print the right `npm create <name>` in help / empty-dir messages.
- **`index.js`**: now a thin bin that just calls `create()`.
- **`package.json`**: adds `exports` (`.` → `./engine.js`) and ships `engine.js`, so wrappers can `import { create } from 'create-wp-local-dev-agent-sandbox'`.
- **README**: documents the *Build your own npm create command* pattern.

The wrapper itself (`create-oxygen-wp`) lives in its own repo — this PR only adds the engine + docs it needs.

## Preset shape (MVP)
```js
create({ preset: { name: 'oxygen-wp', plugins: [{ source: 'https://…/oxygen.zip', activate: true }] } })
```
Plugins are appended to the defaults (`mcp-adapter` + `root-for-agents` always present).

## Testing
- Base CLI unchanged (`--help`, `--scaffold-only`).
- Preset API appends a `.zip` plugin and writes valid JSON, defaults retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)