### PR TITLE
docs: note CLAUDE_CODE_OAUTH_TOKEN auto-login in the package README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ npm run bash       # shell into the workspace container
 npm run claude     # launch Claude Code in the workspace
 ```
 
+**Tip — skip `/login`:** if you export a `CLAUDE_CODE_OAUTH_TOKEN` in your shell (mint one with `claude setup-token`), `npm run claude` forwards it into the workspace container and Claude is logged in automatically. It's passed by name (`docker compose exec -e CLAUDE_CODE_OAUTH_TOKEN`), so the value never appears on the command line. Otherwise just run `/login` once inside the workspace — it persists in `workspace/` across rebuilds.
+
 ## What gets scaffolded
 
 ```


### PR DESCRIPTION
Adds a short tip to the root README quick-start pointing out that exporting `CLAUDE_CODE_OAUTH_TOKEN` makes `npm run claude` log in automatically. The scaffolded `templates/README.md` already covered this (v0.4.0); this just surfaces it on the npm/GitHub landing page. Docs-only — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)