### PR TITLE
Make the workspace root a dir containing wp; add Composer

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -6,10 +6,10 @@ Four services:
 
 - **db** — MariaDB
 - **wordpress** — WordPress on `http://localhost:__WP_PORT__`
-- **workspace** — an isolated dev container (Node + Claude Code + PHP + WP-CLI) that mounts the same WordPress files and reaches the site/DB over the Docker network
+- **workspace** — an isolated dev container (Node + Claude Code + PHP + WP-CLI + Composer) that mounts the same WordPress files and reaches the site/DB over the Docker network
 - **playwright** — a [Playwright MCP](https://github.com/microsoft/playwright-mcp) server (headless Chromium) that Claude drives to browse the site
 
-All data lives in bind-mounted folders in this directory (`db/`, `wp/`, `workspace/`), so it survives restarts and is browsable on your machine. They're git-ignored.
+All data lives in bind-mounted folders in this directory (`db/` and `workspace/` — the latter holds WordPress at `workspace/wp` plus your checkouts), so it survives restarts and is browsable on your machine. They're git-ignored.
 
 ## Requirements
 
@@ -42,11 +42,11 @@ npm run start     # build + start containers
 | `npm run setup` | First-run: start the stack, install WordPress (`admin` / `password`), install plugins |
 | `npm run start` | `docker compose up -d --build` |
 | `npm run stop` | Stop containers (keep data) |
-| `npm run down` | Stop + remove containers (data preserved in `db/`, `wp/`, `workspace/`) |
+| `npm run down` | Stop + remove containers (data preserved in `db/`, `workspace/`) |
 | `npm run restart` | Restart containers |
 | `npm run logs` | Tail logs from all services |
 | `npm run ps` | Show container status |
-| `npm run bash` | Shell into the workspace container (lands in `/wp`) |
+| `npm run bash` | Shell into the workspace container (lands in the workspace root `/home/node`, with WordPress at `wp/`) |
 | `npm run claude` | Launch Claude Code in the workspace (`--dangerously-skip-permissions`, safe because it's contained) |
 | `npm run wp` | Run WP-CLI, e.g. `npm run wp -- plugin list` |
 | `npm run reset` | ⚠️ Wipe all data and rebuild from scratch |
@@ -71,7 +71,16 @@ A bare string is shorthand for `{ "source": "<string>", "activate": true }`. Aft
 
 ## Notes
 
-- **Working on a plugin/theme?** It lives at `wp/wp-content/plugins/…` (or `themes/…`). Edit it on your machine or from inside the workspace container — same files, served live.
+- **Working on a plugin/theme?** Installed ones live at `workspace/wp/wp-content/plugins/…` (or `themes/…`) on your machine — `wp/wp-content/…` from inside the workspace container. Edit them either place — same files, served live.
+- **Developing a plugin/theme from its own repo?** You land in the workspace root (`/home/node`) with WordPress nested at `wp/`, so check it out as a sibling of `wp` and symlink it into place — keeping your repo out of the WordPress tree:
+  ```bash
+  npm run bash                                  # land in the workspace root
+  git clone <your-plugin-repo> my-plugin        # checked out next to wp/, not inside it
+  composer install -d my-plugin                 # Composer is available globally
+  ln -s /home/node/my-plugin wp/wp-content/plugins/my-plugin
+  wp plugin activate my-plugin
+  ```
+  The workspace root is mounted into the wordpress container at the same path, so Apache follows the symlink and serves the plugin live.
 - **First Claude run:** inside the workspace, run `npm run claude` and use `/login` once. Your login persists in `workspace/` across rebuilds.
 - **WP-CLI** talks to the database automatically over the Docker network.
 - **MCP:** `npm run setup` connects Claude to two MCP servers automatically (registered at user scope — `claude mcp list` shows them; re-add or tweak with `bash scripts/connect-mcp.sh`):

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -31,12 +31,18 @@ services:
     ports:
       - "${WP_PORT}:80"
     volumes:
-      - ./wp:/var/www/html
+      - ./workspace/wp:/var/www/html
       - ./php/php.ini:/usr/local/etc/php/conf.d/php.ini:ro   # custom PHP overrides (upload limits, etc.)
+      # Mount the workspace root at the same path the workspace container uses, so
+      # a plugin/theme you check out there and symlink into wp-content resolves
+      # here too (Apache follows the symlink to /home/node/<your-checkout>).
+      - ./workspace:/home/node
 
-  # Isolated dev container: Node + Claude Code + PHP + WP-CLI. This is where you
-  # run agents. It mounts the same WordPress files at /wp and reaches the site
-  # over the Docker network (http://wordpress) and the DB at host "db".
+  # Isolated dev container: Node + Claude Code + PHP + WP-CLI + Composer. This is
+  # where you run agents. You land in the workspace root (/home/node) with
+  # WordPress nested at ./wp — so you can check out plugins/themes as siblings of
+  # wp and symlink them into wp/wp-content/. It reaches the site over the Docker
+  # network (http://wordpress) and the DB at host "db".
   workspace:
     build:
       context: .
@@ -49,8 +55,9 @@ services:
       # So WP-CLI run here agrees with the wordpress container's environment type.
       WP_ENVIRONMENT_TYPE: local
     volumes:
-      - ./workspace:/home/node   # the node user's home — persists Claude login, shell history
-      - ./wp:/wp                 # WordPress files (top-level path, not nested in home)
+      # Workspace root + home: persists your Claude login, shell history, your
+      # plugin/theme checkouts, and WordPress itself (nested at ./wp inside it).
+      - ./workspace:/home/node
 
   # Playwright MCP server (prebaked image, headless Chromium). Claude in the
   # workspace connects to it over HTTP at http://playwright:8931/mcp and drives a

--- a/templates/gitignore
+++ b/templates/gitignore
@@ -1,6 +1,6 @@
 # Runtime data (bind mounts) — never commit these
 db/
-wp/
+# The workspace root: your Claude login, checkouts, and WordPress (./workspace/wp)
 workspace/
 
 # Logs and OS cruft

--- a/templates/scripts/initial-setup.sh
+++ b/templates/scripts/initial-setup.sh
@@ -16,7 +16,7 @@ docker compose up -d --build
 
 echo "→ Waiting for WordPress files and the database…"
 tries=0
-until docker compose exec -T workspace bash -c '[ -f /wp/wp-config.php ] && wp db query "SELECT 1;"' >/dev/null 2>&1; do
+until docker compose exec -T workspace bash -c '[ -f /home/node/wp/wp-config.php ] && wp db query "SELECT 1;"' >/dev/null 2>&1; do
   tries=$((tries + 1))
   if [ "$tries" -gt 60 ]; then
     echo "✖ Timed out waiting for the stack to come up." >&2

--- a/templates/scripts/install-wp.sh
+++ b/templates/scripts/install-wp.sh
@@ -40,7 +40,7 @@ fi
 # AllowOverride All, so they take effect).
 echo "→ Enabling pretty permalinks…"
 docker compose exec -T workspace wp rewrite structure '/%postname%/' >/dev/null
-cat > wp/.htaccess <<'HT'
+cat > workspace/wp/.htaccess <<'HT'
 # BEGIN WordPress
 <IfModule mod_rewrite.c>
 RewriteEngine On

--- a/templates/workspace.Dockerfile
+++ b/templates/workspace.Dockerfile
@@ -14,12 +14,24 @@ RUN chmod 0755 /usr/local/bin/wp-cli.phar \
     && printf '#!/bin/sh\nexec php /usr/local/bin/wp-cli.phar --allow-root "$@"\n' > /usr/local/bin/wp \
     && chmod +x /usr/local/bin/wp
 
+# You land in the workspace root (/home/node), with WordPress nested at ./wp.
+# Point WP-CLI there by default so `wp` works from anywhere without --path. A
+# global config file is used (not the wrapper) so an explicit --path still wins.
+ENV WP_CLI_CONFIG_PATH=/etc/wp-cli.yml
+RUN printf 'path: /home/node/wp\n' > /etc/wp-cli.yml
+
+# Composer (PHP dependency manager), available globally as `composer`.
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+
 RUN npm install -g @anthropic-ai/claude-code
 
 # Run as the image's built-in non-root user (uid 1000) so
 # `claude --dangerously-skip-permissions` is allowed (it refuses to run as root).
 USER node
-WORKDIR /wp
+# The workspace root: WordPress lives at ./wp, and you can check out plugins/
+# themes as siblings and symlink them into wp/wp-content/ (both this container
+# and the wordpress container see them at the same path — see docker-compose.yml).
+WORKDIR /home/node
 
 # Keep the container alive so you can `docker compose exec` into it.
 CMD ["sleep", "infinity"]


### PR DESCRIPTION
## What & why

The workspace container used to land you in the WordPress root (`/wp`), with nowhere to put a plugin checkout *next to* WordPress. This makes the **workspace root a directory that contains `wp`**, so you can check out plugins/themes from their own repos as siblings of `wp` and symlink them into `wp/wp-content/` — keeping your source out of the WordPress tree.

It also installs **Composer globally** in the workspace container.

## Changes

- **Land in the workspace root.** Workspace `WORKDIR` is now `/home/node` (the workspace root / home), with WordPress nested at `./wp`. On the host, WordPress moves from `./wp` to `./workspace/wp` (both git-ignored runtime dirs).
- **Cross-container symlinks work.** For a symlinked plugin to load, the wordpress (Apache) container has to see the checkout at the same path the symlink points to — so the workspace root is now mounted into **both** containers at `/home/node`. Apache follows the symlink to `/home/node/<your-checkout>`.
- **Composer** is copied in globally (`composer:2` image) — available as `composer`.
- **WP-CLI** is pointed at `/home/node/wp` by default via `WP_CLI_CONFIG_PATH`, so `wp` keeps working from the new working directory (an explicit `--path` still wins).
- Updated `initial-setup.sh` readiness check, `install-wp.sh` `.htaccess` path, `.gitignore`, and the README (including a documented checkout + symlink workflow).

## Verification

Scaffolded a fresh project and ran `npm run setup` end-to-end:
- WordPress installs at `workspace/wp`; `npm run bash` lands in `/home/node` with `wp/` inside.
- `composer --version` → Composer 2.10.0.
- Checked out a plugin as a sibling of `wp`, symlinked it into `wp-content/plugins`, and activated it — `readlink -f` resolves the symlink in **both** containers, Apache reads the plugin through it, and the live site serves **HTTP 200** with it active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)