### PR TITLE
feat: devbox control server — manage many WordPress + Cursor worker environments

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -30,6 +30,19 @@ GIT_AUTHOR_EMAIL=devbox@localhost
 # TARGET_PLUGIN_SUBDIR=plugin      # the plugin lives in <repo>/<subdir>
 # WORKER_DIR defaults to the checkout (/home/node/<slug>) when TARGET_REPO is set.
 
+# --- Claude headless sessions -----------------------------------------------
+# Drive `claude -p` in each devbox via the server + web UI. Claude is run through
+# the env's own scripts/in-workspace.sh, which resolves the token the same way
+# `npm run claude` does — so put CLAUDE_CODE_OAUTH_TOKEN here (or in
+# ~/.agent-sandbox/oauth-token). The server keeps no Claude token of its own.
+# CLAUDE_CODE_OAUTH_TOKEN=
+# CLAUDE_DEFAULT_MODEL=          # optional, e.g. claude-sonnet-4-6 (else CLI default)
+# SESSION_RING_BUFFER=500        # live events buffered per session for late SSE subscribers
+
+# Start a Cursor worker automatically on env create (kept available; Claude is the
+# focus now). Set to 0 to skip — envs then run no worker.
+# CURSOR_WORKER_AUTOSTART=1
+
 # --- Optional (defaults shown) ----------------------------------------------
 # DEVBOX_PORT=4000
 # Bind address. Default 127.0.0.1 (localhost only). To reach the server over the

--- a/server/.env.example
+++ b/server/.env.example
@@ -20,6 +20,10 @@ GIT_AUTHOR_EMAIL=devbox@localhost
 
 # --- Optional (defaults shown) ----------------------------------------------
 # DEVBOX_PORT=4000
+# Bind address. Default 127.0.0.1 (localhost only). To reach the server over the
+# network set 0.0.0.0 (all interfaces) or a specific IP — this REQUIRES
+# DEVBOX_API_TOKEN above, and you should keep the host behind a firewall/VPN
+# (the API controls Docker = root-equivalent on this box).
 # DEVBOX_BIND=127.0.0.1
 # WP_PORT_RANGE=9000-9999
 # MAX_ENVIRONMENTS=25
@@ -28,5 +32,8 @@ GIT_AUTHOR_EMAIL=devbox@localhost
 # SCAFFOLDER_DIR=..            # path to the create-wp-local-dev-agent-sandbox repo
 # WORKER_DIR=/home/node
 # WORKER_IDLE_RELEASE_TIMEOUT=
+# Worker health endpoint, bound INSIDE the container (not published to the host).
+# Used for liveness via curl /readyz (the slim image has no pgrep/ps).
+# WORKER_MANAGEMENT_ADDR=127.0.0.1:8930
 # RECONCILE_INTERVAL_MS=45000
 # DEVBOX_ENV_FILE=             # override which .env file to load

--- a/server/.env.example
+++ b/server/.env.example
@@ -18,6 +18,18 @@ DEVBOX_API_TOKEN=
 GIT_AUTHOR_NAME=devbox
 GIT_AUTHOR_EMAIL=devbox@localhost
 
+# --- Target plugin repo -----------------------------------------------------
+# Each environment replaces the release-zip plugin with a LIVE GIT CHECKOUT:
+# clone TARGET_REPO into the workspace, `composer install --no-dev` in its plugin
+# subdir, symlink that into wp-content/plugins, and activate it — so the Cursor
+# worker operates on (and commits to) the real repo. Defaults to Agent Connector
+# for WP. Set TARGET_REPO= (empty) to disable and get a general-purpose worker.
+# TARGET_REPO=https://github.com/soflyy/agent-connector-for-wp.git
+# TARGET_REPO_REF=                 # optional branch/tag/commit to check out
+# TARGET_PLUGIN_SLUG=agent-connector-for-wp   # wp-content/plugins/<slug> + worker name dir
+# TARGET_PLUGIN_SUBDIR=plugin      # the plugin lives in <repo>/<subdir>
+# WORKER_DIR defaults to the checkout (/home/node/<slug>) when TARGET_REPO is set.
+
 # --- Optional (defaults shown) ----------------------------------------------
 # DEVBOX_PORT=4000
 # Bind address. Default 127.0.0.1 (localhost only). To reach the server over the

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,32 @@
+# devbox-server configuration.
+# Copy to `.env` (same dir, next to package.json): cp .env.example .env
+# `.env` is gitignored. `npm start` loads it automatically. Real environment
+# variables already set take precedence over .env (so systemd/export still work).
+
+# --- Required: shared credentials applied to every environment ---------------
+# Cursor service-account / user API key (Cursor dashboard → Settings → API Keys).
+CURSOR_API_KEY=
+# GitHub token so the workers can clone/commit/push (repo scope).
+GITHUB_TOKEN=
+
+# --- Recommended ------------------------------------------------------------
+# Bearer token for THIS server's API (you invent it). If set, every request must
+# send `Authorization: Bearer <value>`. Generate one with: openssl rand -hex 32
+DEVBOX_API_TOKEN=
+
+# Commit identity the workers use.
+GIT_AUTHOR_NAME=devbox
+GIT_AUTHOR_EMAIL=devbox@localhost
+
+# --- Optional (defaults shown) ----------------------------------------------
+# DEVBOX_PORT=4000
+# DEVBOX_BIND=127.0.0.1
+# WP_PORT_RANGE=9000-9999
+# MAX_ENVIRONMENTS=25
+# BUILD_CONCURRENCY=2
+# DEVBOX_ENVS_DIR=data/envs
+# SCAFFOLDER_DIR=..            # path to the create-wp-local-dev-agent-sandbox repo
+# WORKER_DIR=/home/node
+# WORKER_IDLE_RELEASE_TIMEOUT=
+# RECONCILE_INTERVAL_MS=45000
+# DEVBOX_ENV_FILE=             # override which .env file to load

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+data/
+*.log

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 data/
 *.log
+.env

--- a/server/AGENT_USAGE.md
+++ b/server/AGENT_USAGE.md
@@ -138,6 +138,25 @@ curl -s -H "Authorization: Bearer $TOK" -X DELETE "$BASE/environments/my-devbox"
   wrong bearer token; `404` = unknown env; `409` = name taken; `503` = at
   capacity or no free port.
 
+## Driving Claude in an environment (optional)
+
+Besides the Cursor worker, you can run **headless Claude sessions** inside an env and stream them:
+
+```bash
+# start a session (env must be running) → 202 {id, claudeSessionId, status, ...}
+curl -s -H "Authorization: Bearer $TOK" -X POST "$BASE/environments/my-devbox/sessions" \
+  -d '{"prompt":"List the plugin files and summarize them.","model":null}'
+# watch it live (Server-Sent Events; token via query since EventSource can't set headers)
+curl -N "$BASE/sessions/<id>/stream?access_token=$TOK"
+# continue the same conversation
+curl -s -H "Authorization: Bearer $TOK" -X POST "$BASE/sessions/<id>/messages" -d '{"prompt":"now write tests"}'
+# full transcript / interrupt
+curl -s -H "Authorization: Bearer $TOK" "$BASE/sessions/<id>/transcript?tail=500"
+curl -s -H "Authorization: Bearer $TOK" -X POST "$BASE/sessions/<id>/interrupt"
+```
+
+The stream is newline-delimited `stream-json`: a `system`/`init` event (with `session_id`), `stream_event` token deltas, `assistant`/`user` messages (incl. `tool_use`/`tool_result`), and a terminal `result` (with `total_cost_usd`). One turn at a time per session (a second `messages` while running → `409`). There's also a web UI at `/`.
+
 ## Typical end-to-end flow
 
 1. `POST /environments {"name":"feature-x"}` → `202`.

--- a/server/AGENT_USAGE.md
+++ b/server/AGENT_USAGE.md
@@ -11,6 +11,12 @@ one gives you:
   to it from GitHub (comment `@cursor <name> …` on an issue/PR) or the Cursor
   dashboard.
 
+By default each environment also checks out a **target plugin repo** as a live
+git working copy (cloned into the workspace, `composer install`-ed, and symlinked
+into `wp-content/plugins` so it runs live in WordPress) — the worker operates on
+that repo and commits/pushes to it. The default is Agent Connector for WP at
+`/home/node/agent-connector-for-wp`; the operator can change or disable it.
+
 You do **not** need a special client — every action is an HTTP request you can
 make with `curl` (or any HTTP library).
 

--- a/server/AGENT_USAGE.md
+++ b/server/AGENT_USAGE.md
@@ -1,0 +1,142 @@
+# Devbox Server — how to create and manage WordPress + Cursor environments
+
+You are talking to a **devbox control server** over plain HTTP (JSON). It manages
+many self-contained **WordPress dev environments** on one Docker host. Creating
+one gives you:
+
+- a live **WordPress site** (URL returned to you; admin login `admin` / `password`),
+- a workspace container with WP-CLI, Node, `git`, `gh`, Claude Code, and the
+  Cursor CLI,
+- a **named Cursor worker** connected to Cursor's cloud, so work can be dispatched
+  to it from GitHub (comment `@cursor <name> …` on an issue/PR) or the Cursor
+  dashboard.
+
+You do **not** need a special client — every action is an HTTP request you can
+make with `curl` (or any HTTP library).
+
+## Connection
+
+Two values the operator gives you (fill these in):
+
+- **Base URL** — e.g. `http://<host>:4000`
+- **API token** — the value of `DEVBOX_API_TOKEN`. If the server has one set, you
+  MUST send `Authorization: Bearer <token>` on **every** request (you'll get
+  `401` otherwise). If the operator says there's no token, omit the header.
+
+For the examples below:
+
+```bash
+BASE="http://<host>:4000"      # e.g. http://127.0.0.1:4000
+TOK="<DEVBOX_API_TOKEN>"        # ask the operator; omit the -H lines if none
+```
+
+## Quick start — create an environment and wait until it's ready
+
+Creation is **asynchronous**: `POST /environments` returns immediately with
+`202` and `status: "scaffolding"`. The server then builds + boots the stack and
+starts the worker in the background (typically ~20s–3min depending on image
+cache). **Poll `GET /environments/<name>` until `status` is `running`.**
+
+```bash
+# 1. Create (name is optional; if omitted, the server assigns a unique one).
+curl -s -H "Authorization: Bearer $TOK" \
+  -X POST "$BASE/environments" \
+  -d '{"name":"my-devbox"}'
+# → {"id":"env_…","name":"my-devbox","port":9000,"wpUrl":"http://localhost:9000","status":"scaffolding"}
+
+# 2. Poll until running (or failed). Repeat this every ~10s.
+curl -s -H "Authorization: Bearer $TOK" "$BASE/environments/my-devbox"
+# → {... "status":"running","worker":{"running":true,"healthy":true,"state":"connected"} ...}
+```
+
+A ready environment looks like:
+
+```json
+{
+  "id": "env_dc9d01082c",
+  "name": "my-devbox",
+  "port": 9000,
+  "wpUrl": "http://localhost:9000",
+  "status": "running",
+  "worker": { "running": true, "healthy": true, "state": "connected" },
+  "createdAt": "…",
+  "workerStartedAt": "…",
+  "lastError": null,
+  "fleet": { "id": "…", "status": null, "lastSeen": null }
+}
+```
+
+When `status` is `running` and `worker.state` is `connected`, the worker is live
+in Cursor's cloud under the name you chose. Dispatch work to it by commenting
+`@cursor my-devbox <task>` on a GitHub repo where Cursor's GitHub app is
+installed, or from the Cursor agents dashboard.
+
+## Endpoints
+
+| Method & path | What it does |
+| --- | --- |
+| `POST /environments` | Create an env. Body: `{"name":"<optional>"}`. Returns `202` + `{id,name,port,wpUrl,status:"scaffolding"}`. |
+| `GET /environments` | List all envs with live status: `{"environments":[…]}`. |
+| `GET /environments/:id` | One env by **name or id**. Full status + worker health (+ best-effort `fleet`). |
+| `GET /environments/:id/logs?which=setup\|worker\|all&tail=N` | Setup and/or worker logs (`tail` defaults 200, max 5000). |
+| `POST /environments/:id/stop` | Stop the containers + worker (data preserved). → `status:"stopped"`. |
+| `POST /environments/:id/start` | Bring a stopped env back up + reconnect the worker. → `status:"running"`. |
+| `DELETE /environments/:id` | Destroy: stop, remove containers + volumes, delete the dir. → `{"deleted":true}`. |
+| `GET /host` | Host pressure (running containers, disk, load, env count vs cap). Check before mass-creating. |
+| `GET /health` | Liveness of the control server itself. |
+
+Examples:
+
+```bash
+# List everything
+curl -s -H "Authorization: Bearer $TOK" "$BASE/environments"
+
+# Tail the worker log (did it connect? did it pick up a task?)
+curl -s -H "Authorization: Bearer $TOK" \
+  "$BASE/environments/my-devbox/logs?which=worker&tail=50"
+
+# Stop / start / destroy
+curl -s -H "Authorization: Bearer $TOK" -X POST   "$BASE/environments/my-devbox/stop"
+curl -s -H "Authorization: Bearer $TOK" -X POST   "$BASE/environments/my-devbox/start"
+curl -s -H "Authorization: Bearer $TOK" -X DELETE "$BASE/environments/my-devbox"
+```
+
+## Status values
+
+- `scaffolding` → `setting-up` → `configuring` → `starting-worker` → **`running`** — the create pipeline; wait it out.
+- `running` — containers up and the worker process is alive. Check `worker.state`:
+  - `connected` — worker is authenticated and connected to Cursor (ready for tasks).
+  - `starting` — worker process up but not yet confirmed connected; poll again.
+  - `invalid-api-key` / `error` — the worker can't authenticate (operator's `CURSOR_API_KEY` problem). Surface this; don't retry blindly.
+- `degraded` — containers are up but the worker isn't alive/connected. Check `worker.state` and the worker log.
+- `stopped` — explicitly stopped; use `POST …/start` to resume.
+- `failed` — setup errored; see `lastError` and `GET …/logs?which=setup`. Usually `DELETE` and recreate.
+
+## Rules and gotchas
+
+- **Names** must match `^[a-z0-9][a-z0-9-]{1,38}$` (lowercase letters, digits,
+  hyphens; 2–39 chars) and be **unique**. Reusing a live name → `409`. Omit
+  `name` to get an auto-generated unique one.
+- **Create is async.** Don't treat the `202` as "ready" — poll until `running`.
+- **One WordPress port per env** is the only host port; the server allocates it
+  for you and returns it as `wpUrl`. The worker needs no inbound port.
+- **The site URL** (`wpUrl`, e.g. `http://localhost:9000`) is reachable from the
+  Docker host. Inside the environment's own containers the site is
+  `http://wordpress`.
+- **Capacity:** each env is ~4 containers. Call `GET /host` before creating many;
+  respect `503 at capacity` (raise via the operator's `MAX_ENVIRONMENTS`). Stop
+  or delete envs you no longer need.
+- **Credentials are the operator's, server-side.** You never send Cursor or
+  GitHub tokens — the server injects them. Don't ask the user for them.
+- **Errors** come back as `{"error":"…"}` with a 4xx/5xx status. `401` = missing/
+  wrong bearer token; `404` = unknown env; `409` = name taken; `503` = at
+  capacity or no free port.
+
+## Typical end-to-end flow
+
+1. `POST /environments {"name":"feature-x"}` → `202`.
+2. Poll `GET /environments/feature-x` until `status:"running"`, `worker.state:"connected"`.
+3. Use the environment: open `wpUrl` for the site, and/or dispatch a task to the
+   worker via `@cursor feature-x …` on GitHub.
+4. Watch progress with `GET /environments/feature-x/logs?which=worker`.
+5. When done: `POST …/stop` to pause (resume later) or `DELETE …` to remove it.

--- a/server/README.md
+++ b/server/README.md
@@ -1,17 +1,19 @@
 # devbox-server
 
-A small HTTP control server that manages many **WordPress + Cursor worker** environments — each one a full [`create-wp-local-dev-agent-sandbox`](../README.md) stack — on a single Docker host. Each environment runs a **named Cursor self-hosted worker** (`cursor-agent worker … start --name "<name>"`) so you can dispatch work to it from GitHub (`@cursor <name> …`) and have it commit/push.
+A small HTTP control server (with a web UI) that manages many WordPress devbox environments — each a full [`create-wp-local-dev-agent-sandbox`](../README.md) stack — on a single Docker host, and **drives Claude Code headlessly inside each one** with live streaming to the browser. It also keeps the optional **named Cursor self-hosted worker** per env.
 
-It is intentionally dependency-free (bare Node `http`) because it controls Docker and launches agents — keep its supply-chain surface at zero. It is **not** published to npm (the root package's `files` allowlist excludes `server/`).
+It is dependency-free on the server side (bare Node `http`) because it controls Docker and launches agents — keep its supply-chain surface at zero. The UI is buildless (Preact + htm via CDN). It is **not** published to npm (the root package's `files` allowlist excludes `server/`).
+
+The server is a **thin orchestrator over the scaffolded project's own scripts**: it creates envs the normal way and drives them through `npm run …` and `scripts/in-workspace.sh` (the same proven path `npm run claude` uses), all on the **default compose project** (the dir basename) so the server and the project's scripts always agree.
 
 ## How it works
 
-- **Scaffold + boot**: shells out to the scaffolder (`node ../index.js <dir> --port=N --scaffold-only`) then runs `npm run setup` asynchronously (bounded by a build semaphore). The compose project is pinned to `devbox-<name>` via `COMPOSE_PROJECT_NAME`.
+- **Create**: runs the standard scaffolder once — `node ../index.js <dir> --port=N` — which scaffolds **and** `npm run setup` (build + boot + provision). Default compose project = the env name. Bounded by a build semaphore.
 - **Git auth**: configures `gh` + git identity inside the workspace from the shared `GITHUB_TOKEN` (non-fatal).
-- **Target repo**: replaces the release-zip plugin with a live git checkout — clones `TARGET_REPO` into the workspace, runs `composer install --no-dev` in its plugin subdir, symlinks that into `wp-content/plugins/<slug>`, and activates it — so the worker operates on and commits to the real repo. Defaults to [Agent Connector for WP](https://github.com/soflyy/agent-connector-for-wp); set `TARGET_REPO=` empty to disable.
-- **Worker**: launches `cursor-agent worker --name "<name>" --worker-dir /home/node start` detached inside the workspace container, logging to `/home/node/.worker.log`. The worker connects **outbound only** — no inbound port.
-- **Supervision**: a reconcile loop (boot + every ~45s) re-launches a worker whose process died while its stack is up, and reconciles statuses after a server restart. The registry (`data/registry.json`) is the source of truth.
-- **Credentials are shared and server-side** (`CURSOR_API_KEY`, `GITHUB_TOKEN`) — never accepted in request bodies, returned, or logged.
+- **Target repo**: replaces the release-zip plugin with a live git checkout (clone → `composer install --no-dev` → symlink into `wp-content/plugins/<slug>` → activate), so agents operate on and commit to the real repo. Defaults to [Agent Connector for WP](https://github.com/soflyy/agent-connector-for-wp); `TARGET_REPO=` empty disables it.
+- **Claude sessions**: each user message spawns `claude -p [--resume <id>] --output-format stream-json …` via the env's own `scripts/in-workspace.sh` (so auth = the proven token path; the server holds no Claude token). stdout is streamed to the browser over **SSE**; the session id + result + cost are persisted (`data/sessions.json`, raw events in `data/sessions/<id>.ndjson`). Resumable from the UI **and** by SSH (`bash scripts/in-workspace.sh claude --resume <id>`).
+- **Cursor worker (optional)**: unless `CURSOR_WORKER_AUTOSTART=0`, launches `cursor-agent worker --name "<name>" … start` detached; a reconcile loop (boot + ~45s) re-launches it if it dies and reconciles statuses after a server restart.
+- **Credentials are shared and server-side** (`CURSOR_API_KEY`, `GITHUB_TOKEN`, and the Claude token via in-workspace.sh) — never accepted in request bodies, returned, or logged.
 
 ## Configuration (env)
 
@@ -19,6 +21,10 @@ It is intentionally dependency-free (bare Node `http`) because it controls Docke
 | --- | --- | --- |
 | `CURSOR_API_KEY` | — | **required** — shared Cursor service-account key |
 | `GITHUB_TOKEN` | — | **required** — shared GitHub token for clone/commit/push |
+| `CLAUDE_CODE_OAUTH_TOKEN` | — | for Claude sessions — forwarded by `in-workspace.sh` exactly like `npm run claude` (or put it in `~/.agent-sandbox/oauth-token`). The server keeps no Claude token of its own. |
+| `CLAUDE_DEFAULT_MODEL` | — | optional default model for sessions (e.g. `claude-sonnet-4-6`) |
+| `CURSOR_WORKER_AUTOSTART` | `1` | start a Cursor worker per env; `0` to skip |
+| `SESSION_RING_BUFFER` | `500` | live events buffered per session for late SSE subscribers |
 | `DEVBOX_PORT` | `4000` | API listen port |
 | `DEVBOX_BIND` | `127.0.0.1` | bind address. `0.0.0.0` (or a specific IP) to reach it over the network — **requires `DEVBOX_API_TOKEN`** (the server refuses to start network-exposed without one) and a firewall/VPN |
 | `DEVBOX_API_TOKEN` | — | if set, all routes require `Authorization: Bearer <token>` |
@@ -69,15 +75,28 @@ CURSOR_API_KEY=… GITHUB_TOKEN=… DEVBOX_API_TOKEN=secret npm start
 | `GET` | `/environments/:id/logs?which=setup\|worker\|all&tail=N` | logs |
 | `POST` | `/environments/:id/stop` | stop containers + worker |
 | `POST` | `/environments/:id/start` | bring containers up + re-auth + restart worker |
-| `DELETE` | `/environments/:id` | `compose down -v` + remove the dir |
+| `DELETE` | `/environments/:id` | stop + remove the dir; cascades to its sessions |
+| `POST` | `/environments/:id/sessions` | `{prompt,model?}` → 202; start a Claude session (env must be running) |
+| `POST` | `/sessions/:id/messages` | `{prompt}` → 202; continue the session (`--resume`); 409 if a turn is active |
+| `GET` | `/sessions` / `/sessions/:id` | list / one session (id, claudeSessionId, status, cost, `sshResumeHint`) |
+| `GET` | `/sessions/:id/stream` | **SSE** live stream-json (auth: bearer or `?access_token=`) |
+| `GET` | `/sessions/:id/transcript?tail=N` | full event history (ndjson) |
+| `POST` | `/sessions/:id/interrupt` | SIGINT the active turn |
+| `DELETE` | `/sessions/:id` | forget the session |
 | `GET` | `/host` | host pressure (containers, disk, load, counts) |
+| `GET` | `/` , `/ui/*` | the web UI (static; shell unauthenticated, data APIs authed) |
 
 ```bash
 H='-H Authorization:Bearer secret'
 curl -s $H -XPOST localhost:4000/environments -d '{"name":"my-devbox"}'
-curl -s $H localhost:4000/environments/my-devbox | jq
-curl -s $H 'localhost:4000/environments/my-devbox/logs?which=worker&tail=50'
+curl -s $H -XPOST localhost:4000/environments/my-devbox/sessions -d '{"prompt":"summarize the README"}'
+curl -N $H localhost:4000/sessions/<id>/stream         # live stream-json
+curl -s $H -XPOST localhost:4000/sessions/<id>/messages -d '{"prompt":"now add a CHANGELOG entry"}'
 ```
+
+## Web UI
+
+Open `http://<host>:<port>/` and enter the `DEVBOX_API_TOKEN`. List sessions across all devboxes, watch a session stream live (token-by-token, with tool calls), send messages, interrupt, start a new session (pick a devbox + model), and copy the SSH-resume command. Buildless (Preact + htm from a CDN) — to run fully offline, vendor those into `ui/vendor/`.
 
 ## Scale note
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,63 @@
+# devbox-server
+
+A small HTTP control server that manages many **WordPress + Cursor worker** environments — each one a full [`create-wp-local-dev-agent-sandbox`](../README.md) stack — on a single Docker host. Each environment runs a **named Cursor self-hosted worker** (`cursor-agent worker … start --name "<name>"`) so you can dispatch work to it from GitHub (`@cursor <name> …`) and have it commit/push.
+
+It is intentionally dependency-free (bare Node `http`) because it controls Docker and launches agents — keep its supply-chain surface at zero. It is **not** published to npm (the root package's `files` allowlist excludes `server/`).
+
+## How it works
+
+- **Scaffold + boot**: shells out to the scaffolder (`node ../index.js <dir> --port=N --scaffold-only`) then runs `npm run setup` asynchronously (bounded by a build semaphore). The compose project is pinned to `devbox-<name>` via `COMPOSE_PROJECT_NAME`.
+- **Git auth**: configures `gh` + git identity inside the workspace from the shared `GITHUB_TOKEN` (non-fatal).
+- **Worker**: launches `cursor-agent worker --name "<name>" --worker-dir /home/node start` detached inside the workspace container, logging to `/home/node/.worker.log`. The worker connects **outbound only** — no inbound port.
+- **Supervision**: a reconcile loop (boot + every ~45s) re-launches a worker whose process died while its stack is up, and reconciles statuses after a server restart. The registry (`data/registry.json`) is the source of truth.
+- **Credentials are shared and server-side** (`CURSOR_API_KEY`, `GITHUB_TOKEN`) — never accepted in request bodies, returned, or logged.
+
+## Configuration (env)
+
+| Var | Default | Notes |
+| --- | --- | --- |
+| `CURSOR_API_KEY` | — | **required** — shared Cursor service-account key |
+| `GITHUB_TOKEN` | — | **required** — shared GitHub token for clone/commit/push |
+| `DEVBOX_PORT` | `4000` | API listen port |
+| `DEVBOX_BIND` | `127.0.0.1` | bind address (keep on loopback) |
+| `DEVBOX_API_TOKEN` | — | if set, all routes require `Authorization: Bearer <token>` |
+| `WP_PORT_RANGE` | `9000-9999` | host WP ports to allocate from |
+| `MAX_ENVIRONMENTS` | `25` | hard cap on environments |
+| `BUILD_CONCURRENCY` | `2` | simultaneous `docker build`/setup runs |
+| `DEVBOX_ENVS_DIR` | `data/envs` | where stacks are scaffolded |
+| `SCAFFOLDER_DIR` | repo root | path to the scaffolder (`index.js`) |
+| `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL` | `devbox` / `devbox@localhost` | commit identity |
+| `WORKER_DIR` | `/home/node` | worker `--worker-dir` |
+| `WORKER_IDLE_RELEASE_TIMEOUT` | — | optional worker `--idle-release-timeout` (sec) |
+| `RECONCILE_INTERVAL_MS` | `45000` | supervision loop interval |
+
+## Run
+
+```bash
+cd server
+CURSOR_API_KEY=… GITHUB_TOKEN=… DEVBOX_API_TOKEN=secret npm start
+```
+
+## API
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/environments` | `{name?}` → 202 `{id,name,port,wpUrl,status}`; runs the async pipeline |
+| `GET` | `/environments` | list with live status + worker health |
+| `GET` | `/environments/:id` | one env (by id or name); includes best-effort `fleet` info |
+| `GET` | `/environments/:id/logs?which=setup\|worker\|all&tail=N` | logs |
+| `POST` | `/environments/:id/stop` | stop containers + worker |
+| `POST` | `/environments/:id/start` | bring containers up + re-auth + restart worker |
+| `DELETE` | `/environments/:id` | `compose down -v` + remove the dir |
+| `GET` | `/host` | host pressure (containers, disk, load, counts) |
+
+```bash
+H='-H Authorization:Bearer secret'
+curl -s $H -XPOST localhost:4000/environments -d '{"name":"my-devbox"}'
+curl -s $H localhost:4000/environments/my-devbox | jq
+curl -s $H 'localhost:4000/environments/my-devbox/logs?which=worker&tail=50'
+```
+
+## Scale note
+
+Each environment is ~4 containers (MariaDB, Apache/PHP, Node workspace, headless Chromium). Hundreds *running simultaneously* on one box is unrealistic — the registry can track 100s, but the running working-set is bounded by host RAM/CPU/disk. Use `MAX_ENVIRONMENTS`, the build semaphore, `GET /host`, and `stop` idle envs. Future optimization: build the (identical) workspace image once and reference it by tag instead of per-env `build:`.

--- a/server/README.md
+++ b/server/README.md
@@ -19,7 +19,7 @@ It is intentionally dependency-free (bare Node `http`) because it controls Docke
 | `CURSOR_API_KEY` | — | **required** — shared Cursor service-account key |
 | `GITHUB_TOKEN` | — | **required** — shared GitHub token for clone/commit/push |
 | `DEVBOX_PORT` | `4000` | API listen port |
-| `DEVBOX_BIND` | `127.0.0.1` | bind address (keep on loopback) |
+| `DEVBOX_BIND` | `127.0.0.1` | bind address. `0.0.0.0` (or a specific IP) to reach it over the network — **requires `DEVBOX_API_TOKEN`** (the server refuses to start network-exposed without one) and a firewall/VPN |
 | `DEVBOX_API_TOKEN` | — | if set, all routes require `Authorization: Bearer <token>` |
 | `WP_PORT_RANGE` | `9000-9999` | host WP ports to allocate from |
 | `MAX_ENVIRONMENTS` | `25` | hard cap on environments |

--- a/server/README.md
+++ b/server/README.md
@@ -33,8 +33,28 @@ It is intentionally dependency-free (bare Node `http`) because it controls Docke
 
 ## Run
 
+Put your tokens in `server/.env` (next to `package.json`). It's gitignored and
+loaded automatically on `npm start` (via Node's built-in env-file support — no
+dependency). Real environment variables already set take precedence, so
+systemd/`export` setups keep working.
+
 ```bash
 cd server
+cp .env.example .env      # then fill in CURSOR_API_KEY, GITHUB_TOKEN, DEVBOX_API_TOKEN
+npm start
+```
+
+`.env` example:
+
+```ini
+CURSOR_API_KEY=sk_...
+GITHUB_TOKEN=ghp_...
+DEVBOX_API_TOKEN=$(openssl rand -hex 32)   # paste a generated value
+```
+
+Or pass them inline / via your process manager instead of a file:
+
+```bash
 CURSOR_API_KEY=… GITHUB_TOKEN=… DEVBOX_API_TOKEN=secret npm start
 ```
 

--- a/server/README.md
+++ b/server/README.md
@@ -8,6 +8,7 @@ It is intentionally dependency-free (bare Node `http`) because it controls Docke
 
 - **Scaffold + boot**: shells out to the scaffolder (`node ../index.js <dir> --port=N --scaffold-only`) then runs `npm run setup` asynchronously (bounded by a build semaphore). The compose project is pinned to `devbox-<name>` via `COMPOSE_PROJECT_NAME`.
 - **Git auth**: configures `gh` + git identity inside the workspace from the shared `GITHUB_TOKEN` (non-fatal).
+- **Target repo**: replaces the release-zip plugin with a live git checkout — clones `TARGET_REPO` into the workspace, runs `composer install --no-dev` in its plugin subdir, symlinks that into `wp-content/plugins/<slug>`, and activates it — so the worker operates on and commits to the real repo. Defaults to [Agent Connector for WP](https://github.com/soflyy/agent-connector-for-wp); set `TARGET_REPO=` empty to disable.
 - **Worker**: launches `cursor-agent worker --name "<name>" --worker-dir /home/node start` detached inside the workspace container, logging to `/home/node/.worker.log`. The worker connects **outbound only** — no inbound port.
 - **Supervision**: a reconcile loop (boot + every ~45s) re-launches a worker whose process died while its stack is up, and reconciles statuses after a server restart. The registry (`data/registry.json`) is the source of truth.
 - **Credentials are shared and server-side** (`CURSOR_API_KEY`, `GITHUB_TOKEN`) — never accepted in request bodies, returned, or logged.

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "devbox-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "HTTP control server that manages many WordPress + Cursor worker environments (create-wp-local-dev-agent-sandbox) on one Docker host.",
+  "bin": {
+    "devbox-server": "src/index.js"
+  },
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "GPL-2.0-or-later"
+}

--- a/server/src/agent-connector.js
+++ b/server/src/agent-connector.js
@@ -1,5 +1,6 @@
-// Replace the release-zip plugin with a live git checkout of the target repo,
-// so the Cursor worker operates on (and commits to) the real repository.
+// Agent Connector for WP integration: replace the release-zip plugin with a live
+// git checkout of the repo (TARGET_REPO, default soflyy/agent-connector-for-wp),
+// so the agent operates on — and commits to — the real repository.
 //
 // Mirrors the repo's own documented local-dev flow:
 //   clone <repo> → (cd <subdir> && composer install --no-dev) →

--- a/server/src/allocator.js
+++ b/server/src/allocator.js
@@ -63,13 +63,13 @@ export async function allocate(registry, config, { nameHint } = {}) {
           400,
         );
       }
-      if (usedNames.has(name) || existingProjects.has(`devbox-${name}`)) {
+      if (usedNames.has(name) || existingProjects.has(name)) {
         throw new AllocationError(`name "${name}" is already in use`, 409);
       }
     } else {
       do {
         name = randomName();
-      } while (usedNames.has(name) || existingProjects.has(`devbox-${name}`));
+      } while (usedNames.has(name) || existingProjects.has(name));
     }
 
     // Resolve a unique, currently-free port in the configured range.
@@ -91,7 +91,10 @@ export async function allocate(registry, config, { nameHint } = {}) {
     const record = {
       id,
       name,
-      project: `devbox-${name}`,
+      // Compose project name = the dir basename (the default), so the server's
+      // `docker compose` calls, the project's own `npm run …` scripts, and
+      // `scripts/in-workspace.sh` all target the same project.
+      project: name,
       dir,
       port,
       wpUrl: `http://localhost:${port}`,

--- a/server/src/allocator.js
+++ b/server/src/allocator.js
@@ -1,0 +1,113 @@
+// Allocates a unique {id, name, project, port, dir} for a new environment and
+// writes the reservation into the registry — all inside the registry mutex, so
+// concurrent POST /environments can't collide on names, ports, or projects.
+
+import net from 'node:net';
+import { randomBytes } from 'node:crypto';
+import { join } from 'node:path';
+import { listProjects } from './docker.js';
+
+const NAME_RE = /^[a-z0-9][a-z0-9-]{1,38}$/;
+const ADJECTIVES = ['brisk', 'calm', 'keen', 'bold', 'wise', 'swift', 'lucky', 'sunny', 'quiet', 'vivid'];
+const NOUNS = ['otter', 'falcon', 'maple', 'cedar', 'comet', 'pixel', 'harbor', 'meadow', 'river', 'ember'];
+
+export function isValidName(name) {
+  return typeof name === 'string' && NAME_RE.test(name);
+}
+
+function randomName() {
+  const a = ADJECTIVES[randomBytes(1)[0] % ADJECTIVES.length];
+  const n = NOUNS[randomBytes(1)[0] % NOUNS.length];
+  const suffix = randomBytes(2).toString('hex');
+  return `${a}-${n}-${suffix}`;
+}
+
+// True if the port is free to bind on the loopback interface right now.
+function isPortFree(port) {
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.once('error', () => resolve(false));
+    srv.once('listening', () => srv.close(() => resolve(true)));
+    srv.listen(port, '127.0.0.1');
+  });
+}
+
+export class AllocationError extends Error {
+  constructor(message, status = 409) {
+    super(message);
+    this.status = status;
+  }
+}
+
+// Returns the reservation record (already persisted into the registry with
+// status "scaffolding").
+export async function allocate(registry, config, { nameHint } = {}) {
+  return registry.mutate(async (data) => {
+    const envs = Object.values(data.environments);
+    if (envs.length >= config.maxEnvironments) {
+      throw new AllocationError(
+        `at capacity: ${envs.length}/${config.maxEnvironments} environments (raise MAX_ENVIRONMENTS)`,
+        503,
+      );
+    }
+
+    const usedNames = new Set(envs.map((e) => e.name));
+    const existingProjects = new Set(await listProjects());
+
+    // Resolve a unique name.
+    let name = nameHint;
+    if (name !== undefined && name !== null && name !== '') {
+      if (!isValidName(name)) {
+        throw new AllocationError(
+          `invalid name "${name}" — must match ${NAME_RE} (lowercase letters, digits, hyphens; 2-39 chars)`,
+          400,
+        );
+      }
+      if (usedNames.has(name) || existingProjects.has(`devbox-${name}`)) {
+        throw new AllocationError(`name "${name}" is already in use`, 409);
+      }
+    } else {
+      do {
+        name = randomName();
+      } while (usedNames.has(name) || existingProjects.has(`devbox-${name}`));
+    }
+
+    // Resolve a unique, currently-free port in the configured range.
+    const usedPorts = new Set(envs.map((e) => e.port));
+    let port = null;
+    for (let p = config.portRange.lo; p <= config.portRange.hi; p += 1) {
+      if (usedPorts.has(p)) continue;
+      if (await isPortFree(p)) {
+        port = p;
+        break;
+      }
+    }
+    if (port === null) {
+      throw new AllocationError(`no free port in range ${config.portRange.lo}-${config.portRange.hi}`, 503);
+    }
+
+    const id = `env_${randomBytes(5).toString('hex')}`;
+    const dir = join(config.envsDir, name);
+    const record = {
+      id,
+      name,
+      project: `devbox-${name}`,
+      dir,
+      port,
+      wpUrl: `http://localhost:${port}`,
+      status: 'scaffolding',
+      createdAt: new Date().toISOString(),
+      setupStartedAt: null,
+      setupFinishedAt: null,
+      workerStartedAt: null,
+      lastError: null,
+      // Setup log lives OUTSIDE the env dir (the scaffolder requires an empty
+      // target dir). Worker log is written inside the container at this path,
+      // visible on the host at <dir>/workspace/.worker.log.
+      setupLogPath: join(config.dataDir, 'logs', `${name}.log`),
+      workerLogPath: '/home/node/.worker.log',
+    };
+    data.environments[id] = record;
+    return record;
+  });
+}

--- a/server/src/claude.js
+++ b/server/src/claude.js
@@ -1,0 +1,182 @@
+// Claude headless turn engine. Each turn spawns the environment's OWN
+// scripts/in-workspace.sh to run `claude -p … --output-format stream-json` in
+// the workspace container — reusing the proven auth path (token resolution +
+// -e forwarding + the onboarding seed). No Claude token is handled here; it's
+// resolved by in-workspace.sh from this process's env (server/.env) or
+// ~/.agent-sandbox/oauth-token, exactly like `npm run claude`.
+//
+// Claude runs with the container's default cwd (/home/node) every turn, so its
+// session jsonl is consistently scoped and --resume works (and an operator can
+// `bash scripts/in-workspace.sh claude --resume <id>` to take over).
+
+import { spawn } from 'node:child_process';
+import { createWriteStream, mkdirSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import { join } from 'node:path';
+import { log, redact } from './log.js';
+
+const CLAUDE_CWD = '/home/node'; // in-workspace.sh runs claude here (container WORKDIR)
+
+export class ClaudeEngine {
+  constructor(config, store, bus) {
+    this.config = config;
+    this.store = store;
+    this.bus = bus;
+    this.active = new Map(); // sessionId -> { child, ndjson }
+  }
+
+  isActive(id) {
+    return this.active.has(id);
+  }
+
+  // Start a brand-new session (turn 1, no --resume). Returns the session record.
+  async newSession(env, { prompt, model }) {
+    const id = `sess_${randomBytes(5).toString('hex')}`;
+    const record = {
+      id,
+      envId: env.id,
+      envName: env.name,
+      claudeSessionId: null,
+      cwd: CLAUDE_CWD,
+      model: model || this.config.claudeDefaultModel || null,
+      title: title(prompt),
+      status: 'running',
+      turnCount: 0,
+      lastResult: null,
+      costUsd: 0,
+      lastError: null,
+      eventLogPath: join(this.config.sessionsDir, `${id}.ndjson`),
+      createdAt: new Date().toISOString(),
+      lastActivityAt: new Date().toISOString(),
+    };
+    await this.store.create(record);
+    this._runTurn(env, record, prompt);
+    return record;
+  }
+
+  // Continue an existing session (turn 2+, with --resume). Caller ensures the
+  // session isn't already running.
+  async sendMessage(env, session, { prompt }) {
+    await this.store.update(session.id, { status: 'running', lastActivityAt: new Date().toISOString() });
+    this._runTurn(env, { ...session, status: 'running' }, prompt);
+  }
+
+  _runTurn(env, session, prompt) {
+    const args = [
+      join(env.dir, 'scripts', 'in-workspace.sh'),
+      'claude', '-p', prompt,
+      '--output-format', 'stream-json', '--verbose', '--include-partial-messages',
+      '--dangerously-skip-permissions',
+    ];
+    if (session.model) args.push('--model', session.model);
+    if (session.claudeSessionId) args.push('--resume', session.claudeSessionId);
+
+    mkdirSync(this.config.sessionsDir, { recursive: true });
+    const ndjson = createWriteStream(session.eventLogPath, { flags: 'a' });
+    ndjson.on('error', (e) => log.warn(`[${session.id}] event log write error:`, e.message));
+    ndjson.write(`${JSON.stringify({ type: 'control', subtype: 'turn-start', at: new Date().toISOString() })}\n`);
+
+    // stdin ignored → in-workspace.sh sees a non-TTY → adds -T → clean stream-json.
+    const child = spawn('bash', args, { cwd: env.dir, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
+    const entry = { child, ndjson, interrupting: false };
+    this.active.set(session.id, entry);
+
+    let buf = '';
+    let stderr = '';
+    const pending = { claudeSessionId: session.claudeSessionId, lastResult: null, addCost: 0 };
+
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      buf += chunk;
+      let nl;
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (line.trim()) this._handleLine(session, line, ndjson, pending);
+      }
+    });
+    child.stderr.on('data', (d) => {
+      stderr += d;
+      if (stderr.length > 8000) stderr = stderr.slice(-8000);
+      this.bus.publish(session.id, { type: 'stderr', text: redact(String(d)) });
+    });
+
+    const finalize = async (code, signal) => {
+      if (buf.trim()) this._handleLine(session, buf, ndjson, pending); // trailing partial line
+      buf = '';
+      ndjson.end();
+      this.active.delete(session.id);
+      // docker compose exec translates SIGINT to a non-zero exit code, so detect
+      // interruption from the flag we set, not the signal.
+      const interrupted = entry.interrupting || signal === 'SIGINT' || signal === 'SIGTERM';
+      const status = interrupted ? 'interrupted' : code === 0 ? 'idle' : 'error';
+      const patch = {
+        status,
+        turnCount: (session.turnCount || 0) + 1,
+        lastActivityAt: new Date().toISOString(),
+        claudeSessionId: pending.claudeSessionId || session.claudeSessionId || null,
+        costUsd: (session.costUsd || 0) + pending.addCost,
+      };
+      if (pending.lastResult != null) patch.lastResult = trunc(pending.lastResult, 4000);
+      if (status === 'error') patch.lastError = trunc(redact(stderr) || `claude exited with code ${code}`, 800);
+      else if (status === 'idle') patch.lastError = null;
+      await this.store.update(session.id, patch);
+      this.bus.publish(session.id, { type: 'control', subtype: 'turn-end', code, status });
+      log.info(`[${session.id}] turn ended (${status}, code ${code})`);
+    };
+
+    child.on('error', (err) => {
+      this.bus.publish(session.id, { type: 'control', subtype: 'spawn-error', error: redact(err.message) });
+      finalize(-1, null).catch(() => {});
+    });
+    child.on('close', (code, signal) => finalize(code, signal).catch((e) => log.warn(`[${session.id}] finalize:`, e.message)));
+  }
+
+  // Record one stdout line: append to ndjson, publish to the bus, and capture
+  // session_id / result / cost into `pending`.
+  _handleLine(session, line, ndjson, pending) {
+    let evt;
+    try {
+      evt = JSON.parse(line);
+    } catch {
+      evt = { type: 'raw', text: line };
+    }
+    ndjson.write(line + '\n');
+    this.bus.publish(session.id, evt);
+
+    if (evt.type === 'system' && evt.subtype === 'init' && evt.session_id && !pending.claudeSessionId) {
+      pending.claudeSessionId = evt.session_id;
+      // Persist the resume id immediately so a crash mid-turn stays resumable.
+      this.store.update(session.id, { claudeSessionId: evt.session_id }).catch(() => {});
+    }
+    if (evt.type === 'result') {
+      if (typeof evt.result === 'string') pending.lastResult = evt.result;
+      if (typeof evt.total_cost_usd === 'number') pending.addCost += evt.total_cost_usd;
+      if (evt.session_id && !pending.claudeSessionId) pending.claudeSessionId = evt.session_id;
+    }
+  }
+
+  interrupt(id) {
+    const a = this.active.get(id);
+    if (!a) return false;
+    a.interrupting = true;
+    a.child.kill('SIGINT');
+    return true;
+  }
+
+  killEnvSessions(envId) {
+    for (const s of this.store.listByEnv(envId)) {
+      const a = this.active.get(s.id);
+      if (a) a.child.kill('SIGTERM');
+    }
+  }
+}
+
+function title(prompt) {
+  const t = String(prompt || '').replace(/\s+/g, ' ').trim();
+  return t.length > 80 ? `${t.slice(0, 80)}…` : t || '(empty)';
+}
+function trunc(s, n) {
+  s = String(s);
+  return s.length > n ? `${s.slice(0, n)}…` : s;
+}

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -65,10 +65,25 @@ export function loadConfig(env = process.env) {
     // Worker launch tuning
     workerDir: env.WORKER_DIR || '/home/node',
     workerIdleReleaseTimeout: env.WORKER_IDLE_RELEASE_TIMEOUT || null, // seconds, optional
+    // Worker health endpoint, bound inside the container (not published to the
+    // host — no host port consumed). Used for liveness via `curl /readyz`, since
+    // the slim image has no pgrep/ps.
+    workerManagementAddr: env.WORKER_MANAGEMENT_ADDR || '127.0.0.1:8930',
 
     // Cursor fleet API (best-effort enrichment only)
     fleetApiUrl: env.CURSOR_FLEET_API_URL || 'https://api.cursor.com/v0/private-workers',
   };
+
+  // Exposing this API to the network means exposing root-equivalent control of
+  // the Docker host. Refuse to bind a non-loopback address without a bearer
+  // token — otherwise anyone who can reach the port can create/destroy envs.
+  const loopback = new Set(['127.0.0.1', '::1', 'localhost']);
+  if (!loopback.has(config.bind) && !config.apiToken) {
+    throw new Error(
+      `refusing to bind ${config.bind} (network-exposed) without DEVBOX_API_TOKEN. ` +
+        `Set a bearer token (e.g. DEVBOX_API_TOKEN=$(openssl rand -hex 32)) and put this host behind a firewall/VPN.`,
+    );
+  }
 
   // The set of secret strings the logger must redact.
   config.secrets = [config.cursorApiKey, config.githubToken].filter(Boolean);

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -1,0 +1,76 @@
+// Server configuration, read once from the environment and frozen.
+//
+// Secrets (CURSOR_API_KEY, GITHUB_TOKEN) live only here and in the env of the
+// child processes we spawn — never in request bodies, responses, the registry,
+// or logs. See log.js for the redactor that scrubs them if they ever leak.
+
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve, isAbsolute } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SERVER_ROOT = resolve(HERE, '..');
+// The scaffolder repo root (this server lives in <repo>/server).
+const DEFAULT_SCAFFOLDER_DIR = resolve(SERVER_ROOT, '..');
+
+function abs(p, fallback) {
+  const v = p || fallback;
+  return isAbsolute(v) ? v : resolve(SERVER_ROOT, v);
+}
+
+function parseRange(raw, fallback) {
+  const [lo, hi] = (raw || fallback).split('-').map((n) => parseInt(n.trim(), 10));
+  if (!Number.isInteger(lo) || !Number.isInteger(hi) || lo < 1 || hi < lo || hi > 65535) {
+    throw new Error(`Invalid WP_PORT_RANGE "${raw}" — expected "<lo>-<hi>", e.g. 9000-9999`);
+  }
+  return { lo, hi };
+}
+
+export function loadConfig(env = process.env) {
+  const missing = [];
+  if (!env.CURSOR_API_KEY) missing.push('CURSOR_API_KEY');
+  if (!env.GITHUB_TOKEN) missing.push('GITHUB_TOKEN');
+  if (missing.length) {
+    throw new Error(
+      `Missing required env: ${missing.join(', ')}. ` +
+        `These are the shared Cursor + GitHub credentials applied to every environment.`,
+    );
+  }
+
+  const dataDir = abs(env.DEVBOX_DATA_DIR, join(SERVER_ROOT, 'data'));
+
+  const config = {
+    // HTTP
+    port: parseInt(env.DEVBOX_PORT || '4000', 10),
+    bind: env.DEVBOX_BIND || '127.0.0.1',
+    apiToken: env.DEVBOX_API_TOKEN || null, // optional bearer auth
+
+    // Paths
+    scaffolderDir: abs(env.SCAFFOLDER_DIR, DEFAULT_SCAFFOLDER_DIR),
+    dataDir,
+    envsDir: abs(env.DEVBOX_ENVS_DIR, join(dataDir, 'envs')),
+    registryPath: join(dataDir, 'registry.json'),
+
+    // Allocation / limits
+    portRange: parseRange(env.WP_PORT_RANGE, '9000-9999'),
+    maxEnvironments: parseInt(env.MAX_ENVIRONMENTS || '25', 10),
+    buildConcurrency: Math.max(1, parseInt(env.BUILD_CONCURRENCY || '2', 10)),
+    reconcileIntervalMs: parseInt(env.RECONCILE_INTERVAL_MS || '45000', 10),
+
+    // Credentials (shared across all environments)
+    cursorApiKey: env.CURSOR_API_KEY,
+    githubToken: env.GITHUB_TOKEN,
+    gitAuthorName: env.GIT_AUTHOR_NAME || 'devbox',
+    gitAuthorEmail: env.GIT_AUTHOR_EMAIL || 'devbox@localhost',
+
+    // Worker launch tuning
+    workerDir: env.WORKER_DIR || '/home/node',
+    workerIdleReleaseTimeout: env.WORKER_IDLE_RELEASE_TIMEOUT || null, // seconds, optional
+
+    // Cursor fleet API (best-effort enrichment only)
+    fleetApiUrl: env.CURSOR_FLEET_API_URL || 'https://api.cursor.com/v0/private-workers',
+  };
+
+  // The set of secret strings the logger must redact.
+  config.secrets = [config.cursorApiKey, config.githubToken].filter(Boolean);
+  return Object.freeze(config);
+}

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -38,6 +38,11 @@ export function loadConfig(env = process.env) {
 
   const dataDir = abs(env.DEVBOX_DATA_DIR, join(SERVER_ROOT, 'data'));
 
+  // Target repo defaults to Agent Connector for WP; empty string disables it.
+  const DEFAULT_TARGET_REPO = 'https://github.com/soflyy/agent-connector-for-wp.git';
+  const targetRepo = (env.TARGET_REPO !== undefined ? env.TARGET_REPO : DEFAULT_TARGET_REPO).trim();
+  const targetPluginSlug = env.TARGET_PLUGIN_SLUG || 'agent-connector-for-wp';
+
   const config = {
     // HTTP
     port: parseInt(env.DEVBOX_PORT || '4000', 10),
@@ -62,8 +67,18 @@ export function loadConfig(env = process.env) {
     gitAuthorName: env.GIT_AUTHOR_NAME || 'devbox',
     gitAuthorEmail: env.GIT_AUTHOR_EMAIL || 'devbox@localhost',
 
-    // Worker launch tuning
-    workerDir: env.WORKER_DIR || '/home/node',
+    // Target plugin repo: each environment replaces the release-zip plugin with
+    // a live git checkout (cloned into the workspace, composer-installed, and
+    // symlinked into wp-content/plugins) so the worker operates on — and commits
+    // to — the real repo. Set TARGET_REPO="" to disable (general-purpose worker).
+    targetRepo: targetRepo || null,
+    targetRepoRef: env.TARGET_REPO_REF || null, // branch/tag/commit, optional
+    targetPluginSlug,
+    targetPluginSubdir: env.TARGET_PLUGIN_SUBDIR || 'plugin', // plugin lives in repo/<subdir>
+
+    // Worker launch tuning. When a target repo is set, the worker operates inside
+    // the checkout by default (so its git context is the repo); else the home dir.
+    workerDir: env.WORKER_DIR || (targetRepo ? `/home/node/${targetPluginSlug}` : '/home/node'),
     workerIdleReleaseTimeout: env.WORKER_IDLE_RELEASE_TIMEOUT || null, // seconds, optional
     // Worker health endpoint, bound inside the container (not published to the
     // host — no host port consumed). Used for liveness via `curl /readyz`, since

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -51,6 +51,7 @@ export function loadConfig(env = process.env) {
 
     // Paths
     scaffolderDir: abs(env.SCAFFOLDER_DIR, DEFAULT_SCAFFOLDER_DIR),
+    uiRoot: join(SERVER_ROOT, 'ui'),
     dataDir,
     envsDir: abs(env.DEVBOX_ENVS_DIR, join(dataDir, 'envs')),
     registryPath: join(dataDir, 'registry.json'),
@@ -85,8 +86,22 @@ export function loadConfig(env = process.env) {
     // the slim image has no pgrep/ps.
     workerManagementAddr: env.WORKER_MANAGEMENT_ADDR || '127.0.0.1:8930',
 
+    // Start a Cursor worker automatically on env create (kept available, but the
+    // focus is now Claude sessions). Set CURSOR_WORKER_AUTOSTART=0 to skip — then
+    // an env runs no worker and "running" doesn't depend on worker liveness.
+    cursorWorkerAutostart: env.CURSOR_WORKER_AUTOSTART !== '0',
+
     // Cursor fleet API (best-effort enrichment only)
     fleetApiUrl: env.CURSOR_FLEET_API_URL || 'https://api.cursor.com/v0/private-workers',
+
+    // Claude headless sessions. NO Claude token here on purpose — Claude is
+    // driven through the env's own scripts/in-workspace.sh, which resolves
+    // CLAUDE_CODE_OAUTH_TOKEN from this server process's env (e.g. server/.env)
+    // or ~/.agent-sandbox/oauth-token, exactly like `npm run claude`.
+    sessionsPath: join(dataDir, 'sessions.json'),
+    sessionsDir: join(dataDir, 'sessions'),
+    claudeDefaultModel: env.CLAUDE_DEFAULT_MODEL || null, // null → claude's own default
+    sessionRingBufferSize: parseInt(env.SESSION_RING_BUFFER || '500', 10),
   };
 
   // Exposing this API to the network means exposing root-equivalent control of

--- a/server/src/docker.js
+++ b/server/src/docker.js
@@ -1,0 +1,121 @@
+// Thin wrappers over `docker` / `docker compose`. Everything uses execFile with
+// an argv array (no shell) so the only user-controlled value (the env name,
+// already charset-restricted) can't inject. Secrets are passed to children via
+// the `env` option and referenced by name with `-e NAME` — never on argv.
+
+import { execFile } from 'node:child_process';
+import { join } from 'node:path';
+
+const DEFAULT_TIMEOUT = 15_000;
+
+export function run(file, args, { cwd, env, timeout = DEFAULT_TIMEOUT, input } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = execFile(
+      file,
+      args,
+      { cwd, env: env ? { ...process.env, ...env } : process.env, timeout, maxBuffer: 16 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        if (err) {
+          err.stdout = stdout;
+          err.stderr = stderr;
+          err.message = `${file} ${args.join(' ')} failed: ${err.message}\n${stderr || ''}`.trim();
+          return reject(err);
+        }
+        resolve({ stdout, stderr });
+      },
+    );
+    if (input !== undefined) {
+      child.stdin.end(input);
+    }
+  });
+}
+
+// Compose invocation pinned to a project + its dir (so we never depend on cwd).
+function composeArgs(env, rest) {
+  return ['compose', '-p', env.project, ...rest];
+}
+
+export function compose(env, rest, opts = {}) {
+  return run('docker', composeArgs(env, rest), { cwd: env.dir, ...opts });
+}
+
+// `docker compose ps --format json` → array of service status objects.
+export async function ps(env) {
+  try {
+    const { stdout } = await compose(env, ['ps', '--format', 'json', '--all']);
+    // Compose emits either a JSON array or newline-delimited JSON objects.
+    const trimmed = stdout.trim();
+    if (!trimmed) return [];
+    if (trimmed.startsWith('[')) return JSON.parse(trimmed);
+    return trimmed
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+  } catch {
+    return [];
+  }
+}
+
+export function up(env, { build = true, timeout = 600_000 } = {}) {
+  return compose(env, ['up', '-d', ...(build ? ['--build'] : [])], { timeout });
+}
+
+export function stop(env) {
+  return compose(env, ['stop'], { timeout: 120_000 });
+}
+
+export function down(env, { volumes = false } = {}) {
+  return compose(env, ['down', ...(volumes ? ['-v'] : [])], { timeout: 180_000 });
+}
+
+// Run a command inside a service. `detach` uses `-d` (fire-and-forget); envNames
+// are forwarded by name only (their values come from the spawned child's env).
+export function exec(env, service, argv, { detach = false, envNames = [], envValues = {}, tty = false, timeout } = {}) {
+  const flags = [];
+  if (detach) flags.push('-d');
+  if (!tty) flags.push('-T');
+  for (const name of envNames) flags.push('-e', name);
+  return compose(env, ['exec', ...flags, service, ...argv], { env: envValues, timeout });
+}
+
+// List compose projects currently known to the daemon (for name-collision checks).
+export async function listProjects() {
+  try {
+    const { stdout } = await run('docker', ['compose', 'ls', '--all', '--format', 'json']);
+    const arr = JSON.parse(stdout.trim() || '[]');
+    return arr.map((p) => p.Name);
+  } catch {
+    return [];
+  }
+}
+
+// Host pressure snapshot for GET /host.
+export async function hostInfo() {
+  const out = {};
+  await Promise.all([
+    run('docker', ['system', 'df', '--format', 'json'])
+      .then(({ stdout }) => {
+        out.dockerDf = stdout.trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+      })
+      .catch(() => {
+        out.dockerDf = null;
+      }),
+    run('docker', ['ps', '-q'])
+      .then(({ stdout }) => {
+        out.runningContainers = stdout.trim() ? stdout.trim().split('\n').length : 0;
+      })
+      .catch(() => {
+        out.runningContainers = null;
+      }),
+    run('df', ['-h', '/'])
+      .then(({ stdout }) => {
+        out.diskRoot = stdout.trim().split('\n').slice(1).join('\n');
+      })
+      .catch(() => {
+        out.diskRoot = null;
+      }),
+  ]);
+  return out;
+}
+
+export { join };

--- a/server/src/docker.js
+++ b/server/src/docker.js
@@ -1,7 +1,11 @@
-// Thin wrappers over `docker` / `docker compose`. Everything uses execFile with
-// an argv array (no shell) so the only user-controlled value (the env name,
-// already charset-restricted) can't inject. Secrets are passed to children via
-// the `env` option and referenced by name with `-e NAME` — never on argv.
+// Thin wrappers over `docker compose` / `npm` for a scaffolded environment.
+//
+// Everything runs IN the env's directory with the DEFAULT compose project name
+// (the dir basename) — the same project the env's own `npm run …` scripts and
+// `scripts/in-workspace.sh` use. No `-p` override, so the server and the
+// project's scripts always agree. execFile with an argv array (no shell); the
+// only user value (the env name) is charset-restricted. Secrets pass by name
+// (`-e NAME`) with values injected into the child env — never on argv.
 
 import { execFile } from 'node:child_process';
 import { join } from 'node:path';
@@ -24,52 +28,36 @@ export function run(file, args, { cwd, env, timeout = DEFAULT_TIMEOUT, input } =
         resolve({ stdout, stderr });
       },
     );
-    if (input !== undefined) {
-      child.stdin.end(input);
-    }
+    if (input !== undefined) child.stdin.end(input);
   });
 }
 
-// Compose invocation pinned to a project + its dir (so we never depend on cwd).
-function composeArgs(env, rest) {
-  return ['compose', '-p', env.project, ...rest];
+// `docker compose <rest>` in the env dir (default project = dir basename).
+export function compose(env, rest, opts = {}) {
+  return run('docker', ['compose', ...rest], { cwd: env.dir, ...opts });
 }
 
-export function compose(env, rest, opts = {}) {
-  return run('docker', composeArgs(env, rest), { cwd: env.dir, ...opts });
+// Run one of the env's own npm scripts (start/stop/down/…) — drives the project
+// through its own scripts rather than a hand-built parallel.
+export function npmRun(env, script, opts = {}) {
+  return run('npm', ['run', script], { cwd: env.dir, ...opts });
 }
 
 // `docker compose ps --format json` → array of service status objects.
 export async function ps(env) {
   try {
     const { stdout } = await compose(env, ['ps', '--format', 'json', '--all']);
-    // Compose emits either a JSON array or newline-delimited JSON objects.
     const trimmed = stdout.trim();
     if (!trimmed) return [];
     if (trimmed.startsWith('[')) return JSON.parse(trimmed);
-    return trimmed
-      .split('\n')
-      .filter(Boolean)
-      .map((l) => JSON.parse(l));
+    return trimmed.split('\n').filter(Boolean).map((l) => JSON.parse(l));
   } catch {
     return [];
   }
 }
 
-export function up(env, { build = true, timeout = 600_000 } = {}) {
-  return compose(env, ['up', '-d', ...(build ? ['--build'] : [])], { timeout });
-}
-
-export function stop(env) {
-  return compose(env, ['stop'], { timeout: 120_000 });
-}
-
-export function down(env, { volumes = false } = {}) {
-  return compose(env, ['down', ...(volumes ? ['-v'] : [])], { timeout: 180_000 });
-}
-
-// Run a command inside a service. `detach` uses `-d` (fire-and-forget); envNames
-// are forwarded by name only (their values come from the spawned child's env).
+// Run a command inside a service. `detach` → `-d`; envNames are forwarded by
+// name only (values come from the spawned child's env).
 export function exec(env, service, argv, { detach = false, envNames = [], envValues = {}, tty = false, timeout } = {}) {
   const flags = [];
   if (detach) flags.push('-d');
@@ -78,7 +66,7 @@ export function exec(env, service, argv, { detach = false, envNames = [], envVal
   return compose(env, ['exec', ...flags, service, ...argv], { env: envValues, timeout });
 }
 
-// List compose projects currently known to the daemon (for name-collision checks).
+// List compose projects known to the daemon (for name-collision checks).
 export async function listProjects() {
   try {
     const { stdout } = await run('docker', ['compose', 'ls', '--all', '--format', 'json']);

--- a/server/src/fleet.js
+++ b/server/src/fleet.js
@@ -1,0 +1,49 @@
+// Best-effort enrichment from Cursor's fleet API. NEVER load-bearing: failures
+// (or a plan that doesn't expose non-pool named workers) just yield null and the
+// local registry + docker + worker health remain the source of truth.
+
+import { log } from './log.js';
+
+let cache = { at: 0, byName: null };
+const TTL_MS = 10_000;
+
+async function fetchWorkers(config) {
+  const now = Date.now();
+  if (cache.byName && now - cache.at < TTL_MS) return cache.byName;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 3000);
+  try {
+    // Service-account key via HTTP Basic (key as username, empty password).
+    const auth = Buffer.from(`${config.cursorApiKey}:`).toString('base64');
+    const res = await fetch(config.fleetApiUrl, {
+      headers: { authorization: `Basic ${auth}`, accept: 'application/json' },
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`fleet API ${res.status}`);
+    const body = await res.json();
+    const workers = Array.isArray(body) ? body : body.workers || body.privateWorkers || [];
+    const byName = new Map();
+    for (const w of workers) {
+      const name = w.name || w.displayName || w.workerName;
+      if (name) byName.set(name, w);
+    }
+    cache = { at: now, byName };
+    return byName;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Returns the fleet record for a worker name, or null on any failure.
+export async function lookup(name, config) {
+  try {
+    const byName = await fetchWorkers(config);
+    const w = byName.get(name);
+    if (!w) return null;
+    return { id: w.id || w.workerId || null, status: w.status || null, lastSeen: w.lastSeenAt || w.lastSeen || null };
+  } catch (err) {
+    log.warn('fleet API lookup failed (best-effort):', err.message);
+    return null;
+  }
+}

--- a/server/src/gitauth.js
+++ b/server/src/gitauth.js
@@ -10,9 +10,14 @@
 import { exec } from './docker.js';
 import { log } from './log.js';
 
+// The token is carried in DEVBOX_GH_TOKEN (NOT GH_TOKEN/GITHUB_TOKEN): gh refuses
+// to *store* credentials with `--with-token` when GH_TOKEN/GITHUB_TOKEN is set in
+// the env (it would just use the env var, which the worker process doesn't have).
+// Storing via gh + `gh auth setup-git` persists a credential helper in
+// /home/node so the worker can clone/commit/push without the token in its env.
 const SCRIPT = [
   'set -e',
-  'echo "$GH_TOKEN" | gh auth login --with-token',
+  'printf %s "$DEVBOX_GH_TOKEN" | gh auth login --with-token',
   'gh auth setup-git',
   'git config --global user.name "$GIT_AUTHOR_NAME"',
   'git config --global user.email "$GIT_AUTHOR_EMAIL"',
@@ -21,9 +26,9 @@ const SCRIPT = [
 export async function configure(env, config) {
   try {
     await exec(env, 'workspace', ['sh', '-lc', SCRIPT], {
-      envNames: ['GH_TOKEN', 'GIT_AUTHOR_NAME', 'GIT_AUTHOR_EMAIL'],
+      envNames: ['DEVBOX_GH_TOKEN', 'GIT_AUTHOR_NAME', 'GIT_AUTHOR_EMAIL'],
       envValues: {
-        GH_TOKEN: config.githubToken,
+        DEVBOX_GH_TOKEN: config.githubToken,
         GIT_AUTHOR_NAME: config.gitAuthorName,
         GIT_AUTHOR_EMAIL: config.gitAuthorEmail,
       },

--- a/server/src/gitauth.js
+++ b/server/src/gitauth.js
@@ -1,0 +1,37 @@
+// Configure GitHub auth + git identity inside an environment's workspace
+// container, so the Cursor worker can clone/commit/push. Uses the shared
+// GITHUB_TOKEN via `gh auth login --with-token` + `gh auth setup-git` (gh is
+// installed in the image). Secrets are passed by env name (-e), never on argv.
+//
+// Non-fatal: a bad/expired token shouldn't abort environment creation — we log
+// a warning and continue (the worker still runs; pushes will just fail until
+// the token is fixed and /start is re-run).
+
+import { exec } from './docker.js';
+import { log } from './log.js';
+
+const SCRIPT = [
+  'set -e',
+  'echo "$GH_TOKEN" | gh auth login --with-token',
+  'gh auth setup-git',
+  'git config --global user.name "$GIT_AUTHOR_NAME"',
+  'git config --global user.email "$GIT_AUTHOR_EMAIL"',
+].join(' && ');
+
+export async function configure(env, config) {
+  try {
+    await exec(env, 'workspace', ['sh', '-lc', SCRIPT], {
+      envNames: ['GH_TOKEN', 'GIT_AUTHOR_NAME', 'GIT_AUTHOR_EMAIL'],
+      envValues: {
+        GH_TOKEN: config.githubToken,
+        GIT_AUTHOR_NAME: config.gitAuthorName,
+        GIT_AUTHOR_EMAIL: config.gitAuthorEmail,
+      },
+      timeout: 60_000,
+    });
+    return true;
+  } catch (err) {
+    log.warn(`[${env.name}] git auth setup failed (continuing):`, err.message);
+    return false;
+  }
+}

--- a/server/src/http.js
+++ b/server/src/http.js
@@ -1,0 +1,81 @@
+// Bare node:http server with a tiny regex router, JSON body parsing (size
+// limited), uniform error envelope, and optional bearer auth. No framework —
+// this component controls Docker, so we keep its dependency surface at zero.
+
+import http from 'node:http';
+import { timingSafeEqual } from 'node:crypto';
+import { log } from './log.js';
+
+const MAX_BODY = 1 << 20; // 1 MiB
+
+export function createServer(config, routes) {
+  const server = http.createServer(async (req, res) => {
+    try {
+      if (config.apiToken && !authorized(req, config.apiToken)) {
+        return send(res, 401, { error: 'unauthorized' });
+      }
+      const url = new URL(req.url, 'http://localhost');
+      const match = routes.find((r) => r.method === req.method && r.re.test(url.pathname));
+      if (!match) return send(res, 404, { error: 'not found' });
+
+      const params = url.pathname.match(match.re).groups || {};
+      const body = await readJson(req);
+      const ctx = { params, query: url.searchParams, body, send: (code, data) => send(res, code, data) };
+      await match.handler(ctx);
+    } catch (err) {
+      if (err.status) return send(res, err.status, { error: err.message });
+      log.error('request error:', err);
+      send(res, 500, { error: 'internal error', detail: String(err.message || err) });
+    }
+  });
+  return server;
+}
+
+function authorized(req, token) {
+  const header = req.headers.authorization || '';
+  const presented = header.startsWith('Bearer ') ? header.slice(7) : '';
+  const a = Buffer.from(presented);
+  const b = Buffer.from(token);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+function readJson(req) {
+  return new Promise((resolve, reject) => {
+    if (req.method === 'GET' || req.method === 'DELETE') return resolve({});
+    let size = 0;
+    const chunks = [];
+    req.on('data', (c) => {
+      size += c.length;
+      if (size > MAX_BODY) {
+        reject(Object.assign(new Error('body too large'), { status: 413 }));
+        req.destroy();
+        return;
+      }
+      chunks.push(c);
+    });
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8').trim();
+      if (!raw) return resolve({});
+      try {
+        resolve(JSON.parse(raw));
+      } catch {
+        reject(Object.assign(new Error('invalid JSON body'), { status: 400 }));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function send(res, code, data) {
+  const payload = JSON.stringify(data);
+  res.writeHead(code, { 'content-type': 'application/json' });
+  res.end(payload);
+}
+
+// Build a route table entry; `path` uses :param segments turned into named groups.
+export function route(method, path, handler) {
+  const re = new RegExp(
+    '^' + path.replace(/:[a-zA-Z]+/g, (m) => `(?<${m.slice(1)}>[^/]+)`) + '/?$',
+  );
+  return { method, path, re, handler };
+}

--- a/server/src/http.js
+++ b/server/src/http.js
@@ -1,6 +1,13 @@
 // Bare node:http server with a tiny regex router, JSON body parsing (size
 // limited), uniform error envelope, and optional bearer auth. No framework —
 // this component controls Docker, so we keep its dependency surface at zero.
+//
+// Route kinds:
+//   'json'   (default) — body parsed, ctx.send writes JSON, bearer required.
+//   'sse'    — long-lived stream; handler owns ctx.res; auth accepts bearer OR
+//              ?access_token= (EventSource can't set headers).
+//   'static' — serves the UI; handler owns ctx.res; the SHELL is unauthenticated
+//              (it holds no secrets and prompts for the token client-side).
 
 import http from 'node:http';
 import { timingSafeEqual } from 'node:crypto';
@@ -11,18 +18,31 @@ const MAX_BODY = 1 << 20; // 1 MiB
 export function createServer(config, routes) {
   const server = http.createServer(async (req, res) => {
     try {
-      if (config.apiToken && !authorized(req, config.apiToken)) {
-        return send(res, 401, { error: 'unauthorized' });
-      }
       const url = new URL(req.url, 'http://localhost');
       const match = routes.find((r) => r.method === req.method && r.re.test(url.pathname));
       if (!match) return send(res, 404, { error: 'not found' });
 
+      const kind = match.kind || 'json';
+      // Auth: static shell is open; sse accepts header OR ?access_token=; rest bearer.
+      if (config.apiToken && kind !== 'static') {
+        const ok = kind === 'sse'
+          ? tokenOk(bearer(req) || url.searchParams.get('access_token'), config.apiToken)
+          : tokenOk(bearer(req), config.apiToken);
+        if (!ok) return send(res, 401, { error: 'unauthorized' });
+      }
+
       const params = url.pathname.match(match.re).groups || {};
-      const body = await readJson(req);
-      const ctx = { params, query: url.searchParams, body, send: (code, data) => send(res, code, data) };
-      await match.handler(ctx);
+      const ctx = {
+        params,
+        query: url.searchParams,
+        req,
+        res,
+        body: kind === 'json' ? await readJson(req) : {},
+        send: (code, data) => send(res, code, data),
+      };
+      await match.handler(ctx); // sse/static handlers own res and never call send()
     } catch (err) {
+      if (res.headersSent) return; // streaming response already started
       if (err.status) return send(res, err.status, { error: err.message });
       log.error('request error:', err);
       send(res, 500, { error: 'internal error', detail: String(err.message || err) });
@@ -31,10 +51,13 @@ export function createServer(config, routes) {
   return server;
 }
 
-function authorized(req, token) {
+function bearer(req) {
   const header = req.headers.authorization || '';
-  const presented = header.startsWith('Bearer ') ? header.slice(7) : '';
-  const a = Buffer.from(presented);
+  return header.startsWith('Bearer ') ? header.slice(7) : '';
+}
+
+function tokenOk(presented, token) {
+  const a = Buffer.from(presented || '');
   const b = Buffer.from(token);
   return a.length === b.length && timingSafeEqual(a, b);
 }
@@ -72,10 +95,12 @@ function send(res, code, data) {
   res.end(payload);
 }
 
-// Build a route table entry; `path` uses :param segments turned into named groups.
-export function route(method, path, handler) {
-  const re = new RegExp(
-    '^' + path.replace(/:[a-zA-Z]+/g, (m) => `(?<${m.slice(1)}>[^/]+)`) + '/?$',
-  );
-  return { method, path, re, handler };
+// Build a route table entry. `path` uses :param segments → named groups. Supports
+// a trailing :rest* segment (matches the remainder, incl. slashes) for static.
+export function route(method, path, handler, { kind = 'json' } = {}) {
+  const pattern = path
+    .replace(/:([a-zA-Z]+)\*/g, (_, n) => `(?<${n}>.*)`)
+    .replace(/:([a-zA-Z]+)/g, (_, n) => `(?<${n}>[^/]+)`);
+  const re = new RegExp('^' + pattern + '/?$');
+  return { method, path, re, handler, kind };
 }

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Devbox control server entrypoint: load config, init the registry, wire routes,
+// start the HTTP server and the reconcile/supervision loop.
+
+import { loadConfig } from './config.js';
+import { initLog, log } from './log.js';
+import { Registry } from './registry.js';
+import { Manager } from './manager.js';
+import { buildRoutes } from './routes.js';
+import { createServer } from './http.js';
+
+async function main() {
+  const config = loadConfig();
+  initLog(config.secrets);
+
+  const registry = await new Registry(config.registryPath).load();
+  const manager = new Manager(config, registry);
+  const routes = buildRoutes(config, registry, manager);
+  const server = createServer(config, routes);
+
+  server.listen(config.port, config.bind, () => {
+    log.info(`devbox-server listening on http://${config.bind}:${config.port}`);
+    log.info(
+      `envs dir: ${config.envsDir} | port range: ${config.portRange.lo}-${config.portRange.hi} | ` +
+        `max: ${config.maxEnvironments} | auth: ${config.apiToken ? 'bearer' : 'none'}`,
+    );
+    manager.startReconcileLoop();
+  });
+
+  const shutdown = () => {
+    log.info('shutting down');
+    server.close(() => process.exit(0));
+    setTimeout(() => process.exit(0), 3000).unref();
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  // A long-running control plane must never die on a stray async error.
+  process.on('unhandledRejection', (err) => log.error('unhandledRejection:', err));
+  process.on('uncaughtException', (err) => log.error('uncaughtException:', err));
+}
+
+main().catch((err) => {
+  // Pre-log-init failures (e.g. missing config) print plainly.
+  console.error(`devbox-server failed to start: ${err.message}`);
+  process.exit(1);
+});

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -10,6 +10,9 @@ import { loadConfig } from './config.js';
 import { initLog, log } from './log.js';
 import { Registry } from './registry.js';
 import { Manager } from './manager.js';
+import { SessionStore } from './sessions.js';
+import { SessionBus } from './sessionbus.js';
+import { ClaudeEngine } from './claude.js';
 import { buildRoutes } from './routes.js';
 import { createServer } from './http.js';
 
@@ -34,14 +37,23 @@ async function main() {
 
   const registry = await new Registry(config.registryPath).load();
   const manager = new Manager(config, registry);
-  const routes = buildRoutes(config, registry, manager);
+
+  // Claude session subsystem.
+  const sessionStore = await new SessionStore(config.sessionsPath).load();
+  await sessionStore.reconcile(); // running → interrupted (resumable; jsonl persists)
+  const sessionBus = new SessionBus(config.sessionRingBufferSize);
+  const claudeEngine = new ClaudeEngine(config, sessionStore, sessionBus);
+  const sessions = { store: sessionStore, engine: claudeEngine, bus: sessionBus };
+
+  const routes = buildRoutes(config, registry, manager, sessions);
   const server = createServer(config, routes);
 
   server.listen(config.port, config.bind, () => {
     log.info(`devbox-server listening on http://${config.bind}:${config.port}`);
     log.info(
       `envs dir: ${config.envsDir} | port range: ${config.portRange.lo}-${config.portRange.hi} | ` +
-        `max: ${config.maxEnvironments} | auth: ${config.apiToken ? 'bearer' : 'none'}`,
+        `max: ${config.maxEnvironments} | auth: ${config.apiToken ? 'bearer' : 'none'} | ` +
+        `worker autostart: ${config.cursorWorkerAutostart ? 'on' : 'off'} | UI: http://${config.bind}:${config.port}/`,
     );
     manager.startReconcileLoop();
   });

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
-// Devbox control server entrypoint: load config, init the registry, wire routes,
-// start the HTTP server and the reconcile/supervision loop.
+// Devbox control server entrypoint: load .env, load config, init the registry,
+// wire routes, start the HTTP server and the reconcile/supervision loop.
+
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
 
 import { loadConfig } from './config.js';
 import { initLog, log } from './log.js';
@@ -9,9 +13,24 @@ import { Manager } from './manager.js';
 import { buildRoutes } from './routes.js';
 import { createServer } from './http.js';
 
+// Load server/.env (or $DEVBOX_ENV_FILE) into process.env if present, using
+// Node's built-in loader (no dependency). Real environment variables already
+// set take precedence, so systemd/export-based setups keep working.
+function loadDotenv() {
+  const serverRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  const envFile = process.env.DEVBOX_ENV_FILE || join(serverRoot, '.env');
+  if (existsSync(envFile)) {
+    process.loadEnvFile(envFile);
+    return envFile;
+  }
+  return null;
+}
+
 async function main() {
+  const envFile = loadDotenv();
   const config = loadConfig();
   initLog(config.secrets);
+  if (envFile) log.info(`loaded env from ${envFile}`);
 
   const registry = await new Registry(config.registryPath).load();
   const manager = new Manager(config, registry);

--- a/server/src/log.js
+++ b/server/src/log.js
@@ -1,0 +1,42 @@
+// Tiny logger that redacts known secret values and token-shaped strings, so a
+// stray interpolation can never print CURSOR_API_KEY / GITHUB_TOKEN.
+
+let SECRETS = [];
+
+// Token-ish substrings to scrub even if not in the known-secrets list.
+const TOKEN_PATTERNS = [
+  /\bsk_[A-Za-z0-9_-]{10,}/g, // cursor-style
+  /\bgh[posru]_[A-Za-z0-9]{20,}/g, // github tokens
+  /\bgithub_pat_[A-Za-z0-9_]{20,}/g,
+];
+
+export function initLog(secrets = []) {
+  SECRETS = secrets.filter((s) => typeof s === 'string' && s.length >= 6);
+}
+
+export function redact(value) {
+  let s = typeof value === 'string' ? value : safeStringify(value);
+  for (const secret of SECRETS) s = s.split(secret).join('***');
+  for (const re of TOKEN_PATTERNS) s = s.replace(re, '***');
+  return s;
+}
+
+function safeStringify(v) {
+  if (v instanceof Error) return `${v.name}: ${v.message}`;
+  try {
+    return typeof v === 'object' ? JSON.stringify(v) : String(v);
+  } catch {
+    return String(v);
+  }
+}
+
+function emit(stream, level, args) {
+  const line = args.map((a) => redact(a)).join(' ');
+  stream.write(`${new Date().toISOString()} ${level} ${line}\n`);
+}
+
+export const log = {
+  info: (...a) => emit(process.stdout, 'INFO ', a),
+  warn: (...a) => emit(process.stderr, 'WARN ', a),
+  error: (...a) => emit(process.stderr, 'ERROR', a),
+};

--- a/server/src/manager.js
+++ b/server/src/manager.js
@@ -103,7 +103,7 @@ export class Manager {
   async _gather(record) {
     const ps = await docker.ps(record);
     const up = coreUp(ps);
-    const worker = up ? await workerMod.health(record) : { running: false, healthy: false, state: 'down' };
+    const worker = up ? await workerMod.health(record, this.config) : { running: false, healthy: false, state: 'down' };
     const jobState = this.jobs.get(record.id) || null;
     const status = computeStatus({ record, jobState, ps, worker });
     return { ps, worker, status };
@@ -185,7 +185,7 @@ export class Manager {
           continue;
         }
         // Containers up but worker dead → relaunch (this is the supervision).
-        const alive = await workerMod.isRunning(record);
+        const alive = await workerMod.isRunning(record, this.config);
         if (!alive && record.status !== 'stopped') {
           log.info(`[${record.name}] worker not running but stack is up — relaunching`);
           await gitauth.configure(record, this.config);

--- a/server/src/manager.js
+++ b/server/src/manager.js
@@ -11,7 +11,7 @@ import { allocate } from './allocator.js';
 import * as docker from './docker.js';
 import * as workerMod from './worker.js';
 import * as gitauth from './gitauth.js';
-import * as targetrepo from './targetrepo.js';
+import * as agentConnector from './agent-connector.js';
 import * as fleet from './fleet.js';
 import { computeStatus, coreUp, publicView } from './status.js';
 import { log, redact } from './log.js';
@@ -80,7 +80,7 @@ export class Manager {
       this.jobs.set(record.id, 'configuring');
       await registry.update(record.id, { status: 'configuring' });
       await gitauth.configure(record, config);
-      await targetrepo.setup(record, config);
+      await agentConnector.setup(record, config);
 
       // 3. Optionally start the named Cursor worker.
       if (config.cursorWorkerAutostart) {

--- a/server/src/manager.js
+++ b/server/src/manager.js
@@ -59,40 +59,40 @@ export class Manager {
     try {
       await mkdir(config.envsDir, { recursive: true });
 
-      // 1. Scaffold (fast, files only).
-      this.jobs.set(record.id, 'scaffolding');
-      await this._spawnLogged(
-        'node',
-        [join(config.scaffolderDir, 'index.js'), record.dir, `--port=${record.port}`, '--scaffold-only'],
-        { logPath: record.setupLogPath, truncate: true },
-      );
-
-      // 2. Build + boot + provision (heavy; bounded by the build semaphore).
+      // 1. Create the environment the NORMAL way: the standard scaffolder
+      //    scaffolds the project AND runs `npm run setup` (build + boot +
+      //    provision) in one shot. Default compose project = dir basename =
+      //    record.name, so the project's own scripts + in-workspace.sh agree.
+      //    Bounded by the build semaphore; output captured to the setup log.
       this.jobs.set(record.id, 'setting-up');
       await registry.update(record.id, { status: 'setting-up', setupStartedAt: new Date().toISOString() });
       await this.buildSem.run(() =>
-        this._spawnLogged('npm', ['run', 'setup'], {
-          cwd: record.dir,
+        this._spawnLogged('node', [join(config.scaffolderDir, 'index.js'), record.dir, `--port=${record.port}`], {
           logPath: record.setupLogPath,
-          // Pin the compose project so the env's own scripts and our commands agree.
-          env: { COMPOSE_PROJECT_NAME: record.project },
+          truncate: true,
           timeout: 30 * 60 * 1000,
         }),
       );
       await registry.update(record.id, { setupFinishedAt: new Date().toISOString() });
 
-      // 3. Git auth (non-fatal), then swap the target plugin to a live git
-      //    checkout the worker operates on (fatal — that's the env's purpose).
+      // 2. Git auth (non-fatal), then swap the target plugin to a live git
+      //    checkout (fatal — that's the env's purpose).
       this.jobs.set(record.id, 'configuring');
       await registry.update(record.id, { status: 'configuring' });
       await gitauth.configure(record, config);
       await targetrepo.setup(record, config);
 
-      // 4. Start the named worker.
-      this.jobs.set(record.id, 'starting-worker');
-      await registry.update(record.id, { status: 'starting-worker' });
-      await workerMod.start(record, config);
-      await registry.update(record.id, { status: 'running', workerStartedAt: new Date().toISOString(), lastError: null });
+      // 3. Optionally start the named Cursor worker.
+      if (config.cursorWorkerAutostart) {
+        this.jobs.set(record.id, 'starting-worker');
+        await registry.update(record.id, { status: 'starting-worker' });
+        await workerMod.start(record, config);
+      }
+      await registry.update(record.id, {
+        status: 'running',
+        workerStartedAt: config.cursorWorkerAutostart ? new Date().toISOString() : null,
+        lastError: null,
+      });
     } catch (err) {
       log.error(`[${record.name}] setup failed:`, err.message);
       await registry.update(record.id, { status: 'failed', lastError: truncate(redactErr(err)) });
@@ -106,7 +106,10 @@ export class Manager {
   async _gather(record) {
     const ps = await docker.ps(record);
     const up = coreUp(ps);
-    const worker = up ? await workerMod.health(record, this.config) : { running: false, healthy: false, state: 'down' };
+    // worker === null means "no worker expected" (autostart off) → status ignores it.
+    const worker = up && this.config.cursorWorkerAutostart
+      ? await workerMod.health(record, this.config)
+      : null;
     const jobState = this.jobs.get(record.id) || null;
     const status = computeStatus({ record, jobState, ps, worker });
     return { ps, worker, status };
@@ -123,11 +126,17 @@ export class Manager {
     return Promise.all(this.registry.list().map((r) => this.describe(r, { fleetLookup: false })));
   }
 
+  // Is the env's core stack up (so we can exec claude/agents in it)? Cheap.
+  async usable(record) {
+    return coreUp(await docker.ps(record));
+  }
+
   // ---- lifecycle ----------------------------------------------------------
 
+  // Lifecycle through the env's own npm scripts (default compose project).
+
   async stop(record) {
-    await workerMod.stop(record);
-    await docker.stop(record);
+    await docker.npmRun(record, 'stop', { timeout: 120_000 });
     await this.registry.update(record.id, { status: 'stopped' });
     return this.describe(record);
   }
@@ -135,10 +144,14 @@ export class Manager {
   async start(record) {
     this.jobs.set(record.id, 'starting-worker');
     try {
-      await docker.up(record, { build: false });
+      await docker.npmRun(record, 'start', { timeout: 600_000 }); // up -d --build (cached)
       await gitauth.configure(record, this.config);
-      await workerMod.start(record, this.config);
-      await this.registry.update(record.id, { status: 'running', workerStartedAt: new Date().toISOString(), lastError: null });
+      if (this.config.cursorWorkerAutostart) await workerMod.start(record, this.config);
+      await this.registry.update(record.id, {
+        status: 'running',
+        workerStartedAt: this.config.cursorWorkerAutostart ? new Date().toISOString() : null,
+        lastError: null,
+      });
     } finally {
       this.jobs.delete(record.id);
     }
@@ -148,7 +161,9 @@ export class Manager {
   async destroy(record) {
     this.jobs.set(record.id, 'destroying');
     try {
-      await docker.down(record, { volumes: true }).catch((e) => log.warn(`[${record.name}] down failed:`, e.message));
+      // `npm run down` (compose down). Data is in bind mounts (no named volumes),
+      // so removing the dir clears it.
+      await docker.npmRun(record, 'down', { timeout: 180_000 }).catch((e) => log.warn(`[${record.name}] down failed:`, e.message));
       await rm(record.dir, { recursive: true, force: true }).catch((e) =>
         log.warn(`[${record.name}] dir removal failed:`, e.message),
       );
@@ -187,7 +202,14 @@ export class Manager {
           }
           continue;
         }
-        // Containers up but worker dead → relaunch (this is the supervision).
+        // Containers up. If no worker is expected, just keep status running.
+        if (!this.config.cursorWorkerAutostart) {
+          if (record.status !== 'running' && record.status !== 'stopped') {
+            await this.registry.update(record.id, { status: 'running' });
+          }
+          continue;
+        }
+        // Worker expected but dead → relaunch (this is the supervision).
         const alive = await workerMod.isRunning(record, this.config);
         if (!alive && record.status !== 'stopped') {
           log.info(`[${record.name}] worker not running but stack is up — relaunching`);

--- a/server/src/manager.js
+++ b/server/src/manager.js
@@ -1,0 +1,254 @@
+// Orchestrates the environment lifecycle: allocate → scaffold → setup → git auth
+// → start worker → running, plus stop/start/destroy, status, logs, and a
+// reconcile loop that supervises workers.
+
+import { spawn } from 'node:child_process';
+import { createWriteStream, mkdirSync } from 'node:fs';
+import { readFile, rm, mkdir } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+
+import { allocate } from './allocator.js';
+import * as docker from './docker.js';
+import * as workerMod from './worker.js';
+import * as gitauth from './gitauth.js';
+import * as fleet from './fleet.js';
+import { computeStatus, coreUp, publicView } from './status.js';
+import { log, redact } from './log.js';
+
+// Counting semaphore to bound concurrent (heavy) docker builds.
+class Semaphore {
+  constructor(max) {
+    this.max = max;
+    this.active = 0;
+    this.queue = [];
+  }
+  async run(fn) {
+    if (this.active >= this.max) await new Promise((r) => this.queue.push(r));
+    this.active += 1;
+    try {
+      return await fn();
+    } finally {
+      this.active -= 1;
+      const next = this.queue.shift();
+      if (next) next();
+    }
+  }
+}
+
+export class Manager {
+  constructor(config, registry) {
+    this.config = config;
+    this.registry = registry;
+    this.jobs = new Map(); // id -> transient state string
+    this.buildSem = new Semaphore(config.buildConcurrency);
+  }
+
+  // ---- create -------------------------------------------------------------
+
+  async createEnvironment({ name } = {}) {
+    const record = await allocate(this.registry, this.config, { nameHint: name });
+    this.jobs.set(record.id, 'scaffolding');
+    // Fire-and-forget pipeline; status is observable via GET.
+    this._pipeline(record).catch((err) => log.error(`[${record.name}] pipeline crashed:`, err));
+    return record;
+  }
+
+  async _pipeline(record) {
+    const { config, registry } = this;
+    try {
+      await mkdir(config.envsDir, { recursive: true });
+
+      // 1. Scaffold (fast, files only).
+      this.jobs.set(record.id, 'scaffolding');
+      await this._spawnLogged(
+        'node',
+        [join(config.scaffolderDir, 'index.js'), record.dir, `--port=${record.port}`, '--scaffold-only'],
+        { logPath: record.setupLogPath, truncate: true },
+      );
+
+      // 2. Build + boot + provision (heavy; bounded by the build semaphore).
+      this.jobs.set(record.id, 'setting-up');
+      await registry.update(record.id, { status: 'setting-up', setupStartedAt: new Date().toISOString() });
+      await this.buildSem.run(() =>
+        this._spawnLogged('npm', ['run', 'setup'], {
+          cwd: record.dir,
+          logPath: record.setupLogPath,
+          // Pin the compose project so the env's own scripts and our commands agree.
+          env: { COMPOSE_PROJECT_NAME: record.project },
+          timeout: 30 * 60 * 1000,
+        }),
+      );
+      await registry.update(record.id, { setupFinishedAt: new Date().toISOString() });
+
+      // 3. Git auth (non-fatal).
+      this.jobs.set(record.id, 'configuring');
+      await registry.update(record.id, { status: 'configuring' });
+      await gitauth.configure(record, config);
+
+      // 4. Start the named worker.
+      this.jobs.set(record.id, 'starting-worker');
+      await registry.update(record.id, { status: 'starting-worker' });
+      await workerMod.start(record, config);
+      await registry.update(record.id, { status: 'running', workerStartedAt: new Date().toISOString(), lastError: null });
+    } catch (err) {
+      log.error(`[${record.name}] setup failed:`, err.message);
+      await registry.update(record.id, { status: 'failed', lastError: truncate(redactErr(err)) });
+    } finally {
+      this.jobs.delete(record.id);
+    }
+  }
+
+  // ---- status / describe --------------------------------------------------
+
+  async _gather(record) {
+    const ps = await docker.ps(record);
+    const up = coreUp(ps);
+    const worker = up ? await workerMod.health(record) : { running: false, healthy: false, state: 'down' };
+    const jobState = this.jobs.get(record.id) || null;
+    const status = computeStatus({ record, jobState, ps, worker });
+    return { ps, worker, status };
+  }
+
+  async describe(record, { fleetLookup = true } = {}) {
+    const { worker, status } = await this._gather(record);
+    let fleetInfo;
+    if (fleetLookup) fleetInfo = await fleet.lookup(record.name, this.config);
+    return publicView(record, { status, worker, fleet: fleetInfo });
+  }
+
+  async list() {
+    return Promise.all(this.registry.list().map((r) => this.describe(r, { fleetLookup: false })));
+  }
+
+  // ---- lifecycle ----------------------------------------------------------
+
+  async stop(record) {
+    await workerMod.stop(record);
+    await docker.stop(record);
+    await this.registry.update(record.id, { status: 'stopped' });
+    return this.describe(record);
+  }
+
+  async start(record) {
+    this.jobs.set(record.id, 'starting-worker');
+    try {
+      await docker.up(record, { build: false });
+      await gitauth.configure(record, this.config);
+      await workerMod.start(record, this.config);
+      await this.registry.update(record.id, { status: 'running', workerStartedAt: new Date().toISOString(), lastError: null });
+    } finally {
+      this.jobs.delete(record.id);
+    }
+    return this.describe(record);
+  }
+
+  async destroy(record) {
+    this.jobs.set(record.id, 'destroying');
+    try {
+      await docker.down(record, { volumes: true }).catch((e) => log.warn(`[${record.name}] down failed:`, e.message));
+      await rm(record.dir, { recursive: true, force: true }).catch((e) =>
+        log.warn(`[${record.name}] dir removal failed:`, e.message),
+      );
+      await this.registry.mutate((data) => {
+        delete data.environments[record.id];
+      });
+    } finally {
+      this.jobs.delete(record.id);
+    }
+  }
+
+  async logs(record, which = 'all', tail = 200) {
+    const out = {};
+    if (which === 'setup' || which === 'all') out.setup = await tailFile(record.setupLogPath, tail);
+    if (which === 'worker' || which === 'all') out.worker = await tailFile(join(record.dir, 'workspace', '.worker.log'), tail);
+    return out;
+  }
+
+  // ---- reconcile loop (supervisor) ----------------------------------------
+
+  async reconcile() {
+    for (const record of this.registry.list()) {
+      if (this.jobs.has(record.id)) continue; // pipeline owns it
+      try {
+        const ps = await docker.ps(record);
+        if (!coreUp(ps)) {
+          // Containers down: a record left mid-pipeline by a crash is failed;
+          // an explicitly stopped one stays stopped.
+          if (['running', 'degraded', 'starting-worker', 'setting-up', 'configuring', 'scaffolding'].includes(record.status)) {
+            if (record.status !== 'stopped') {
+              const patch = record.status === 'running' || record.status === 'degraded'
+                ? { status: 'stopped' }
+                : { status: 'failed', lastError: record.lastError || 'interrupted (server restart or crash)' };
+              await this.registry.update(record.id, patch);
+            }
+          }
+          continue;
+        }
+        // Containers up but worker dead → relaunch (this is the supervision).
+        const alive = await workerMod.isRunning(record);
+        if (!alive && record.status !== 'stopped') {
+          log.info(`[${record.name}] worker not running but stack is up — relaunching`);
+          await gitauth.configure(record, this.config);
+          await workerMod.start(record, this.config);
+          await this.registry.update(record.id, { status: 'running', workerStartedAt: new Date().toISOString() });
+        } else if (alive && record.status !== 'running') {
+          await this.registry.update(record.id, { status: 'running' });
+        }
+      } catch (err) {
+        log.warn(`[${record.name}] reconcile error:`, err.message);
+      }
+    }
+  }
+
+  startReconcileLoop() {
+    const tick = () => this.reconcile().catch((e) => log.warn('reconcile loop error:', e.message));
+    tick(); // run once at boot
+    this.reconcileTimer = setInterval(tick, this.config.reconcileIntervalMs);
+    this.reconcileTimer.unref?.();
+  }
+
+  // ---- helpers ------------------------------------------------------------
+
+  _spawnLogged(cmd, args, { cwd, env, logPath, truncate = false, timeout } = {}) {
+    return new Promise((resolve, reject) => {
+      mkdirSync(dirname(logPath), { recursive: true });
+      const stream = createWriteStream(logPath, { flags: truncate ? 'w' : 'a' });
+      stream.on('error', (err) => reject(err)); // never let a log FS error crash the server
+      stream.write(`\n=== ${new Date().toISOString()} $ ${cmd} ${args.join(' ')} ===\n`);
+      const child = spawn(cmd, args, {
+        cwd,
+        env: env ? { ...process.env, ...env } : process.env,
+      });
+      let timer;
+      if (timeout) timer = setTimeout(() => child.kill('SIGKILL'), timeout);
+      child.stdout.pipe(stream, { end: false });
+      child.stderr.pipe(stream, { end: false });
+      child.on('error', (err) => {
+        if (timer) clearTimeout(timer);
+        stream.end();
+        reject(err);
+      });
+      child.on('close', (code) => {
+        if (timer) clearTimeout(timer);
+        stream.end();
+        if (code === 0) resolve();
+        else reject(new Error(`${cmd} exited with code ${code} (see ${logPath})`));
+      });
+    });
+  }
+}
+
+function truncate(s, n = 600) {
+  return s && s.length > n ? `${s.slice(0, n)}…` : s;
+}
+function redactErr(err) {
+  return redact(err && err.message ? err.message : String(err));
+}
+async function tailFile(path, n) {
+  try {
+    const text = await readFile(path, 'utf8');
+    return text.split('\n').slice(-n).join('\n');
+  } catch {
+    return null;
+  }
+}

--- a/server/src/manager.js
+++ b/server/src/manager.js
@@ -11,6 +11,7 @@ import { allocate } from './allocator.js';
 import * as docker from './docker.js';
 import * as workerMod from './worker.js';
 import * as gitauth from './gitauth.js';
+import * as targetrepo from './targetrepo.js';
 import * as fleet from './fleet.js';
 import { computeStatus, coreUp, publicView } from './status.js';
 import { log, redact } from './log.js';
@@ -80,10 +81,12 @@ export class Manager {
       );
       await registry.update(record.id, { setupFinishedAt: new Date().toISOString() });
 
-      // 3. Git auth (non-fatal).
+      // 3. Git auth (non-fatal), then swap the target plugin to a live git
+      //    checkout the worker operates on (fatal — that's the env's purpose).
       this.jobs.set(record.id, 'configuring');
       await registry.update(record.id, { status: 'configuring' });
       await gitauth.configure(record, config);
+      await targetrepo.setup(record, config);
 
       // 4. Start the named worker.
       this.jobs.set(record.id, 'starting-worker');

--- a/server/src/registry.js
+++ b/server/src/registry.js
@@ -1,0 +1,88 @@
+// JSON-file registry — the source of truth for env → metadata. Mutations are
+// serialized through an async mutex and persisted with an atomic temp+rename so
+// a crash mid-write can't corrupt it.
+
+import { readFile, writeFile, rename, mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+// Minimal promise-chain mutex (no deps). runExclusive(fn) serializes callers.
+export function createMutex() {
+  let tail = Promise.resolve();
+  return function runExclusive(fn) {
+    const result = tail.then(() => fn());
+    // Keep the chain alive regardless of fn outcome; swallow here so one
+    // rejection doesn't poison the queue (callers still see their own result).
+    tail = result.then(
+      () => {},
+      () => {},
+    );
+    return result;
+  };
+}
+
+export class Registry {
+  constructor(path) {
+    this.path = path;
+    this.data = { version: 1, environments: {} };
+    this.mutex = createMutex();
+  }
+
+  async load() {
+    try {
+      const raw = await readFile(this.path, 'utf8');
+      const parsed = JSON.parse(raw);
+      if (parsed && parsed.environments) this.data = parsed;
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err;
+      await mkdir(dirname(this.path), { recursive: true });
+      await this._persist();
+    }
+    return this;
+  }
+
+  list() {
+    return Object.values(this.data.environments);
+  }
+
+  get(id) {
+    return this.data.environments[id] || null;
+  }
+
+  getByName(name) {
+    return this.list().find((e) => e.name === name) || null;
+  }
+
+  usedPorts() {
+    return new Set(this.list().map((e) => e.port));
+  }
+
+  usedNames() {
+    return new Set(this.list().map((e) => e.name));
+  }
+
+  // Serialized read-modify-write: mutate(data) gets the live data object and may
+  // change it; the result is persisted atomically. Returns mutate()'s return.
+  mutate(fn) {
+    return this.mutex(async () => {
+      const ret = await fn(this.data);
+      await this._persist();
+      return ret;
+    });
+  }
+
+  // Convenience: patch one environment's fields and persist.
+  update(id, patch) {
+    return this.mutate((data) => {
+      const env = data.environments[id];
+      if (!env) return null;
+      Object.assign(env, patch);
+      return env;
+    });
+  }
+
+  async _persist() {
+    const tmp = join(dirname(this.path), `.registry.${process.pid}.tmp`);
+    await writeFile(tmp, JSON.stringify(this.data, null, 2));
+    await rename(tmp, this.path);
+  }
+}

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -1,0 +1,78 @@
+// Endpoint handlers — thin: validate input, call the manager, shape the response.
+
+import { route } from './http.js';
+import { hostInfo } from './docker.js';
+import { AllocationError } from './allocator.js';
+
+export function buildRoutes(config, registry, manager) {
+  const findOr404 = (ctx) => {
+    const rec = registry.get(ctx.params.id) || registry.getByName(ctx.params.id);
+    if (!rec) {
+      const e = new Error(`environment "${ctx.params.id}" not found`);
+      e.status = 404;
+      throw e;
+    }
+    return rec;
+  };
+
+  return [
+    route('GET', '/health', async (ctx) => ctx.send(200, { ok: true, version: 1 })),
+
+    route('GET', '/host', async (ctx) => {
+      const info = await hostInfo();
+      ctx.send(200, {
+        ...info,
+        environments: registry.list().length,
+        maxEnvironments: config.maxEnvironments,
+        loadavg: (await import('node:os')).loadavg(),
+      });
+    }),
+
+    route('POST', '/environments', async (ctx) => {
+      try {
+        const record = await manager.createEnvironment({ name: ctx.body.name });
+        ctx.send(202, {
+          id: record.id,
+          name: record.name,
+          port: record.port,
+          wpUrl: record.wpUrl,
+          status: record.status,
+        });
+      } catch (err) {
+        if (err instanceof AllocationError) {
+          const e = new Error(err.message);
+          e.status = err.status;
+          throw e;
+        }
+        throw err;
+      }
+    }),
+
+    route('GET', '/environments', async (ctx) => {
+      ctx.send(200, { environments: await manager.list() });
+    }),
+
+    route('GET', '/environments/:id', async (ctx) => {
+      ctx.send(200, await manager.describe(findOr404(ctx)));
+    }),
+
+    route('GET', '/environments/:id/logs', async (ctx) => {
+      const which = ctx.query.get('which') || 'all';
+      const tail = Math.min(parseInt(ctx.query.get('tail') || '200', 10) || 200, 5000);
+      ctx.send(200, await manager.logs(findOr404(ctx), which, tail));
+    }),
+
+    route('POST', '/environments/:id/stop', async (ctx) => {
+      ctx.send(200, await manager.stop(findOr404(ctx)));
+    }),
+
+    route('POST', '/environments/:id/start', async (ctx) => {
+      ctx.send(200, await manager.start(findOr404(ctx)));
+    }),
+
+    route('DELETE', '/environments/:id', async (ctx) => {
+      await manager.destroy(findOr404(ctx));
+      ctx.send(200, { deleted: true });
+    }),
+  ];
+}

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -1,19 +1,51 @@
-// Endpoint handlers — thin: validate input, call the manager, shape the response.
+// Endpoint handlers — thin: validate input, call the manager/session engine,
+// shape the response. `sessions` bundles { store, engine, bus }.
 
+import { readFile } from 'node:fs/promises';
 import { route } from './http.js';
 import { hostInfo } from './docker.js';
 import { AllocationError } from './allocator.js';
+import { openSse } from './sse.js';
+import { makeStaticHandler } from './static.js';
 
-export function buildRoutes(config, registry, manager) {
-  const findOr404 = (ctx) => {
+export function buildRoutes(config, registry, manager, sessions) {
+  const staticHandler = makeStaticHandler(config.uiRoot);
+
+  const envOr404 = (ctx) => {
     const rec = registry.get(ctx.params.id) || registry.getByName(ctx.params.id);
-    if (!rec) {
-      const e = new Error(`environment "${ctx.params.id}" not found`);
-      e.status = 404;
-      throw e;
-    }
+    if (!rec) throw httpErr(404, `environment "${ctx.params.id}" not found`);
     return rec;
   };
+  const sessionOr404 = (ctx) => {
+    const s = sessions.store.get(ctx.params.id);
+    if (!s) throw httpErr(404, `session "${ctx.params.id}" not found`);
+    return s;
+  };
+  const assertUsable = async (env) => {
+    if (!(await manager.usable(env))) throw httpErr(409, `environment "${env.name}" is not running`);
+  };
+  const sshHint = (s) => {
+    const env = registry.get(s.envId);
+    if (!env || !s.claudeSessionId) return null;
+    return `cd ${env.dir} && bash scripts/in-workspace.sh claude --resume ${s.claudeSessionId}`;
+  };
+  const publicSession = (s) => ({
+    id: s.id,
+    envId: s.envId,
+    envName: s.envName,
+    claudeSessionId: s.claudeSessionId,
+    cwd: s.cwd,
+    model: s.model,
+    title: s.title,
+    status: sessions.engine.isActive(s.id) ? 'running' : s.status,
+    turnCount: s.turnCount,
+    lastResult: s.lastResult,
+    costUsd: s.costUsd,
+    lastError: s.lastError,
+    createdAt: s.createdAt,
+    lastActivityAt: s.lastActivityAt,
+    sshResumeHint: sshHint(s),
+  });
 
   return [
     route('GET', '/health', async (ctx) => ctx.send(200, { ok: true, version: 1 })),
@@ -23,56 +55,116 @@ export function buildRoutes(config, registry, manager) {
       ctx.send(200, {
         ...info,
         environments: registry.list().length,
+        sessions: sessions.store.list().length,
         maxEnvironments: config.maxEnvironments,
         loadavg: (await import('node:os')).loadavg(),
       });
     }),
 
+    // ---- environments -----------------------------------------------------
     route('POST', '/environments', async (ctx) => {
       try {
         const record = await manager.createEnvironment({ name: ctx.body.name });
-        ctx.send(202, {
-          id: record.id,
-          name: record.name,
-          port: record.port,
-          wpUrl: record.wpUrl,
-          status: record.status,
-        });
+        ctx.send(202, { id: record.id, name: record.name, port: record.port, wpUrl: record.wpUrl, status: record.status });
       } catch (err) {
-        if (err instanceof AllocationError) {
-          const e = new Error(err.message);
-          e.status = err.status;
-          throw e;
-        }
+        if (err instanceof AllocationError) throw httpErr(err.status, err.message);
         throw err;
       }
     }),
-
-    route('GET', '/environments', async (ctx) => {
-      ctx.send(200, { environments: await manager.list() });
-    }),
-
-    route('GET', '/environments/:id', async (ctx) => {
-      ctx.send(200, await manager.describe(findOr404(ctx)));
-    }),
-
+    route('GET', '/environments', async (ctx) => ctx.send(200, { environments: await manager.list() })),
+    route('GET', '/environments/:id', async (ctx) => ctx.send(200, await manager.describe(envOr404(ctx)))),
     route('GET', '/environments/:id/logs', async (ctx) => {
       const which = ctx.query.get('which') || 'all';
       const tail = Math.min(parseInt(ctx.query.get('tail') || '200', 10) || 200, 5000);
-      ctx.send(200, await manager.logs(findOr404(ctx), which, tail));
+      ctx.send(200, await manager.logs(envOr404(ctx), which, tail));
     }),
-
-    route('POST', '/environments/:id/stop', async (ctx) => {
-      ctx.send(200, await manager.stop(findOr404(ctx)));
-    }),
-
-    route('POST', '/environments/:id/start', async (ctx) => {
-      ctx.send(200, await manager.start(findOr404(ctx)));
-    }),
-
+    route('POST', '/environments/:id/stop', async (ctx) => ctx.send(200, await manager.stop(envOr404(ctx)))),
+    route('POST', '/environments/:id/start', async (ctx) => ctx.send(200, await manager.start(envOr404(ctx)))),
     route('DELETE', '/environments/:id', async (ctx) => {
-      await manager.destroy(findOr404(ctx));
+      const env = envOr404(ctx);
+      sessions.engine.killEnvSessions(env.id);
+      for (const s of sessions.store.listByEnv(env.id)) await sessions.store.update(s.id, { status: 'env-destroyed' });
+      await manager.destroy(env);
       ctx.send(200, { deleted: true });
     }),
+
+    // ---- claude sessions --------------------------------------------------
+    route('POST', '/environments/:id/sessions', async (ctx) => {
+      const env = envOr404(ctx);
+      await assertUsable(env);
+      const prompt = (ctx.body.prompt || '').trim();
+      if (!prompt) throw httpErr(400, 'prompt is required');
+      const record = await sessions.engine.newSession(env, { prompt, model: ctx.body.model });
+      ctx.send(202, publicSession(record));
+    }),
+
+    route('POST', '/sessions/:id/messages', async (ctx) => {
+      const s = sessionOr404(ctx);
+      if (sessions.engine.isActive(s.id)) throw httpErr(409, 'a turn is already in progress for this session');
+      const env = registry.get(s.envId);
+      if (!env) throw httpErr(410, 'the environment for this session no longer exists');
+      await assertUsable(env);
+      const prompt = (ctx.body.prompt || '').trim();
+      if (!prompt) throw httpErr(400, 'prompt is required');
+      await sessions.engine.sendMessage(env, s, { prompt });
+      ctx.send(202, publicSession(sessions.store.get(s.id)));
+    }),
+
+    route('GET', '/sessions', async (ctx) => {
+      let list = sessions.store.list();
+      const envId = ctx.query.get('envId');
+      const status = ctx.query.get('status');
+      if (envId) list = list.filter((s) => s.envId === envId);
+      if (status) list = list.filter((s) => publicSession(s).status === status);
+      ctx.send(200, { sessions: list.map(publicSession) });
+    }),
+
+    route('GET', '/sessions/:id', async (ctx) => ctx.send(200, publicSession(sessionOr404(ctx)))),
+
+    route('GET', '/sessions/:id/transcript', async (ctx) => {
+      const s = sessionOr404(ctx);
+      const tail = Math.min(parseInt(ctx.query.get('tail') || '2000', 10) || 2000, 20000);
+      let events = [];
+      try {
+        const text = await readFile(s.eventLogPath, 'utf8');
+        events = text.split('\n').filter(Boolean).slice(-tail).map((l) => {
+          try { return JSON.parse(l); } catch { return { type: 'raw', text: l }; }
+        });
+      } catch { /* no log yet */ }
+      ctx.send(200, { events });
+    }),
+
+    route('GET', '/sessions/:id/stream', async (ctx) => {
+      const s = sessionOr404(ctx);
+      const sse = openSse(ctx.res);
+      for (const e of sessions.bus.backlog(s.id)) sse.send(e);
+      sse.send({ type: 'control', subtype: 'snapshot', session: publicSession(s) });
+      const unsub = sessions.bus.subscribe(s.id, sse.send);
+      ctx.req.on('close', () => { unsub(); sse.close(); });
+    }, { kind: 'sse' }),
+
+    route('POST', '/sessions/:id/interrupt', async (ctx) => {
+      const s = sessionOr404(ctx);
+      if (!sessions.engine.interrupt(s.id)) throw httpErr(409, 'no active turn to interrupt');
+      ctx.send(200, publicSession(sessions.store.get(s.id)));
+    }),
+
+    route('DELETE', '/sessions/:id', async (ctx) => {
+      const s = sessionOr404(ctx);
+      sessions.engine.interrupt(s.id);
+      sessions.bus.clear(s.id);
+      await sessions.store.remove(s.id);
+      ctx.send(200, { deleted: true });
+    }),
+
+    // ---- UI (static; shell unauthenticated, data APIs above are authed) ----
+    route('GET', '/', staticHandler, { kind: 'static' }),
+    route('GET', '/ui/:rest*', staticHandler, { kind: 'static' }),
   ];
+}
+
+function httpErr(status, message) {
+  const e = new Error(message);
+  e.status = status;
+  return e;
 }

--- a/server/src/sessionbus.js
+++ b/server/src/sessionbus.js
@@ -1,0 +1,40 @@
+// Per-session event bus + bounded ring buffer. Live turn events are published
+// here; SSE subscribers replay the recent backlog (ring) then receive live
+// events. Full history lives in each session's ndjson log (see claude.js).
+
+export class SessionBus {
+  constructor(ringSize = 500) {
+    this.ringSize = ringSize;
+    this.rings = new Map(); // sessionId -> event[]
+    this.subs = new Map(); // sessionId -> Set<fn>
+  }
+
+  publish(sessionId, event) {
+    const ring = this.rings.get(sessionId) || [];
+    ring.push(event);
+    if (ring.length > this.ringSize) ring.shift();
+    this.rings.set(sessionId, ring);
+    const set = this.subs.get(sessionId);
+    if (set) for (const fn of set) { try { fn(event); } catch { /* a bad subscriber can't break others */ } }
+  }
+
+  backlog(sessionId) {
+    return this.rings.get(sessionId) || [];
+  }
+
+  subscribe(sessionId, fn) {
+    let set = this.subs.get(sessionId);
+    if (!set) this.subs.set(sessionId, (set = new Set()));
+    set.add(fn);
+    return () => {
+      set.delete(fn);
+      if (!set.size) this.subs.delete(sessionId);
+    };
+  }
+
+  // Drop a finished/destroyed session's buffer (subscribers should be gone).
+  clear(sessionId) {
+    this.rings.delete(sessionId);
+    this.subs.delete(sessionId);
+  }
+}

--- a/server/src/sessions.js
+++ b/server/src/sessions.js
@@ -1,0 +1,92 @@
+// JSON-file store of Claude sessions — the durable record of each conversation.
+// Mirrors registry.js (shared async mutex + atomic temp+rename write).
+//
+// A "session" is the durable thread (our stable id + the claude session_id used
+// for --resume). A "turn" is one `claude -p` run; we don't persist turns
+// separately beyond turnCount + the per-session ndjson event log.
+
+import { readFile, writeFile, rename, mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { createMutex } from './registry.js';
+
+export class SessionStore {
+  constructor(path) {
+    this.path = path;
+    this.data = { version: 1, sessions: {} };
+    this.mutex = createMutex();
+  }
+
+  async load() {
+    try {
+      const parsed = JSON.parse(await readFile(this.path, 'utf8'));
+      if (parsed && parsed.sessions) this.data = parsed;
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err;
+      await mkdir(dirname(this.path), { recursive: true });
+      await this._persist();
+    }
+    return this;
+  }
+
+  list() {
+    return Object.values(this.data.sessions);
+  }
+
+  get(id) {
+    return this.data.sessions[id] || null;
+  }
+
+  listByEnv(envId) {
+    return this.list().filter((s) => s.envId === envId);
+  }
+
+  mutate(fn) {
+    return this.mutex(async () => {
+      const ret = await fn(this.data);
+      await this._persist();
+      return ret;
+    });
+  }
+
+  create(record) {
+    return this.mutate((data) => {
+      data.sessions[record.id] = record;
+      return record;
+    });
+  }
+
+  update(id, patch) {
+    return this.mutate((data) => {
+      const s = data.sessions[id];
+      if (!s) return null;
+      Object.assign(s, patch);
+      return s;
+    });
+  }
+
+  remove(id) {
+    return this.mutate((data) => {
+      delete data.sessions[id];
+    });
+  }
+
+  // Boot: a session left `running` had its turn killed when the server stopped.
+  // The claude session jsonl persists on disk, so it's resumable — mark it
+  // interrupted so the next message resumes it.
+  reconcile() {
+    return this.mutate((data) => {
+      for (const s of Object.values(data.sessions)) {
+        if (s.status === 'running') {
+          s.status = 'interrupted';
+          s.lastError = s.lastError || 'turn interrupted (server restart)';
+        }
+      }
+    });
+  }
+
+  async _persist() {
+    const tmp = join(dirname(this.path), `.sessions.${process.pid}.tmp`);
+    await writeFile(tmp, JSON.stringify(this.data, null, 2));
+    await rename(tmp, this.path);
+  }
+}

--- a/server/src/sse.js
+++ b/server/src/sse.js
@@ -1,0 +1,35 @@
+// Server-Sent Events helper. Opens an event stream on a raw http response and
+// returns send/close. Heartbeat comments keep the connection alive through
+// proxies/idle timeouts.
+
+export function openSse(res) {
+  res.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache, no-transform',
+    connection: 'keep-alive',
+    'x-accel-buffering': 'no', // tell nginx-style proxies not to buffer
+  });
+  res.flushHeaders?.();
+  res.write(': connected\n\n');
+  const hb = setInterval(() => {
+    try {
+      res.write(': hb\n\n');
+    } catch {
+      /* socket gone; close() will clear */
+    }
+  }, 15000);
+  hb.unref?.();
+  return {
+    send(event) {
+      res.write(`data: ${JSON.stringify(event)}\n\n`);
+    },
+    close() {
+      clearInterval(hb);
+      try {
+        res.end();
+      } catch {
+        /* already closed */
+      }
+    },
+  };
+}

--- a/server/src/static.js
+++ b/server/src/static.js
@@ -1,0 +1,50 @@
+// Minimal static-file handler for the UI. GET only, confined to the UI root
+// (no path traversal), content-type by extension. Buildless: serves the files
+// in server/ui as-is.
+
+import { createReadStream } from 'node:fs';
+import { stat, realpath } from 'node:fs/promises';
+import { join, normalize, extname } from 'node:path';
+
+const TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.png': 'image/png',
+  '.woff2': 'font/woff2',
+  '.map': 'application/json',
+};
+
+export function makeStaticHandler(uiRoot) {
+  return async function serveStatic(ctx) {
+    const { res } = ctx;
+    // ctx.params.rest is the path after /ui/ (or empty for /ui or /).
+    let rel = (ctx.params.rest || '').replace(/^\/+/, '');
+    if (!rel || rel.endsWith('/')) rel += 'index.html';
+    const full = normalize(join(uiRoot, rel));
+    try {
+      const real = await realpath(full);
+      const rootReal = await realpath(uiRoot);
+      if (real !== rootReal && !real.startsWith(rootReal + '/')) {
+        res.writeHead(403).end('forbidden');
+        return;
+      }
+      const st = await stat(real);
+      if (!st.isFile()) {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      res.writeHead(200, {
+        'content-type': TYPES[extname(real)] || 'application/octet-stream',
+        'cache-control': 'no-cache',
+      });
+      createReadStream(real).pipe(res);
+    } catch {
+      res.writeHead(404).end('not found');
+    }
+  };
+}

--- a/server/src/status.js
+++ b/server/src/status.js
@@ -41,8 +41,11 @@ export function computeStatus({ record, jobState, ps, worker }) {
   if (!anyUp(ps)) return 'stopped';
   if (!coreUp(ps)) return 'degraded'; // some but not all core services up
 
-  // Core stack is up; worker liveness decides running vs degraded.
-  if (worker && worker.running) return 'running';
+  // Core stack is up. `worker === null` means no Cursor worker is expected for
+  // this env (autostart off) — it's simply running. Otherwise worker liveness
+  // decides running vs degraded.
+  if (worker == null) return 'running';
+  if (worker.running) return 'running';
   return 'degraded';
 }
 

--- a/server/src/status.js
+++ b/server/src/status.js
@@ -1,0 +1,63 @@
+// Pure live-status computation. Reconciles three signals the caller gathers:
+//   - jobState: the transient state of an in-flight create/start pipeline (or null)
+//   - ps:       parsed `docker compose ps` for the project
+//   - worker:   { running, healthy, state } from worker.health (or null)
+//
+// Container-up and worker-alive are independent: containers up but worker dead
+// surfaces as "degraded".
+
+export const TRANSIENT = new Set(['scaffolding', 'setting-up', 'configuring', 'starting-worker', 'destroying']);
+
+// Services whose "running" state means the stack is up. Playwright is present
+// but not gated on (it's the heaviest and least essential to core operation).
+const CORE_SERVICES = ['db', 'wordpress', 'workspace'];
+
+function runningServices(ps) {
+  const running = new Set();
+  for (const svc of ps) {
+    const name = svc.Service || svc.service;
+    const state = (svc.State || svc.state || '').toLowerCase();
+    if (name && state === 'running') running.add(name);
+  }
+  return running;
+}
+
+export function coreUp(ps) {
+  const running = runningServices(ps);
+  return CORE_SERVICES.every((s) => running.has(s));
+}
+
+export function anyUp(ps) {
+  return runningServices(ps).size > 0;
+}
+
+export function computeStatus({ record, jobState, ps, worker }) {
+  // An in-flight pipeline wins — it's the authoritative transient state.
+  if (jobState && TRANSIENT.has(jobState)) return jobState;
+
+  // Sticky failure until the user acts (start/destroy).
+  if (record.status === 'failed' && !coreUp(ps)) return 'failed';
+
+  if (!anyUp(ps)) return 'stopped';
+  if (!coreUp(ps)) return 'degraded'; // some but not all core services up
+
+  // Core stack is up; worker liveness decides running vs degraded.
+  if (worker && worker.running) return 'running';
+  return 'degraded';
+}
+
+// Public-facing view of an environment (no secrets).
+export function publicView(record, { status, worker, fleet }) {
+  return {
+    id: record.id,
+    name: record.name,
+    port: record.port,
+    wpUrl: record.wpUrl,
+    status,
+    worker: worker ? { running: worker.running, healthy: worker.healthy, state: worker.state } : null,
+    createdAt: record.createdAt,
+    workerStartedAt: record.workerStartedAt,
+    lastError: record.lastError,
+    ...(fleet !== undefined ? { fleet } : {}),
+  };
+}

--- a/server/src/targetrepo.js
+++ b/server/src/targetrepo.js
@@ -1,0 +1,76 @@
+// Replace the release-zip plugin with a live git checkout of the target repo,
+// so the Cursor worker operates on (and commits to) the real repository.
+//
+// Mirrors the repo's own documented local-dev flow:
+//   clone <repo> → (cd <subdir> && composer install --no-dev) →
+//   symlink <subdir> into wp-content/plugins/<slug> → wp plugin activate <slug>
+//
+// Runs once in the create pipeline (after git auth, before the worker starts).
+// Requires git auth to be configured first (so a private repo can be cloned and
+// later pushed). Fatal on error — an environment whose whole purpose is to work
+// on this repo isn't useful without it.
+
+import { appendFile } from 'node:fs/promises';
+import { exec } from './docker.js';
+
+// Run in the workspace container. All inputs arrive via env (off argv). The
+// plugin lives at $DEST/$SUBDIR; vendor/ is gitignored so composer install is
+// required when a composer.json is present.
+const SCRIPT = `set -e
+DEST="/home/node/$T_SLUG"
+PLUGIN_DIR="/home/node/wp/wp-content/plugins/$T_SLUG"
+
+echo "→ Removing any installed '$T_SLUG' (replacing release zip with the git checkout)…"
+wp plugin delete "$T_SLUG" >/dev/null 2>&1 || true
+
+if [ -d "$DEST/.git" ]; then
+  echo "→ Repo already present at $DEST — updating…"
+  git -C "$DEST" remote set-url origin "$T_REPO"
+  git -C "$DEST" fetch --all --prune
+else
+  echo "→ Cloning $T_REPO → $DEST…"
+  rm -rf "$DEST"
+  git clone "$T_REPO" "$DEST"
+fi
+if [ -n "$T_REF" ]; then
+  echo "→ Checking out $T_REF…"
+  git -C "$DEST" checkout "$T_REF"
+fi
+
+if [ -f "$DEST/$T_SUBDIR/composer.json" ]; then
+  echo "→ composer install --no-dev in $T_SUBDIR (vendor/ is gitignored)…"
+  composer install --no-dev --no-interaction --no-progress -d "$DEST/$T_SUBDIR"
+fi
+
+echo "→ Symlinking $DEST/$T_SUBDIR → $PLUGIN_DIR…"
+rm -rf "$PLUGIN_DIR"
+ln -s "$DEST/$T_SUBDIR" "$PLUGIN_DIR"
+
+echo "→ Activating '$T_SLUG'…"
+wp plugin activate "$T_SLUG"
+echo "✓ '$T_SLUG' is now served from the git checkout at $DEST"
+`;
+
+export async function setup(env, config) {
+  if (!config.targetRepo) return false; // disabled → general-purpose worker
+  let out = '';
+  try {
+    const res = await exec(env, 'workspace', ['sh', '-lc', SCRIPT], {
+      envNames: ['T_SLUG', 'T_REPO', 'T_REF', 'T_SUBDIR'],
+      envValues: {
+        T_SLUG: config.targetPluginSlug,
+        T_REPO: config.targetRepo,
+        T_REF: config.targetRepoRef || '',
+        T_SUBDIR: config.targetPluginSubdir,
+      },
+      timeout: 5 * 60 * 1000,
+    });
+    out = `${res.stdout || ''}${res.stderr || ''}`;
+    await appendFile(env.setupLogPath, `\n=== target repo: ${config.targetPluginSlug} ===\n${out}\n`).catch(() => {});
+    return true;
+  } catch (err) {
+    out = `${err.stdout || ''}${err.stderr || err.message || err}`;
+    await appendFile(env.setupLogPath, `\n=== target repo FAILED ===\n${out}\n`).catch(() => {});
+    throw new Error(`target repo setup failed for ${config.targetPluginSlug}`);
+  }
+}

--- a/server/src/targetrepo.js
+++ b/server/src/targetrepo.js
@@ -48,6 +48,17 @@ ln -s "$DEST/$T_SUBDIR" "$PLUGIN_DIR"
 
 echo "→ Activating '$T_SLUG'…"
 wp plugin activate "$T_SLUG"
+
+# If the repo ships a skill installer (convention: abilities-generator), run it
+# so its Claude/Cursor skill(s) are linked into the agents' skills dirs. The skill
+# dirs are made node-writable by install-skills.sh during \`npm run setup\` (which
+# runs before this). Non-fatal — a skill-install hiccup shouldn't fail the env.
+SKILL_INSTALLER="$DEST/abilities-generator/scripts/install-skill.sh"
+if [ -f "$SKILL_INSTALLER" ]; then
+  echo "→ Installing repo skill(s) via abilities-generator/scripts/install-skill.sh…"
+  ( cd "$DEST/abilities-generator" && bash scripts/install-skill.sh ) || echo "  (claude skill install failed; continuing)"
+  ( cd "$DEST/abilities-generator" && CLAUDE_SKILLS_DIR=/home/node/.cursor/skills bash scripts/install-skill.sh ) || echo "  (cursor skill install failed; continuing)"
+fi
 echo "✓ '$T_SLUG' is now served from the git checkout at $DEST"
 `;
 

--- a/server/src/worker.js
+++ b/server/src/worker.js
@@ -1,0 +1,86 @@
+// Start / stop / health-check the named Cursor self-hosted worker inside an
+// environment's workspace container.
+//
+// The worker connects OUTBOUND to Cursor only (no inbound port). We launch it
+// detached (`compose exec -d`) writing to /home/node/.worker.log (persisted in
+// the bind mount, so the host can read it at <dir>/workspace/.worker.log). The
+// control server's reconcile loop is the supervisor: it re-launches a worker
+// whose process has died while its containers are up.
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { exec } from './docker.js';
+
+const WORKER_MATCH = 'cursor-agent worker'; // pgrep pattern for liveness
+
+// Build the `cursor-agent worker … start` argv. Flags live on the `worker`
+// command (before `start`); CURSOR_API_KEY is read from the env by the binary.
+function workerCommand(env, config) {
+  const parts = [
+    'cursor-agent',
+    'worker',
+    '--name',
+    quote(env.name),
+    '--worker-dir',
+    config.workerDir,
+  ];
+  if (config.workerIdleReleaseTimeout) {
+    parts.push('--idle-release-timeout', String(config.workerIdleReleaseTimeout));
+  }
+  parts.push('start');
+  // Append (don't truncate) the log so restarts keep history.
+  return `${parts.join(' ')} >> /home/node/.worker.log 2>&1`;
+}
+
+function quote(s) {
+  return `"${String(s).replace(/"/g, '\\"')}"`;
+}
+
+export async function start(env, config) {
+  const cmd = workerCommand(env, config);
+  // `sh -lc` so PATH/profile are loaded; detached so it outlives the exec.
+  await exec(env, 'workspace', ['sh', '-lc', cmd], {
+    detach: true,
+    envNames: ['CURSOR_API_KEY'],
+    envValues: { CURSOR_API_KEY: config.cursorApiKey },
+  });
+}
+
+// Liveness: is the worker process running in the workspace container?
+export async function isRunning(env) {
+  try {
+    await exec(env, 'workspace', ['pgrep', '-f', WORKER_MATCH], { timeout: 10_000 });
+    return true; // pgrep exits 0 when a match exists
+  } catch {
+    return false;
+  }
+}
+
+// Stop the worker process without touching the container.
+export async function stop(env) {
+  try {
+    await exec(env, 'workspace', ['pkill', '-f', WORKER_MATCH], { timeout: 10_000 });
+  } catch {
+    /* no process / already gone */
+  }
+}
+
+// Read the connection state from the tail of the worker log (host-side, since
+// the log lives in the bind-mounted workspace dir). Best-effort.
+export async function logState(env) {
+  try {
+    const text = await readFile(join(env.dir, 'workspace', '.worker.log'), 'utf8');
+    const tail = text.slice(-4000);
+    if (/invalid api key/i.test(tail)) return 'invalid-api-key';
+    if (/connected|registered|listening|ready/i.test(tail)) return 'connected';
+    if (/error|failed/i.test(tail)) return 'error';
+    return 'starting';
+  } catch {
+    return 'unknown';
+  }
+}
+
+export async function health(env) {
+  const [running, state] = await Promise.all([isRunning(env), logState(env)]);
+  return { running, healthy: running && state === 'connected', state };
+}

--- a/server/src/worker.js
+++ b/server/src/worker.js
@@ -11,10 +11,9 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { exec } from './docker.js';
 
-const WORKER_MATCH = 'cursor-agent worker'; // pgrep pattern for liveness
-
 // Build the `cursor-agent worker … start` argv. Flags live on the `worker`
 // command (before `start`); CURSOR_API_KEY is read from the env by the binary.
+// --management-addr exposes /readyz inside the container for liveness checks.
 function workerCommand(env, config) {
   const parts = [
     'cursor-agent',
@@ -23,6 +22,8 @@ function workerCommand(env, config) {
     quote(env.name),
     '--worker-dir',
     config.workerDir,
+    '--management-addr',
+    config.workerManagementAddr,
   ];
   if (config.workerIdleReleaseTimeout) {
     parts.push('--idle-release-timeout', String(config.workerIdleReleaseTimeout));
@@ -36,6 +37,10 @@ function quote(s) {
   return `"${String(s).replace(/"/g, '\\"')}"`;
 }
 
+function readyzUrl(config) {
+  return `http://${config.workerManagementAddr}/readyz`;
+}
+
 export async function start(env, config) {
   const cmd = workerCommand(env, config);
   // `sh -lc` so PATH/profile are loaded; detached so it outlives the exec.
@@ -46,23 +51,21 @@ export async function start(env, config) {
   });
 }
 
-// Liveness: is the worker process running in the workspace container?
-export async function isRunning(env) {
+// Liveness via the worker's own /readyz endpoint (the slim image has no
+// pgrep/ps; curl is present). Exit 0 from curl --fail means up + ready.
+export async function isRunning(env, config) {
   try {
-    await exec(env, 'workspace', ['pgrep', '-f', WORKER_MATCH], { timeout: 10_000 });
-    return true; // pgrep exits 0 when a match exists
+    await exec(env, 'workspace', ['curl', '-fsS', '-m', '3', readyzUrl(config)], { timeout: 10_000 });
+    return true;
   } catch {
     return false;
   }
 }
 
-// Stop the worker process without touching the container.
-export async function stop(env) {
-  try {
-    await exec(env, 'workspace', ['pkill', '-f', WORKER_MATCH], { timeout: 10_000 });
-  } catch {
-    /* no process / already gone */
-  }
+// No process-kill tool in the image; the container stop in manager.stop() reaps
+// the worker. Kept as a hook (best-effort) for callers that only stop the worker.
+export async function stop() {
+  /* no-op: container stop reaps the worker (no pkill in the slim image) */
 }
 
 // Read the connection state from the tail of the worker log (host-side, since
@@ -80,7 +83,7 @@ export async function logState(env) {
   }
 }
 
-export async function health(env) {
-  const [running, state] = await Promise.all([isRunning(env), logState(env)]);
+export async function health(env, config) {
+  const [running, state] = await Promise.all([isRunning(env, config), logState(env)]);
   return { running, healthy: running && state === 'connected', state };
 }

--- a/server/ui/app.js
+++ b/server/ui/app.js
@@ -76,27 +76,55 @@ function StatusDot({ status }) {
   return html`<span class="dot ${status}" title=${status}></span>`;
 }
 
-function Sidebar({ sessions, envs, selectedId, onSelect, onNew, onSettings }) {
+const TRANSIENT_ENV = ['scaffolding', 'setting-up', 'configuring', 'starting-worker', 'destroying'];
+
+function EnvRow({ env, onAction }) {
+  const building = TRANSIENT_ENV.includes(env.status);
+  const up = env.status === 'running' || env.status === 'degraded';
+  return html`
+    <div class="env">
+      <div class="env-top">
+        <${StatusDot} status=${env.status} /> <span class="env-name">${env.name}</span>
+        <a class="env-port" href=${env.wpUrl} target="_blank" rel="noreferrer" onClick=${(e) => e.stopPropagation()}>:${env.port}</a>
+      </div>
+      <div class="env-actions">
+        ${building
+          ? html`<span class="muted small">${env.status}…</span>`
+          : html`
+            ${up && html`<button class="lnk" onClick=${() => onAction('session', env)}>+ session</button>`}
+            ${up && html`<button class="lnk" onClick=${() => onAction('stop', env)}>stop</button>`}
+            ${env.status === 'stopped' && html`<button class="lnk" onClick=${() => onAction('start', env)}>start</button>`}
+            ${env.status === 'failed' && html`<button class="lnk" onClick=${() => onAction('start', env)}>retry</button>`}
+            <button class="lnk danger" onClick=${() => onAction('delete', env)}>delete</button>`}
+      </div>
+    </div>`;
+}
+
+function Sidebar({ sessions, envs, selectedId, onSelect, onNewSession, onNewEnv, onEnvAction, onSettings }) {
   return html`
     <aside class="sidebar">
       <div class="side-head">
-        <strong>Sessions</strong>
-        <div>
-          <button class="btn small" onClick=${onNew}>+ New</button>
-          <button class="btn small ghost" onClick=${onSettings} title="API token">⚙</button>
+        <strong>Devbox</strong>
+        <button class="btn small ghost" onClick=${onSettings} title="API token">⚙</button>
+      </div>
+      <div class="side-section">
+        <div class="section-head"><span>Environments</span><button class="btn small" onClick=${onNewEnv}>+ Env</button></div>
+        ${envs.length === 0 && html`<div class="muted pad small">No environments — create one.</div>`}
+        ${envs.map((e) => html`<${EnvRow} env=${e} key=${e.id} onAction=${onEnvAction} />`)}
+      </div>
+      <div class="side-section grow">
+        <div class="section-head"><span>Sessions</span><button class="btn small" onClick=${onNewSession}>+ Session</button></div>
+        <div class="side-list">
+          ${sessions.length === 0 && html`<div class="muted pad small">No sessions yet.</div>`}
+          ${sessions.map(
+            (s) => html`
+              <div class=${`sess ${s.id === selectedId ? 'active' : ''}`} key=${s.id} onClick=${() => onSelect(s.id)}>
+                <div class="sess-top"><${StatusDot} status=${s.status} /> <span class="sess-title">${s.title || s.id}</span></div>
+                <div class="sess-sub muted">${s.envName} · ${s.turnCount} turn${s.turnCount === 1 ? '' : 's'} · $${(s.costUsd || 0).toFixed(3)}</div>
+              </div>`,
+          )}
         </div>
       </div>
-      <div class="side-list">
-        ${sessions.length === 0 && html`<div class="muted pad">No sessions yet.</div>`}
-        ${sessions.map(
-          (s) => html`
-            <div class=${`sess ${s.id === selectedId ? 'active' : ''}`} key=${s.id} onClick=${() => onSelect(s.id)}>
-              <div class="sess-top"><${StatusDot} status=${s.status} /> <span class="sess-title">${s.title || s.id}</span></div>
-              <div class="sess-sub muted">${s.envName} · ${s.turnCount} turn${s.turnCount === 1 ? '' : 's'} · $${(s.costUsd || 0).toFixed(3)}</div>
-            </div>`,
-        )}
-      </div>
-      <div class="side-foot muted">${envs.length} environment${envs.length === 1 ? '' : 's'}</div>
     </aside>`;
 }
 
@@ -196,9 +224,9 @@ function SessionView({ session, onChanged }) {
     </section>`;
 }
 
-function NewSessionModal({ envs, onClose, onCreate }) {
+function NewSessionModal({ envs, preselect, onClose, onCreate }) {
   const usable = envs.filter((e) => e.status === 'running' || e.status === 'degraded');
-  const [envId, setEnvId] = useState(usable[0] && usable[0].id);
+  const [envId, setEnvId] = useState(preselect || (usable[0] && usable[0].id));
   const [model, setModel] = useState('');
   const [prompt, setPrompt] = useState('');
   const [err, setErr] = useState('');
@@ -229,6 +257,31 @@ function NewSessionModal({ envs, onClose, onCreate }) {
     </div>`;
 }
 
+function NewEnvModal({ onClose, onCreate }) {
+  const [name, setName] = useState('');
+  const [err, setErr] = useState('');
+  const [busy, setBusy] = useState(false);
+  const create = async () => {
+    setBusy(true); setErr('');
+    try { await onCreate(name.trim() || undefined); } catch (e) { setErr(e.message); setBusy(false); }
+  };
+  return html`
+    <div class="modal-bg" onClick=${onClose}>
+      <div class="modal" onClick=${(e) => e.stopPropagation()}>
+        <h3>New environment</h3>
+        <p class="muted">Builds a fresh WordPress devbox (≈1 min) with the target plugin checked out. Leave the name blank to auto-generate.</p>
+        <label>Name (optional)
+          <input value=${name} placeholder="my-devbox (a-z, 0-9, -)" onInput=${(e) => setName(e.target.value)} />
+        </label>
+        ${err && html`<div class="err-msg">${err}</div>`}
+        <div class="modal-foot">
+          <button class="btn ghost" onClick=${onClose}>Cancel</button>
+          <button class="btn" onClick=${create} disabled=${busy}>${busy ? 'Creating…' : 'Create'}</button>
+        </div>
+      </div>
+    </div>`;
+}
+
 function TokenGate({ onSave }) {
   const [val, setVal] = useState(token.get());
   return html`
@@ -246,7 +299,8 @@ function App() {
   const [sessions, setSessions] = useState([]);
   const [envs, setEnvs] = useState([]);
   const [selectedId, setSelectedId] = useState(null);
-  const [showNew, setShowNew] = useState(false);
+  const [newSession, setNewSession] = useState(null); // null | { preselect? }
+  const [showNewEnv, setShowNewEnv] = useState(false);
   const [needToken, setNeedToken] = useState(false);
   const [authed, setAuthed] = useState(!!token.get());
 
@@ -262,19 +316,42 @@ function App() {
   if (needToken || !authed) return html`<${TokenGate} onSave=${() => { setAuthed(true); setNeedToken(false); refresh(); }} />`;
 
   const selected = sessions.find((s) => s.id === selectedId);
+
   const createSession = async (envId, prompt, model) => {
     const s = await api(`/environments/${envId}/sessions`, { method: 'POST', body: JSON.stringify({ prompt, model }) });
-    setShowNew(false); await refresh(); setSelectedId(s.id);
+    setNewSession(null); await refresh(); setSelectedId(s.id);
+  };
+  const createEnv = async (name) => {
+    await api('/environments', { method: 'POST', body: JSON.stringify({ name }) });
+    setShowNewEnv(false); refresh();
+  };
+  const envAction = async (action, env) => {
+    try {
+      if (action === 'session') return setNewSession({ preselect: env.id });
+      if (action === 'start') await api(`/environments/${env.id}/start`, { method: 'POST' });
+      if (action === 'stop') await api(`/environments/${env.id}/stop`, { method: 'POST' });
+      if (action === 'delete') {
+        if (!confirm(`Destroy environment "${env.name}"? This removes its containers and all its data.`)) return;
+        await api(`/environments/${env.id}`, { method: 'DELETE' });
+      }
+      refresh();
+    } catch (e) { alert(`${action} failed: ${e.message}`); }
   };
 
   return html`
     <div class="layout">
       <${Sidebar} sessions=${sessions} envs=${envs} selectedId=${selectedId}
-        onSelect=${setSelectedId} onNew=${() => setShowNew(true)} onSettings=${() => setAuthed(false)} />
+        onSelect=${setSelectedId} onNewSession=${() => setNewSession({})} onNewEnv=${() => setShowNewEnv(true)}
+        onEnvAction=${envAction} onSettings=${() => setAuthed(false)} />
       ${selected
         ? html`<${SessionView} session=${selected} key=${selected.id} onChanged=${refresh} />`
-        : html`<section class="main empty"><div class="muted">Select a session, or <button class="btn" onClick=${() => setShowNew(true)}>start a new one</button>.</div></section>`}
-      ${showNew && html`<${NewSessionModal} envs=${envs} onClose=${() => setShowNew(false)} onCreate=${createSession} />`}
+        : html`<section class="main empty"><div class="muted">
+            ${envs.length === 0
+              ? html`No environments yet. <button class="btn" onClick=${() => setShowNewEnv(true)}>Create an environment</button> to begin.`
+              : html`Select a session, or <button class="btn" onClick=${() => setNewSession({})}>start a new one</button>.`}
+          </div></section>`}
+      ${newSession && html`<${NewSessionModal} envs=${envs} preselect=${newSession.preselect} onClose=${() => setNewSession(null)} onCreate=${createSession} />`}
+      ${showNewEnv && html`<${NewEnvModal} onClose=${() => setShowNewEnv(false)} onCreate=${createEnv} />`}
     </div>`;
 }
 

--- a/server/ui/app.js
+++ b/server/ui/app.js
@@ -1,0 +1,281 @@
+// Devbox Claude-sessions UI — buildless Preact + htm (ES modules from esm.sh).
+import { h, render } from 'https://esm.sh/preact@10.24.3';
+import { useState, useEffect, useRef, useCallback } from 'https://esm.sh/preact@10.24.3/hooks';
+import htm from 'https://esm.sh/htm@3.1.1';
+const html = htm.bind(h);
+
+// ---- API ------------------------------------------------------------------
+const token = {
+  get: () => localStorage.getItem('devbox_token') || '',
+  set: (t) => localStorage.setItem('devbox_token', t || ''),
+};
+async function api(path, opts = {}) {
+  const t = token.get();
+  const res = await fetch(path, {
+    ...opts,
+    headers: { 'content-type': 'application/json', ...(t ? { authorization: `Bearer ${t}` } : {}), ...(opts.headers || {}) },
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const e = new Error(body.error || `${res.status} ${res.statusText}`);
+    e.status = res.status;
+    throw e;
+  }
+  return res.json();
+}
+const streamUrl = (id) => {
+  const t = token.get();
+  return `/sessions/${id}/stream${t ? `?access_token=${encodeURIComponent(t)}` : ''}`;
+};
+
+// ---- stream-json → transcript items --------------------------------------
+function reduce(items, partialRef, evt) {
+  const push = (it) => items.push(it);
+  switch (evt.type) {
+    case 'system':
+      if (evt.subtype === 'init') push({ kind: 'system', text: `session ${String(evt.session_id || '').slice(0, 8)} · ${evt.model || ''}` });
+      break;
+    case 'stream_event': {
+      const d = evt.event && evt.event.delta;
+      if (d && d.type === 'text_delta' && d.text) partialRef.text += d.text;
+      break;
+    }
+    case 'assistant': {
+      partialRef.text = '';
+      const content = (evt.message && evt.message.content) || [];
+      for (const b of content) {
+        if (b.type === 'text' && b.text.trim()) push({ kind: 'assistant', text: b.text });
+        else if (b.type === 'tool_use') push({ kind: 'tool_use', name: b.name, input: b.input });
+      }
+      break;
+    }
+    case 'user': {
+      const content = (evt.message && evt.message.content) || [];
+      for (const b of content) {
+        if (b.type === 'tool_result') push({ kind: 'tool_result', content: b.content });
+      }
+      break;
+    }
+    case 'result':
+      push({ kind: 'result', result: evt.result, cost: evt.total_cost_usd, ms: evt.duration_ms, isError: evt.is_error });
+      break;
+    case 'stderr':
+      if (String(evt.text || '').trim()) push({ kind: 'stderr', text: evt.text });
+      break;
+    case 'control':
+      if (evt.subtype === 'turn-start') push({ kind: 'control', text: '— turn —' });
+      break;
+    case 'raw':
+      push({ kind: 'raw', text: evt.text });
+      break;
+  }
+}
+
+// ---- components -----------------------------------------------------------
+function StatusDot({ status }) {
+  return html`<span class="dot ${status}" title=${status}></span>`;
+}
+
+function Sidebar({ sessions, envs, selectedId, onSelect, onNew, onSettings }) {
+  return html`
+    <aside class="sidebar">
+      <div class="side-head">
+        <strong>Sessions</strong>
+        <div>
+          <button class="btn small" onClick=${onNew}>+ New</button>
+          <button class="btn small ghost" onClick=${onSettings} title="API token">⚙</button>
+        </div>
+      </div>
+      <div class="side-list">
+        ${sessions.length === 0 && html`<div class="muted pad">No sessions yet.</div>`}
+        ${sessions.map(
+          (s) => html`
+            <div class=${`sess ${s.id === selectedId ? 'active' : ''}`} key=${s.id} onClick=${() => onSelect(s.id)}>
+              <div class="sess-top"><${StatusDot} status=${s.status} /> <span class="sess-title">${s.title || s.id}</span></div>
+              <div class="sess-sub muted">${s.envName} · ${s.turnCount} turn${s.turnCount === 1 ? '' : 's'} · $${(s.costUsd || 0).toFixed(3)}</div>
+            </div>`,
+        )}
+      </div>
+      <div class="side-foot muted">${envs.length} environment${envs.length === 1 ? '' : 's'}</div>
+    </aside>`;
+}
+
+function Bubble({ it }) {
+  if (it.kind === 'assistant') return html`<div class="bubble assistant"><pre>${it.text}</pre></div>`;
+  if (it.kind === 'system') return html`<div class="chip">${it.text}</div>`;
+  if (it.kind === 'control') return html`<div class="divider">${it.text}</div>`;
+  if (it.kind === 'tool_use')
+    return html`<details class="tool"><summary>🔧 ${it.name}</summary><pre>${JSON.stringify(it.input, null, 2)}</pre></details>`;
+  if (it.kind === 'tool_result') {
+    const text = typeof it.content === 'string' ? it.content : JSON.stringify(it.content, null, 2);
+    return html`<details class="tool result"><summary>↳ result</summary><pre>${text}</pre></details>`;
+  }
+  if (it.kind === 'result')
+    return html`<div class="result-foot ${it.isError ? 'err' : ''}">✓ done · $${(it.cost || 0).toFixed(4)} · ${Math.round((it.ms || 0))}ms</div>`;
+  if (it.kind === 'stderr') return html`<div class="stderr"><pre>${it.text}</pre></div>`;
+  return html`<div class="raw"><pre>${it.text}</pre></div>`;
+}
+
+function SessionView({ session, onChanged }) {
+  const [items, setItems] = useState([]);
+  const [partial, setPartial] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [input, setInput] = useState('');
+  const partialRef = useRef({ text: '' });
+  const seen = useRef(new Set());
+  const scroller = useRef(null);
+  const id = session.id;
+
+  useEffect(() => {
+    // Reset for the newly-selected session, load history, then go live.
+    setItems([]); setPartial(''); partialRef.current = { text: '' }; seen.current = new Set();
+    let es;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { events } = await api(`/sessions/${id}/transcript?tail=5000`);
+        const arr = [];
+        for (const e of events) { if (e.uuid) seen.current.add(e.uuid); reduce(arr, partialRef.current, e); }
+        if (!cancelled) { setItems(arr.slice()); setPartial(partialRef.current.text); }
+      } catch { /* fresh session, no transcript */ }
+      if (cancelled) return;
+      es = new EventSource(streamUrl(id));
+      es.onmessage = (m) => {
+        let evt; try { evt = JSON.parse(m.data); } catch { return; }
+        if (evt.type === 'control' && evt.subtype === 'snapshot') return;
+        if (evt.uuid && seen.current.has(evt.uuid)) return;
+        if (evt.uuid) seen.current.add(evt.uuid);
+        if (evt.type === 'control' && evt.subtype === 'turn-end') { setBusy(false); onChanged && onChanged(); }
+        setItems((prev) => { const next = prev.slice(); reduce(next, partialRef.current, evt); return next; });
+        setPartial(partialRef.current.text);
+      };
+      es.onerror = () => {/* EventSource auto-reconnects */};
+    })();
+    return () => { cancelled = true; if (es) es.close(); };
+  }, [id]);
+
+  useEffect(() => { if (scroller.current) scroller.current.scrollTop = scroller.current.scrollHeight; }, [items, partial]);
+
+  const running = busy || session.status === 'running';
+  const send = useCallback(async () => {
+    const prompt = input.trim();
+    if (!prompt || running) return;
+    setInput(''); setBusy(true);
+    try { await api(`/sessions/${id}/messages`, { method: 'POST', body: JSON.stringify({ prompt }) }); onChanged && onChanged(); }
+    catch (e) { setBusy(false); alert(`Send failed: ${e.message}`); }
+  }, [input, running, id]);
+  const interrupt = async () => { try { await api(`/sessions/${id}/interrupt`, { method: 'POST' }); } catch (e) { alert(e.message); } };
+
+  return html`
+    <section class="main">
+      <header class="bar">
+        <div><${StatusDot} status=${session.status} /> <strong>${session.title || id}</strong></div>
+        <div class="bar-meta muted">
+          ${session.envName} · ${session.model || 'default model'} · $${(session.costUsd || 0).toFixed(4)}
+          ${session.claudeSessionId && html`· <code title="claude session id">${session.claudeSessionId.slice(0, 8)}</code>`}
+        </div>
+      </header>
+      ${session.sshResumeHint && html`<div class="ssh muted" onClick=${() => navigator.clipboard?.writeText(session.sshResumeHint)} title="click to copy">SSH resume: <code>${session.sshResumeHint}</code></div>`}
+      <div class="transcript" ref=${scroller}>
+        ${items.map((it, i) => html`<${Bubble} it=${it} key=${i} />`)}
+        ${partial && html`<div class="bubble assistant live"><pre>${partial}</pre><span class="cursor">▍</span></div>`}
+        ${running && !partial && html`<div class="muted pad">…thinking</div>`}
+      </div>
+      <footer class="composer">
+        <textarea
+          value=${input}
+          placeholder=${running ? 'Turn in progress…' : 'Message Claude (Enter to send, Shift+Enter for newline)'}
+          disabled=${running}
+          onInput=${(e) => setInput(e.target.value)}
+          onKeyDown=${(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); } }}
+        ></textarea>
+        ${running
+          ? html`<button class="btn warn" onClick=${interrupt}>Interrupt</button>`
+          : html`<button class="btn" onClick=${send} disabled=${!input.trim()}>Send</button>`}
+      </footer>
+    </section>`;
+}
+
+function NewSessionModal({ envs, onClose, onCreate }) {
+  const usable = envs.filter((e) => e.status === 'running' || e.status === 'degraded');
+  const [envId, setEnvId] = useState(usable[0] && usable[0].id);
+  const [model, setModel] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [err, setErr] = useState('');
+  const create = async () => {
+    if (!envId || !prompt.trim()) return;
+    try { await onCreate(envId, prompt.trim(), model.trim() || undefined); } catch (e) { setErr(e.message); }
+  };
+  return html`
+    <div class="modal-bg" onClick=${onClose}>
+      <div class="modal" onClick=${(e) => e.stopPropagation()}>
+        <h3>New Claude session</h3>
+        ${usable.length === 0 && html`<div class="muted">No running environments. Create/start one first.</div>`}
+        <label>Environment
+          <select value=${envId} onChange=${(e) => setEnvId(e.target.value)}>
+            ${usable.map((e) => html`<option value=${e.id} key=${e.id}>${e.name} (:${e.port})</option>`)}
+          </select>
+        </label>
+        <label>Model <input value=${model} placeholder="default (e.g. claude-sonnet-4-6)" onInput=${(e) => setModel(e.target.value)} /></label>
+        <label>First message
+          <textarea value=${prompt} rows="4" onInput=${(e) => setPrompt(e.target.value)} placeholder="Describe the task…"></textarea>
+        </label>
+        ${err && html`<div class="err-msg">${err}</div>`}
+        <div class="modal-foot">
+          <button class="btn ghost" onClick=${onClose}>Cancel</button>
+          <button class="btn" onClick=${create} disabled=${!envId || !prompt.trim()}>Create</button>
+        </div>
+      </div>
+    </div>`;
+}
+
+function TokenGate({ onSave }) {
+  const [val, setVal] = useState(token.get());
+  return html`
+    <div class="modal-bg">
+      <div class="modal">
+        <h3>API token</h3>
+        <p class="muted">Enter the server's <code>DEVBOX_API_TOKEN</code> (stored in this browser only).</p>
+        <input type="password" value=${val} onInput=${(e) => setVal(e.target.value)} placeholder="Bearer token" />
+        <div class="modal-foot"><button class="btn" onClick=${() => { token.set(val); onSave(); }}>Save</button></div>
+      </div>
+    </div>`;
+}
+
+function App() {
+  const [sessions, setSessions] = useState([]);
+  const [envs, setEnvs] = useState([]);
+  const [selectedId, setSelectedId] = useState(null);
+  const [showNew, setShowNew] = useState(false);
+  const [needToken, setNeedToken] = useState(false);
+  const [authed, setAuthed] = useState(!!token.get());
+
+  const refresh = useCallback(async () => {
+    try {
+      const [s, e] = await Promise.all([api('/sessions'), api('/environments')]);
+      setSessions(s.sessions); setEnvs(e.environments); setNeedToken(false);
+    } catch (err) { if (err.status === 401) setNeedToken(true); }
+  }, []);
+
+  useEffect(() => { if (authed) { refresh(); const t = setInterval(refresh, 3000); return () => clearInterval(t); } }, [authed, refresh]);
+
+  if (needToken || !authed) return html`<${TokenGate} onSave=${() => { setAuthed(true); setNeedToken(false); refresh(); }} />`;
+
+  const selected = sessions.find((s) => s.id === selectedId);
+  const createSession = async (envId, prompt, model) => {
+    const s = await api(`/environments/${envId}/sessions`, { method: 'POST', body: JSON.stringify({ prompt, model }) });
+    setShowNew(false); await refresh(); setSelectedId(s.id);
+  };
+
+  return html`
+    <div class="layout">
+      <${Sidebar} sessions=${sessions} envs=${envs} selectedId=${selectedId}
+        onSelect=${setSelectedId} onNew=${() => setShowNew(true)} onSettings=${() => setAuthed(false)} />
+      ${selected
+        ? html`<${SessionView} session=${selected} key=${selected.id} onChanged=${refresh} />`
+        : html`<section class="main empty"><div class="muted">Select a session, or <button class="btn" onClick=${() => setShowNew(true)}>start a new one</button>.</div></section>`}
+      ${showNew && html`<${NewSessionModal} envs=${envs} onClose=${() => setShowNew(false)} onCreate=${createSession} />`}
+    </div>`;
+}
+
+render(html`<${App} />`, document.getElementById('root'));

--- a/server/ui/index.html
+++ b/server/ui/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Devbox · Claude sessions</title>
+    <link rel="stylesheet" href="/ui/style.css" />
+  </head>
+  <body>
+    <div id="root">Loading…</div>
+    <!-- Buildless SPA: Preact + htm loaded as ES modules from esm.sh.
+         (To run fully offline, vendor these into /ui/vendor/ and repoint.) -->
+    <script type="module" src="/ui/app.js"></script>
+  </body>
+</html>

--- a/server/ui/style.css
+++ b/server/ui/style.css
@@ -1,0 +1,84 @@
+:root {
+  --bg: #0f1115; --panel: #161922; --panel2: #1c2030; --line: #272c3a;
+  --text: #e6e8ee; --muted: #8b91a3; --accent: #6ea8fe; --accent2: #2b3350;
+  --green: #3fb950; --amber: #d29922; --red: #f85149; --grey: #6e7681;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; height: 100%; background: var(--bg); color: var(--text);
+  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+#root, .layout { height: 100vh; }
+.layout { display: grid; grid-template-columns: 300px 1fr; }
+.muted { color: var(--muted); }
+.pad { padding: 12px; }
+code { background: var(--panel2); padding: 1px 5px; border-radius: 4px; font-size: 12px; }
+pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12.5px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+/* sidebar */
+.sidebar { background: var(--panel); border-right: 1px solid var(--line); display: flex; flex-direction: column; min-height: 0; }
+.side-head { display: flex; justify-content: space-between; align-items: center; padding: 12px; border-bottom: 1px solid var(--line); }
+.side-list { overflow-y: auto; flex: 1; }
+.side-foot { padding: 8px 12px; border-top: 1px solid var(--line); font-size: 12px; }
+.sess { padding: 10px 12px; border-bottom: 1px solid var(--line); cursor: pointer; }
+.sess:hover { background: var(--panel2); }
+.sess.active { background: var(--accent2); }
+.sess-top { display: flex; align-items: center; gap: 7px; }
+.sess-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.sess-sub { font-size: 12px; margin-top: 2px; }
+
+/* main */
+.main { display: flex; flex-direction: column; min-height: 0; }
+.main.empty { align-items: center; justify-content: center; }
+.bar { display: flex; justify-content: space-between; align-items: center; gap: 12px;
+  padding: 12px 16px; border-bottom: 1px solid var(--line); background: var(--panel); }
+.bar-meta { font-size: 12px; }
+.ssh { padding: 6px 16px; border-bottom: 1px solid var(--line); font-size: 12px; cursor: pointer; }
+.ssh:hover { background: var(--panel2); }
+.transcript { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 10px; }
+
+.bubble { max-width: 80%; padding: 10px 12px; border-radius: 10px; }
+.bubble.assistant { background: var(--panel2); border: 1px solid var(--line); align-self: flex-start; }
+.bubble.live { border-color: var(--accent); }
+.cursor { animation: blink 1s steps(2) infinite; color: var(--accent); }
+@keyframes blink { 50% { opacity: 0; } }
+.chip { align-self: center; font-size: 11px; color: var(--muted); background: var(--panel); border: 1px solid var(--line); padding: 2px 8px; border-radius: 99px; }
+.divider { align-self: center; color: var(--grey); font-size: 11px; }
+.tool { align-self: flex-start; max-width: 80%; background: #14171f; border: 1px solid var(--line); border-radius: 8px; padding: 6px 10px; }
+.tool.result { border-style: dashed; }
+.tool summary { cursor: pointer; color: var(--accent); font-size: 12px; }
+.tool pre { margin-top: 8px; max-height: 320px; overflow: auto; }
+.result-foot { align-self: center; color: var(--green); font-size: 12px; }
+.result-foot.err { color: var(--red); }
+.stderr { align-self: flex-start; max-width: 80%; }
+.stderr pre { color: var(--amber); }
+.raw pre { color: var(--grey); }
+
+/* composer */
+.composer { display: flex; gap: 8px; padding: 12px 16px; border-top: 1px solid var(--line); background: var(--panel); }
+.composer textarea { flex: 1; resize: vertical; min-height: 44px; max-height: 200px; background: var(--bg);
+  color: var(--text); border: 1px solid var(--line); border-radius: 8px; padding: 10px; font: inherit; }
+
+/* buttons */
+.btn { background: var(--accent); color: #07101f; border: 0; border-radius: 8px; padding: 9px 14px; font-weight: 600; cursor: pointer; }
+.btn:hover { filter: brightness(1.08); }
+.btn:disabled { opacity: 0.45; cursor: not-allowed; }
+.btn.small { padding: 4px 9px; font-size: 12px; }
+.btn.ghost { background: var(--panel2); color: var(--text); }
+.btn.warn { background: var(--amber); color: #1a1300; }
+
+/* status dots */
+.dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; background: var(--grey); flex: none; }
+.dot.running { background: var(--accent); box-shadow: 0 0 0 3px rgba(110,168,254,.2); }
+.dot.idle { background: var(--green); }
+.dot.degraded, .dot.interrupted { background: var(--amber); }
+.dot.error, .dot.failed, .dot.env-destroyed { background: var(--red); }
+.dot.stopped { background: var(--grey); }
+
+/* modal */
+.modal-bg { position: fixed; inset: 0; background: rgba(0,0,0,.55); display: flex; align-items: center; justify-content: center; z-index: 10; }
+.modal { background: var(--panel); border: 1px solid var(--line); border-radius: 12px; padding: 20px; width: 460px; max-width: 92vw; }
+.modal h3 { margin: 0 0 12px; }
+.modal label { display: block; margin: 12px 0 4px; font-size: 13px; color: var(--muted); }
+.modal input, .modal select, .modal textarea { width: 100%; background: var(--bg); color: var(--text);
+  border: 1px solid var(--line); border-radius: 8px; padding: 9px; font: inherit; }
+.modal-foot { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; }
+.err-msg { color: var(--red); margin-top: 10px; font-size: 13px; }

--- a/server/ui/style.css
+++ b/server/ui/style.css
@@ -17,7 +17,21 @@ pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12.5px/1.5
 .sidebar { background: var(--panel); border-right: 1px solid var(--line); display: flex; flex-direction: column; min-height: 0; }
 .side-head { display: flex; justify-content: space-between; align-items: center; padding: 12px; border-bottom: 1px solid var(--line); }
 .side-list { overflow-y: auto; flex: 1; }
-.side-foot { padding: 8px 12px; border-top: 1px solid var(--line); font-size: 12px; }
+.side-section { border-bottom: 1px solid var(--line); display: flex; flex-direction: column; min-height: 0; }
+.side-section.grow { flex: 1; }
+.side-section.grow .side-list { max-height: none; }
+.section-head { display: flex; justify-content: space-between; align-items: center; padding: 8px 12px; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+.small { font-size: 12px; }
+
+/* environment rows */
+.env { padding: 7px 12px; border-top: 1px solid var(--line); }
+.env-top { display: flex; align-items: center; gap: 7px; }
+.env-name { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.env-port { margin-left: auto; color: var(--accent); font-size: 12px; text-decoration: none; }
+.env-actions { display: flex; gap: 10px; margin-top: 3px; padding-left: 16px; }
+.lnk { background: none; border: 0; color: var(--accent); cursor: pointer; font-size: 12px; padding: 0; }
+.lnk:hover { text-decoration: underline; }
+.lnk.danger { color: var(--red); margin-left: auto; }
 .sess { padding: 10px 12px; border-bottom: 1px solid var(--line); cursor: pointer; }
 .sess:hover { background: var(--panel2); }
 .sess.active { background: var(--accent2); }

--- a/templates/scripts/in-workspace.sh
+++ b/templates/scripts/in-workspace.sh
@@ -66,7 +66,15 @@ esac
 # Export so the values are inherited by the container via name-only -e (off argv).
 export CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_TOKEN"
 export CURSOR_API_KEY="$CURSOR_KEY"
-exec docker compose exec \
+
+# Allocate a TTY only when we actually have one. Interactive use (`npm run claude`,
+# `npm run bash`) keeps its TTY; piped/headless callers (e.g. driving
+# `claude -p --output-format stream-json` from a script or server) get a clean,
+# non-TTY pipe — without this, `docker compose exec` errors "the input device is
+# not a TTY".
+TTY_FLAG=""
+[ -t 0 ] || TTY_FLAG="-T"
+exec docker compose exec $TTY_FLAG \
   -e CLAUDE_CODE_OAUTH_TOKEN \
   -e CURSOR_API_KEY \
   workspace "$@"

--- a/templates/scripts/install-skills.sh
+++ b/templates/scripts/install-skills.sh
@@ -20,6 +20,14 @@ if [ -d skills ] && [ -n "$(ls -A skills 2>/dev/null)" ]; then
     mkdir -p "$dest"
     cp -R skills/. "$dest"/
   done
+  # The host-side copy above is owned by whoever ran `npm run setup` — which is
+  # root when this runs under the devbox control server. The agents run as the
+  # node user (uid 1000) and need to add/symlink their OWN skills at runtime, so
+  # hand the skill dirs to node. Done inside the container as root so it works
+  # regardless of the host user's uid. Non-fatal (container may be down on a
+  # standalone re-run).
+  docker compose exec -T -u root workspace \
+    chown -R node:node /home/node/.claude/skills /home/node/.cursor/skills >/dev/null 2>&1 || true
   echo "✓ Skills installed into the workspace (~/.claude/skills and ~/.cursor/skills)."
 else
   echo "→ No skills/ to install — skipping."


### PR DESCRIPTION
## What

A small HTTP control server (new, **unpublished** `server/` dir) that fires up `create-wp-local-dev-agent-sandbox` environments on one Docker host and runs a **named Cursor self-hosted worker** in each — so you can dispatch work to a specific box via `@cursor <name> …` on GitHub and have it commit/push.

```bash
cd server
CURSOR_API_KEY=… GITHUB_TOKEN=… DEVBOX_API_TOKEN=secret npm start

curl -H 'Authorization: Bearer secret' -XPOST localhost:4000/environments -d '{"name":"my-devbox"}'
# → 202 {id,name:"my-devbox",port,wpUrl,status:"scaffolding"}  … then walks to running
```

## Design (matches the approved plan)

- **HTTP REST, zero deps** (bare `node:http`). It controls Docker and launches agents, so the supply-chain surface is kept at zero. Localhost-bound by default; optional `DEVBOX_API_TOKEN` bearer auth (constant-time compare).
- **Named workers only** — `cursor-agent worker --name "<name>" --worker-dir /home/node start`, launched detached in the workspace container, logging to `/home/node/.worker.log`. (Pool workers are enterprise-only; we don't use them.) Worker connects **outbound only — no inbound port**.
- **Shared, server-config credentials** (`CURSOR_API_KEY`, `GITHUB_TOKEN`) — never accepted in request bodies, returned, stored, or logged (redacting logger; secrets passed to children by env name, off argv, mirroring the repo's `in-workspace.sh`).
- **Pipeline:** allocate (unique name + free port under a mutex, with a port bind-probe) → scaffold (`--scaffold-only`) → `npm run setup` (async, bounded by a build semaphore, `COMPOSE_PROJECT_NAME` pinned to `devbox-<name>` so the env's own scripts and the server agree) → `gh auth` (non-fatal) → start worker → `running`. A JSON registry is the source of truth (atomic temp+rename writes).
- **Supervision:** a reconcile loop (boot + ~45s) relaunches a worker whose process died while its stack is up, and reconciles status after a server restart.
- **Status** reconciles the registry + `docker compose ps` + worker liveness; container-up vs worker-alive are surfaced independently (up-but-worker-dead → `degraded`).
- **Endpoints:** `POST/GET/DELETE /environments(/:id)`, `GET /environments/:id/logs`, `POST …/stop`, `POST …/start`, `GET /host` (host pressure).

## Layout
```
server/
  package.json (private), README.md, .gitignore
  src/{index,config,http,routes,manager,allocator,registry,docker,worker,gitauth,status,fleet,log}.js
```
Excluded from the npm package by the root `files` allowlist (confirmed via `npm pack --dry-run`).

## Verified end-to-end (real Docker, placeholder creds)
- ✅ Create → **full** WP provisioning completes (WP install, Agent Connector, MCP for both agents, skills, `cursor-wp-mcp-helper`), all 4 services up, WP serves 302.
- ✅ Worker launches in-container, reads `CURSOR_API_KEY`, and (with a fake key) fails auth → status `degraded`; the reconcile loop relaunches it — exactly the designed behavior. With a real key it connects → `running`.
- ✅ **Concurrent** creates get unique names **and** ports (no collision; mutex works).
- ✅ `stop` → containers down/WP unreachable; `start` → back up, worker relaunched.
- ✅ **Restart-survival:** killing + relaunching the server reconciles all envs from disk + live Docker.
- ✅ `DELETE` tears down containers + volumes + the env dir; registry empties; no `devbox-` projects left.
- ✅ Auth (401 without token), input validation (bad name → 400), `/host`, `/logs`.

**Needs the operator's real credentials to fully exercise:** the worker connecting to Cursor cloud (flips `degraded`→`running`) and `git push` auth — both fail gracefully and are surfaced.

## Scale note
Each env ≈ 4 containers (MariaDB + Apache + Node + headless Chromium). Hundreds *running simultaneously* on one box is unrealistic — the registry holds 100s but the running working-set is host-bounded. Shipped mitigations: `MAX_ENVIRONMENTS` cap, build semaphore, `GET /host` pressure, `stop` for idle envs. Documented fast-follow: build the identical workspace image once and reference by tag instead of per-env `build:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)