### PR TITLE
feat: enable Agent Connector via option, not wp-config constant

### DIFF
--- a/templates/scripts/install-agent-connector.sh
+++ b/templates/scripts/install-agent-connector.sh
@@ -13,17 +13,20 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 echo "→ Enabling Agent Connector for WP…"
-# A single wp-config.php constant gates all of the plugin's abilities — it's inert
-# without it. We enable it: this is a trusted, throwaway dev sandbox (Claude
-# already runs here with --dangerously-skip-permissions, and the plugin itself
-# refuses to run on a production environment type).
-docker compose exec -T workspace wp config set AGENT_CONNECTOR_FOR_WP_ENABLED true --raw --type=constant >/dev/null
+# The plugin is inert until explicitly switched on. That switch is a WordPress
+# option (flipped from its Settings screen in the admin) — there is no wp-config
+# constant anymore. We set the option directly: this is a trusted, throwaway dev
+# sandbox (Claude already runs here with --dangerously-skip-permissions). The
+# stack marks the site as WP_ENVIRONMENT_TYPE=local (see docker-compose.yml), so
+# the enable toggle alone activates it — no production override needed.
+docker compose exec -T workspace wp option update agent_connector_for_wp_enabled 1 >/dev/null
 
 # Install from the packaged release zip — vendor/ (incl. the bundled mcp-adapter)
 # is baked in, so no composer step is needed. --force reinstalls cleanly on
-# re-run; --activate switches it on (the constant above is its gate).
+# re-run; --activate activates the plugin (the option set above is what actually
+# exposes its abilities).
 docker compose exec -T workspace wp plugin install \
-  https://github.com/soflyy/agent-connector-for-wp/releases/download/v1.1.0/agent-connector-for-wp.zip \
+  https://github.com/soflyy/agent-connector-for-wp/releases/download/v1.2.0/agent-connector-for-wp.zip \
   --force --activate
 
 echo "✓ Agent Connector for WP enabled (shell, WP-CLI, PHP eval, filesystem)."

--- a/templates/scripts/install-agent-connector.sh
+++ b/templates/scripts/install-agent-connector.sh
@@ -21,12 +21,13 @@ echo "→ Enabling Agent Connector for WP…"
 # the enable toggle alone activates it — no production override needed.
 docker compose exec -T workspace wp option update agent_connector_for_wp_enabled 1 >/dev/null
 
-# Install from the packaged release zip — vendor/ (incl. the bundled mcp-adapter)
-# is baked in, so no composer step is needed. --force reinstalls cleanly on
-# re-run; --activate activates the plugin (the option set above is what actually
-# exposes its abilities).
+# Install from the latest packaged release zip — vendor/ (incl. the bundled
+# mcp-adapter) is baked in, so no composer step is needed. The /releases/latest/
+# URL always resolves to the newest release's asset, so we never pin a version.
+# --force reinstalls cleanly on re-run; --activate activates the plugin (the
+# option set above is what actually exposes its abilities).
 docker compose exec -T workspace wp plugin install \
-  https://github.com/soflyy/agent-connector-for-wp/releases/download/v1.2.0/agent-connector-for-wp.zip \
+  https://github.com/soflyy/agent-connector-for-wp/releases/latest/download/agent-connector-for-wp.zip \
   --force --activate
 
 echo "✓ Agent Connector for WP enabled (shell, WP-CLI, PHP eval, filesystem)."


### PR DESCRIPTION
## What

Agent Connector for WP dropped the `AGENT_CONNECTOR_FOR_WP_ENABLED` wp-config constant in favor of a Settings-screen toggle backed by the `agent_connector_for_wp_enabled` option (the upstream PR that added the Settings/domain-lock screen, shipped in v1.2.0). This updates the sandbox's provisioning step to the new method.

## Changes (`templates/scripts/install-agent-connector.sh`)

- **Enable mechanism:** `wp config set AGENT_CONNECTOR_FOR_WP_ENABLED true --type=constant` -> `wp option update agent_connector_for_wp_enabled 1`.
- **Always install the latest release:** download from `.../releases/latest/download/agent-connector-for-wp.zip` instead of a pinned tag, so the sandbox tracks the newest built release with no manual version bumps. (The old `v1.1.0` pin was also constant-based; latest is now the option-gated build, with `vendor/` baked in.)
- Reworded the comments to match.

## Why nothing else was needed

- The stack already sets `WP_ENVIRONMENT_TYPE: local` (docker-compose.yml), so `Config::can_boot()` activates on the enable toggle alone — no production override.
- The new domain lock is inert when unset (`locked_host === '' -> allowed`), so abilities run without a reconnect step.
- `connect-mcp.sh` gates on `wp plugin is-active`, which still holds — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)