### PR TITLE
Install GitHub CLI (gh) in the workspace container

### DIFF
--- a/templates/workspace.Dockerfile
+++ b/templates/workspace.Dockerfile
@@ -1,10 +1,19 @@
 FROM node:22-bookworm-slim
 
 # PHP + the extensions WP-CLI needs (mysql for DB, curl/zip for installs, etc.)
-# plus the mysql client for `wp db ...`, and curl for general use.
+# plus the mysql client for `wp db ...`, git, and curl for general use.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         php-cli php-mysql php-curl php-xml php-mbstring php-zip \
-        default-mysql-client curl ca-certificates \
+        default-mysql-client curl ca-certificates git \
+    && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI (`gh`) from its official apt repo.
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
 # WP-CLI, wrapped so `wp` always runs with --allow-root (harmless for non-root).


### PR DESCRIPTION
## What

Adds the [GitHub CLI](https://cli.github.com/) (`gh`) to the scaffolded workspace container, installed from its official apt repo. Also adds `git`, which `gh` relies on.

## Why

So agents working inside the sandbox can interact with GitHub (PRs, issues, etc.) without extra setup.

## Notes

- New scaffolded projects get `gh` automatically.
- Existing projects pick it up after rebuilding the workspace image (`docker compose build workspace` / `docker compose up --build`).
- Verified by scaffolding a fresh project — the workspace image builds successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)