### PR TITLE
fix(scaffolder): set FS_METHOD=direct so WP_Filesystem works in the sandbox

### DIFF
--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -37,6 +37,13 @@ services:
             define( 'WP_HOME', $$scheme . '://' . $$_SERVER['HTTP_HOST'] );
             define( 'WP_SITEURL', $$scheme . '://' . $$_SERVER['HTTP_HOST'] );
         }
+        // Use direct PHP filesystem access — no FTP-credentials prompt. WordPress
+        // otherwise guesses the method by comparing file ownership against the web
+        // server's uid; in this sandbox that heuristic can pick a non-'direct'
+        // method, so WP_Filesystem fails to init and plugins that read/write files
+        // through it (e.g. a fonts.json reader) fatal. Safe here: throwaway local
+        // sandbox, and the web container can read/write the bind-mounted tree.
+        define( 'FS_METHOD', 'direct' );
     ports:
       - "${WP_PORT}:80"
     volumes:


### PR DESCRIPTION
## Symptom
A plugin's front end fatals reading its `fonts.json` (works fine via WP-CLI). Agents were diagnosing it as a sandbox file-ownership mismatch and hand-patching `FS_METHOD direct` into individual envs' `wp-config.php`.

## Cause
WordPress decides how to touch the filesystem via `get_filesystem_method()`, which compares the web server's uid against file ownership. In the devbox that heuristic can land on a non-`direct` method, so `WP_Filesystem()` doesn't initialize → plugins that read/write through it return null/false and fatal. (Confirmed in a live env: PHP/Apache runs as **root** while the WordPress tree is owned by uid 1000, so the ownership check is mismatched.)

## Fix
Define `FS_METHOD=direct` in the generated `wp-config.php` via `WORDPRESS_CONFIG_EXTRA` in `templates/docker-compose.yml`, so every scaffolded env uses direct PHP filesystem access. It's the standard containerized-WP setting and exactly the workaround agents were applying by hand — now baked in. Safe here: throwaway local sandbox, web container can read/write the bind-mounted tree.

Applies to **newly created** envs. Existing envs can add the same line to their `wp-config.php` (or `npm run reset`).

> Deeper note (not fixed here): `APACHE_RUN_USER=#1000` isn't taking effect in the current WordPress image — Apache workers run as **root**, so PHP-created files (uploads, plugin logs) end up root-owned and not editable by the workspace `node` user. `FS_METHOD=direct` sidesteps the fonts.json class; making PHP actually run as uid 1000 is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)