### PR TITLE
feat: pre-create bind-mount host dirs to avoid root-owned mounts on Linux

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -125,6 +125,13 @@ export async function create({ preset = {}, argv = process.argv.slice(2) } = {})
   await copyTemplates(TEMPLATES, targetDir, { projectName, port: String(args.port) });
   await applyPreset(targetDir, preset);
 
+  // Pre-create the bind-mount host dirs (see docker-compose.yml). If they don't
+  // exist when the stack first comes up, Docker creates them as root — on Linux
+  // that leaves them owned by root and unwritable from the host.
+  for (const d of ['db', 'workspace/wp']) {
+    await mkdir(join(targetDir, d), { recursive: true });
+  }
+
   const cd = args.dir ? args.dir : '.';
   console.log(`\n✔ Scaffolded WordPress + agent sandbox in ${targetDir}\n`);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-wp-local-dev-agent-sandbox",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Scaffold a local WordPress + AI-agent dev environment (Docker Compose) with WP-CLI and Claude Code in an isolated workspace container.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What

Pre-create the bind-mount host dirs (`db`, `workspace`, `workspace/wp`) during scaffolding.

## Why

If these dirs don't exist when the Docker stack first comes up, Docker creates them itself — as root. On Linux that leaves them owned by root and unwritable from the host, causing permission problems. Creating them up front means the host user owns them.

Also bumps version to `0.3.1` for the npm release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)