### PR TITLE
fix: align WordPress container to uid 1000 to fix Linux bind-mount perms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-wp-local-dev-agent-sandbox",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Scaffold a local WordPress + AI-agent dev environment (Docker Compose) with WP-CLI and Claude Code in an isolated workspace container.",
   "type": "module",
   "bin": {

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -18,6 +18,15 @@ services:
       WORDPRESS_DB_PASSWORD: ${MARIADB_PASSWORD}
       # Marks the site as local so e.g. Application Passwords work over plain HTTP.
       WP_ENVIRONMENT_TYPE: local
+      # Run Apache (and chown the WordPress files) as uid/gid 1000 — the same
+      # user the workspace container runs as (node). On Linux, bind mounts keep
+      # the container's uid on the host, so without this the wordpress container
+      # would write wp-content/.htaccess as www-data (uid 33), and neither the
+      # workspace container (WP-CLI, plugin installs) nor your host user could
+      # write into the tree. Anchoring everything to 1000 keeps it writable from
+      # all three. (Docker Desktop on macOS papers over this; native Linux doesn't.)
+      APACHE_RUN_USER: "#1000"
+      APACHE_RUN_GROUP: "#1000"
       # Derive the site URL from the request host so the site works without
       # redirects both from your machine (localhost:${WP_PORT}) and from inside
       # the Docker network (http://wordpress — used by the Playwright browser).

--- a/templates/scripts/install-wp.sh
+++ b/templates/scripts/install-wp.sh
@@ -34,13 +34,16 @@ EOF
 fi
 
 # Pretty permalinks (idempotent). Needed so the REST API is reachable at the
-# clean /wp-json/ paths (e.g. the WordPress MCP server). WP-CLI runs in the
-# workspace, not the Apache container, so its --hard flush can't write the
-# .htaccess — we write the standard rules ourselves (Apache has mod_rewrite +
-# AllowOverride All, so they take effect).
+# clean /wp-json/ paths (e.g. the WordPress MCP server). WP-CLI's --hard flush
+# only writes .htaccess when it detects Apache's mod_rewrite, which it can't from
+# the workspace container — so we write the standard rules ourselves (Apache has
+# mod_rewrite + AllowOverride All, so they take effect). We write from inside the
+# workspace container rather than the host: it owns the WordPress tree (uid 1000,
+# see APACHE_RUN_USER in docker-compose.yml), so this doesn't depend on the host
+# user's uid matching — which it wouldn't, on Linux.
 echo "→ Enabling pretty permalinks…"
 docker compose exec -T workspace wp rewrite structure '/%postname%/' >/dev/null
-cat > workspace/wp/.htaccess <<'HT'
+docker compose exec -T workspace sh -c 'cat > wp/.htaccess' <<'HT'
 # BEGIN WordPress
 <IfModule mod_rewrite.c>
 RewriteEngine On


### PR DESCRIPTION
## Problem

On **native Linux**, `npm run setup` fails:

```
Warning: Unable to create directory wp-content/uploads/2026/06. Is its parent directory writable by the server?
scripts/install-wp.sh: line 43: workspace/wp/.htaccess: Permission denied
✖ Initial setup did not finish
```

Linux bind mounts preserve the **container's** uid on the host. The `wordpress` container runs Apache as `www-data` (uid 33), so it owns `wp-content` and the html root as 33. But the `workspace` container runs as `node` (uid **1000**) — that's where WP-CLI, plugin installs, and agents run — and the host user is typically 1000 too. None of them can write into a uid-33 tree. Docker Desktop on macOS papers over this by remapping ownership; native Linux doesn't, so it only reproduces there.

Two symptoms, same root cause:
1. `wp core install` (workspace, uid 1000) can't create `wp-content/uploads` (owned by 33).
2. `install-wp.sh` wrote `.htaccess` **from the host** into a uid-33 dir → permission denied.

## Fix

- **Anchor the wordpress container to uid 1000.** Set `APACHE_RUN_USER` / `APACHE_RUN_GROUP` to `#1000` on the `wordpress` service. The official image both runs Apache workers as that user *and* `chown`s the WordPress files to it on first boot (verified in the image's `docker-entrypoint.sh`), so the whole tree ends up owned by 1000 — matching the workspace `node` user and the default Ubuntu host user. `wp-content` writes (uploads, plugin installs) now work from the workspace container.
- **Write `.htaccess` from inside the workspace container** instead of the host (`docker compose exec -T workspace sh -c 'cat > wp/.htaccess'`). The workspace container owns the tree at 1000, so this no longer depends on the host user's uid being 1000.

## Notes / testing

- Container-to-container alignment is deterministic: the `node` base image fixes the workspace user at uid 1000, so 1000 is the correct anchor regardless of host. Direct host editing still benefits when the host user is uid 1000 (the Ubuntu default).
- **Not yet verified on a live Linux stack** — reasoned from the image's entrypoint behavior and the uid model. Worth a real `npm run setup` on Ubuntu before release.
- **Existing broken sandboxes** need `npm run reset` to repopulate `wp/` with the corrected ownership.

Bumps version to `0.4.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)