### PR TITLE
feat(scaffolder): install Default Abilities companion + expose built-in abilities over MCP

### DIFF
--- a/templates/scripts/install-agent-connector.sh
+++ b/templates/scripts/install-agent-connector.sh
@@ -1,33 +1,39 @@
 #!/usr/bin/env bash
 #
 # Install & enable Agent Connector for WP (https://github.com/soflyy/agent-connector-for-wp)
-# — the plugin that exposes root-equivalent abilities (shell, WP-CLI, PHP eval,
-# filesystem) to agents over MCP. It bundles wordpress/mcp-adapter (no separate
-# "MCP Adapter" plugin needed) and registers its abilities through the WordPress
-# Abilities API, which is in core as of WordPress 7.0. Run via `npm run setup`.
-# Idempotent.
+# plus its Default Abilities companion, so agents get the root-equivalent built-in
+# abilities (shell, WP-CLI, PHP eval, filesystem, env-inspect, admin-login-link)
+# over MCP. The main plugin is the secured MCP gateway (it bundles
+# wordpress/mcp-adapter); the abilities now live in a separate companion plugin
+# and are off until you opt in. Run via `npm run setup`. Idempotent.
 #
 set -euo pipefail
 
 # This script lives in scripts/ — operate from the project root.
 cd "$(dirname "$0")/.."
 
-echo "→ Enabling Agent Connector for WP…"
-# The plugin is inert until explicitly switched on. That switch is a WordPress
-# option (flipped from its Settings screen in the admin) — there is no wp-config
-# constant anymore. We set the option directly: this is a trusted, throwaway dev
-# sandbox (Claude already runs here with --dangerously-skip-permissions). The
-# stack marks the site as WP_ENVIRONMENT_TYPE=local (see docker-compose.yml), so
-# the enable toggle alone activates it — no production override needed.
-docker compose exec -T workspace wp option update agent_connector_for_wp_enabled 1 >/dev/null
-
-# Install from the latest packaged release zip — vendor/ (incl. the bundled
-# mcp-adapter) is baked in, so no composer step is needed. The /releases/latest/
-# URL always resolves to the newest release's asset, so we never pin a version.
-# --force reinstalls cleanly on re-run; --activate activates the plugin (the
-# option set above is what actually exposes its abilities).
+# Install the gateway from its latest release zip (vendor/ + mcp-adapter baked
+# in, so no composer step). --force reinstalls cleanly on re-run.
+echo "→ Installing Agent Connector for WP (MCP gateway)…"
 docker compose exec -T workspace wp plugin install \
   https://github.com/soflyy/agent-connector-for-wp/releases/latest/download/agent-connector-for-wp.zip \
   --force --activate
 
-echo "✓ Agent Connector for WP enabled (shell, WP-CLI, PHP eval, filesystem)."
+# Install the Default Abilities companion (the built-in abilities now live here).
+# It declares `Requires Plugins: agent-connector-for-wp`, so the gateway must be
+# active first (it is, above). Pinned `default-abilities-plugin` release tag.
+echo "→ Installing the Default Abilities companion…"
+docker compose exec -T workspace wp plugin install \
+  https://github.com/soflyy/agent-connector-for-wp/releases/download/default-abilities-plugin/default-abilities-plugin.zip \
+  --force --activate
+
+# Switch it on. Two options set directly — the equivalent of the Connection
+# screen's checkboxes — fine here: a trusted, throwaway dev sandbox marked
+# WP_ENVIRONMENT_TYPE=local (Claude already runs with --dangerously-skip-permissions):
+#   agent_connector_for_wp_enabled            → the gateway master switch
+#   agent_connector_for_wp_builtin_abilities  → "Expose the built-in abilities over MCP"
+echo "→ Enabling the gateway and exposing the built-in abilities over MCP…"
+docker compose exec -T workspace wp option update agent_connector_for_wp_enabled 1 >/dev/null
+docker compose exec -T workspace wp option update agent_connector_for_wp_builtin_abilities 1 >/dev/null
+
+echo "✓ Agent Connector for WP + Default Abilities enabled (shell, WP-CLI, PHP eval, filesystem) over MCP."


### PR DESCRIPTION
## What

Agent Connector for WP split its built-in abilities into a separate **Default Abilities** companion plugin (soflyy/agent-connector-for-wp#45); the main plugin is now just the MCP gateway. This updates `templates/scripts/install-agent-connector.sh` so fresh sandboxes get the built-in abilities over MCP out of the box.

The script now:
- installs + activates the gateway (`agent-connector-for-wp`, latest release)
- installs + activates the **Default Abilities** companion (`default-abilities-plugin` release tag; it declares `Requires Plugins: agent-connector-for-wp`)
- sets the two opt-in options — the Connection screen's checkboxes:
  - `agent_connector_for_wp_enabled` = `1` (gateway master switch)
  - `agent_connector_for_wp_builtin_abilities` = `1` ("Expose the built-in abilities over MCP")

## Why

Built-in abilities are now off until you opt in. Without this, a fresh env has the gateway but no abilities exposed — so `shell`, `wp-cli`, `php-eval`, filesystem, `env-inspect`, and `create-admin-login-link` aren't reachable over MCP until manually enabled.

## Verification

On a fresh env: both plugins active, both options set, all 10 `agent-connector-for-wp/*` abilities registered (`wp_get_abilities`) and active in both the wp-cli and Apache contexts; a raw `discover` over MCP returned all 10.

⚠️ **To confirm on merge:** `discover` was intermittent across rapid repeat calls in my testing (some calls returned empty). The install + enable logic this PR changes is verified; the intermittent MCP `discover` behavior should be reproduced/ironed out separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)