### PR TITLE
fix: make /home/node writable when scaffolding as root; harden Cursor MCP step

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -7,7 +7,7 @@
  * "Build your own npm create command".
  */
 
-import { readdir, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { readdir, mkdir, readFile, writeFile, chown } from 'node:fs/promises';
 import { dirname, join, resolve, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
@@ -130,6 +130,21 @@ export async function create({ preset = {}, argv = process.argv.slice(2) } = {})
   // that leaves them owned by root and unwritable from the host.
   for (const d of ['db', 'workspace/wp']) {
     await mkdir(join(targetDir, d), { recursive: true });
+  }
+
+  // ./workspace is the workspace container's home (/home/node), and that
+  // container runs as the node user (uid/gid 1000). On Linux a bind mount keeps
+  // the host's ownership, so node can write there only if the host dir is owned
+  // by 1000 — the repo's "anchor everything to uid 1000" model (see
+  // APACHE_RUN_USER in docker-compose.yml), which holds when the default Ubuntu
+  // host user (also 1000) scaffolds. When scaffolding as root the dir would be
+  // root-owned and unwritable, so the agents' configs (~/.claude.json, the seed,
+  // ~/.cursor/mcp.json) silently fail to persist. Align it explicitly. (db/ is
+  // left alone — the mariadb container manages its own datadir ownership.)
+  if (process.getuid && process.getuid() === 0) {
+    for (const d of ['workspace', 'workspace/wp']) {
+      await chown(join(targetDir, d), 1000, 1000);
+    }
   }
 
   const cd = args.dir ? args.dir : '.';

--- a/templates/scripts/connect-mcp.sh
+++ b/templates/scripts/connect-mcp.sh
@@ -60,10 +60,13 @@ claude mcp remove playwright --scope user >/dev/null 2>&1 || true
 claude mcp add playwright --scope user --transport http "$PLAYWRIGHT_URL"
 
 # Cursor reads ~/.cursor/mcp.json (same servers, its own format). Merge into any
-# existing file so a manual /login or other servers aren't clobbered. The proxy
+# existing file so a manual login or other servers aren't clobbered. The proxy
 # command + the playwright HTTP url mirror the Claude registrations above.
+# Non-fatal: if the home dir isn't writable (e.g. a root-owned /home/node from
+# scaffolding as a non-1000 host user), warn and continue rather than aborting
+# setup — Claude registration above is independent.
 echo "→ Connecting Cursor to the MCP servers (~/.cursor/mcp.json)…"
-HAS_WP="$HAS_WP" APPPASS="$APPPASS" WP_MCP_URL="$WP_MCP_URL" PLAYWRIGHT_URL="$PLAYWRIGHT_URL" node -e '
+if HAS_WP="$HAS_WP" APPPASS="$APPPASS" WP_MCP_URL="$WP_MCP_URL" PLAYWRIGHT_URL="$PLAYWRIGHT_URL" node -e '
   const fs = require("fs"), os = require("os"), path = require("path");
   const dir = path.join(os.homedir(), ".cursor");
   fs.mkdirSync(dir, { recursive: true });
@@ -87,9 +90,13 @@ HAS_WP="$HAS_WP" APPPASS="$APPPASS" WP_MCP_URL="$WP_MCP_URL" PLAYWRIGHT_URL="$PL
   }
   c.mcpServers.playwright = { url: process.env.PLAYWRIGHT_URL };
   fs.writeFileSync(p, JSON.stringify(c, null, 2) + "\n");
-'
-
-echo "✓ MCP servers registered for Claude ('claude mcp list') and Cursor (~/.cursor/mcp.json)."
+'; then
+  echo "✓ MCP servers registered for Claude ('claude mcp list') and Cursor (~/.cursor/mcp.json)."
+else
+  echo "⚠ Could not write ~/.cursor/mcp.json (is /home/node writable by the node user?)." >&2
+  echo "  Skipping Cursor's MCP setup — Claude is registered and unaffected. Fix the" >&2
+  echo "  workspace/ ownership (it must be uid 1000) and re-run: bash scripts/connect-mcp.sh" >&2
+fi
 EOF
 
 echo "✓ Run 'npm run claude' or 'npm run cursor' and use the MCP servers right away."


### PR DESCRIPTION
## Problem

Running the scaffolder **as root** on Linux (cloud shells, CI, many devcontainers) left `./workspace` — the workspace container's `/home/node` — **root-owned**, so the container's `node` user (uid 1000) couldn't write its own home.

Surfaced (reported by @louisreingold) as `npm run setup` crashing on the new Cursor MCP step:

```
Error: EACCES: permission denied, mkdir '/home/node/.cursor'
✖ Initial setup did not finish
```

Investigating revealed it's broader than the Cursor code: the Cursor step just failed *loudly*. **Claude was failing silently the whole time** in this scenario — `~/.claude.json` never persisted, the onboarding seed no-op'd, and `claude mcp list` came back empty.

Root cause: the repo's design anchors everything to **uid 1000** (the `node` user and the default Linux host user — see `APACHE_RUN_USER` in `docker-compose.yml`). `engine.js` pre-creates `workspace/wp` so Docker doesn't make it root-owned, but that only holds when the host user *is* 1000. As root (uid 0), `workspace/` is `0:0` and unwritable from the container.

## Fix (per maintainer's chosen approach: root-cause + resilience)

- **`engine.js`** — when scaffolding as root (`process.getuid() === 0`), `chown` the pre-created `workspace/` and `workspace/wp` to `1000:1000`, extending the existing "anchor to uid 1000" model to the root-host case. `db/` is intentionally left to the mariadb container (uid 999).
- **`connect-mcp.sh`** — make the Cursor `~/.cursor/mcp.json` write **non-fatal**: on a non-writable home it warns and continues rather than aborting setup (Claude registration is independent). Belt-and-suspenders for any other uid mismatch.

Both fixes are no-ops in the common cases (host user already uid 1000, or macOS Docker Desktop which remaps ownership), so existing setups are unaffected.

## Verification (real `npm run setup` as root, Docker available)

- ✅ Setup runs to completion — Cursor MCP step succeeds, `install-skills` runs (both previously skipped by the crash).
- ✅ `/home/node` is now `1000:1000`; `db/` remains `999:999`.
- ✅ `~/.cursor/mcp.json` written with both `wordpress` + `playwright`.
- ✅ **`claude mcp list` shows both servers `✔ Connected`** — the WordPress one connecting confirms the minted app-password auth works end to end. This was silently broken before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)