### PR TITLE
Setup script, wp-config defines & ordered plugin activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,19 @@ npx create-wp-local-dev-agent-sandbox my-site
 # choose a host port (default 8080):
 npx create-wp-local-dev-agent-sandbox my-site --port=8090
 
+# run a setup script in the workspace, add wp-config constants, and activate
+# plugins (in order) it drops into wp-content — see "Customizing setup" below:
+npx create-wp-local-dev-agent-sandbox my-site \
+  --setup-script=./setup.sh \
+  --defines=./defines.json \
+  --activate=oxygen-elements,breakdance-elements,breakdance-main
+
 # just write files, don't touch Docker:
 npx create-wp-local-dev-agent-sandbox my-site --scaffold-only
 ```
+
+> Through `npm create`, put the flags after `--`, e.g.
+> `npm create wp-local-dev-agent-sandbox@latest my-site -- --port=8090`.
 
 Docker must be running. When it finishes you have a live site at **http://localhost:8080** — log in at `/wp-admin` with `admin` / `password` (the default; configurable in `.env` via `WP_ADMIN_USER` / `WP_ADMIN_PASSWORD`). Then:
 
@@ -43,15 +53,68 @@ my-site/
 ├── .env                    # DB creds + WP_PORT
 ├── .gitignore              # ignores the bind-mounted data dirs
 ├── package.json            # the npm-scripts UX (setup/start/stop/bash/claude/cursor/wp/reset)
-├── sandbox.config.json     # plugins to install on `npm run setup` (+ future params)
+├── sandbox.config.json     # plugins to install, wp-config defines, setup script & activation order for `npm run setup`
 ├── php/php.ini             # custom PHP overrides for the wordpress container (upload limits, etc.)
-├── scripts/                # provisioning steps run by initial-setup.sh (install-wp, plugins, root-for-agents, mcp, skills) + in-workspace.sh (credential-resolving launcher for bash/claude/cursor)
+├── scripts/                # provisioning steps run by initial-setup.sh (install-wp, defines, user setup script, plugins, agent-connector, mcp, skills) + in-workspace.sh (credential-resolving launcher for bash/claude/cursor)
 ├── bin/                    # cursor-wp-mcp-helper — Node CLI for the WordPress MCP server, baked onto the workspace PATH
 ├── skills/                 # agent skills installed into the workspace (wordpress-dev, cursor-wp-mcp-helper) — copied to both ~/.claude/skills and ~/.cursor/skills
 └── README.md
 ```
 
 WordPress data, the database, and the workspace home are bind-mounted into `wp/`, `db/`, and `workspace/` in the project, so everything is visible on your machine and survives restarts.
+
+## Customizing setup
+
+Beyond the bundled plugins, you can run your own setup script, add `wp-config.php` constants, and activate plugins in a chosen order. All three are flags on the create command and are persisted into the project's `sandbox.config.json`, so they re-run on `npm run setup` (and `npm run reset`) — the project stays self-contained.
+
+```bash
+npx create-wp-local-dev-agent-sandbox my-site \
+  --port=8090 \
+  --setup-script=./setup.sh \
+  --defines=./defines.json \
+  --activate=oxygen-elements,breakdance-elements,breakdance-main
+```
+
+On the first `npm run setup` these run **in order**: install WordPress → apply `--defines` → run `--setup-script` → install bundled `plugins` and activate the `--activate` list. So a plugin your script drops into `wp-content` exists by the time it's activated.
+
+- **`--setup-script=PATH`** — a shell script run **inside the workspace container as `node`** — the same environment `npm run bash` gives you, with the working directory at `/home/node` and WordPress at `/home/node/wp`. Use it to clone a repo and run its installer, build a plugin/theme, seed content, etc. It's piped in over stdin, so `gh repo clone <repo>` lands a checkout right next to `./wp`. `npm run setup` may run it again, so guard side effects (e.g. skip a clone when the directory already exists). To clone a **private** repo, authenticate `gh` once inside (`npm run bash` → `gh auth login`; it persists in `workspace/`), or export `GH_TOKEN` on your host before setup — it's forwarded into the container.
+
+- **`--defines=PATH`** — a JSON file of `{ "WP_CONST": value }` pairs written into `wp-config.php` as constants via `wp config set`, which places them correctly (above the "stop editing" marker) and updates them in place on re-run. Booleans and numbers become raw PHP literals (`define( 'WP_DEBUG', true )`); strings are quoted (`define( 'WP_MEMORY_LIMIT', '512M' )`). Use `{ "value": "...", "raw": true }` to force a raw (unquoted) value.
+
+  ```json
+  {
+    "WP_DEBUG": true,
+    "WP_MEMORY_LIMIT": "512M"
+  }
+  ```
+
+  > **Why key:value rather than a raw `wp-config` snippet?** You don't have to worry about *where* in the file each `define()` lands or about duplicating one that already exists — `wp config set` handles placement and is idempotent.
+
+- **`--activate=a,b,c`** — plugin slugs to activate, in this exact order, **after** the setup script. This is for plugins that are already present (e.g. dropped into `wp-content` by your script) — there's nothing to download, just activate. For plugins installed from wordpress.org or a `.zip`, use `plugins` in `sandbox.config.json` (see below) instead.
+
+A worked example (Breakdance) lives in [`examples/`](examples/).
+
+### `sandbox.config.json`
+
+The flags above just write into this file; you can also edit it directly and `npm run reset`:
+
+```json
+{
+  "plugins": [
+    "ai",
+    { "source": "akismet", "activate": false, "version": "5.3" },
+    { "source": "https://example.com/plugin.zip", "activate": true }
+  ],
+  "defines": { "WP_DEBUG": true, "WP_MEMORY_LIMIT": "512M" },
+  "setupScript": "scripts/user-setup.sh",
+  "activate": ["oxygen-elements", "breakdance-elements", "breakdance-main"]
+}
+```
+
+- `plugins` — installed (and activated unless `"activate": false`) from a wordpress.org slug or a URL/path to a `.zip`. `version` is optional (slugs only).
+- `defines` — `wp-config.php` constants (see `--defines` above).
+- `setupScript` — project-relative path to the script run in the workspace (`--setup-script` copies your file here as `scripts/user-setup.sh`).
+- `activate` — slugs activated in order, after `setupScript` (see `--activate` above).
 
 ## Requirements
 
@@ -118,6 +181,22 @@ This package is also a library. If you ship a WordPress plugin (or a stack of th
    They get the full sandbox (WordPress + Claude Code + Cursor CLI + the WordPress & Playwright MCP servers + Root for Agents) **plus your plugins**, installed and activated on the first `npm run setup`.
 
 Your preset's plugins are **appended** to the defaults, so `mcp-adapter` and `root-for-agents` are always present. Everything else — templates, Docker setup, the `npm run …` UX — is inherited from this package, so improvements here flow to every `create-<brand>` that depends on it.
+
+A preset can also carry the same customizations as the CLI flags above — they're merged into the generated `sandbox.config.json` (and combine with anything the end user passes):
+
+```js
+create({
+  preset: {
+    name: 'breakdance-wp',
+    plugins: [{ source: 'https://example.com/breakdance.zip', activate: true }],
+    defines: { WP_DEBUG: true, WP_MEMORY_LIMIT: '512M' },
+    activate: ['oxygen-elements', 'breakdance-elements', 'breakdance-main'],
+    setupScript: 'set -euo pipefail\ncd /home/node\n# …clone/build/seed here…\n',
+  },
+});
+```
+
+`setupScript` here is the script's **contents** (a string), written into the project as `scripts/user-setup.sh`. A user's `--setup-script=PATH` overrides it.
 
 > **Premium plugins:** a *public* `create-<brand>` can only bake in a `.zip` URL that's publicly reachable. For licensed plugins, point at a gated endpoint you control, or have your wrapper read the URL from a prompt or an env var instead of hardcoding it.
 

--- a/engine.js
+++ b/engine.js
@@ -30,10 +30,14 @@ const ALLOWED_EXISTING = new Set([
 ]);
 
 function parseArgs(argv) {
-  const out = { dir: null, port: '8080', setup: true };
+  const out = { dir: null, port: '8080', setup: true, setupScript: null, defines: null, activate: [] };
   for (const a of argv) {
     if (a.startsWith('--port=')) out.port = a.slice('--port='.length);
-    else if (a === '--scaffold-only') out.setup = false;
+    else if (a.startsWith('--setup-script=')) out.setupScript = a.slice('--setup-script='.length);
+    else if (a.startsWith('--defines=')) out.defines = a.slice('--defines='.length);
+    else if (a.startsWith('--activate=')) {
+      out.activate = a.slice('--activate='.length).split(',').map((s) => s.trim()).filter(Boolean);
+    } else if (a === '--scaffold-only') out.setup = false;
     else if (a === '-h' || a === '--help') out.help = true;
     else if (!a.startsWith('-') && out.dir === null) out.dir = a;
   }
@@ -46,15 +50,21 @@ function usage(pkg, create) {
 Scaffold a local WordPress + AI-agent Docker dev environment.
 
 Usage:
-  npm ${create} -- [dir] [--port=8080] [--scaffold-only]
-  npx ${pkg} [dir] [--port=8080] [--scaffold-only]
+  npm ${create} -- [dir] [options]
+  npx ${pkg} [dir] [options]
 
 Arguments:
-  dir              Target directory (default: current directory)
+  dir                   Target directory (default: current directory)
 
 Options:
-  --port=NNNN      Host port for WordPress (default: 8080)
-  --scaffold-only  Only write files; skip the automatic \`npm run setup\`
+  --port=NNNN           Host port for WordPress (default: 8080)
+  --setup-script=PATH   Shell script to run inside the workspace (as node) on
+                        first setup — e.g. clone a repo and run its installer.
+  --defines=PATH        JSON file of { "WP_CONST": value } pairs added to
+                        wp-config.php as constants (via \`wp config set\`).
+  --activate=a,b,c      Plugin slugs to activate, in this exact order, after the
+                        setup script runs (for plugins it dropped into wp-content).
+  --scaffold-only       Only write files; skip the automatic \`npm run setup\`
 `);
 }
 
@@ -98,15 +108,37 @@ async function copyTemplates(srcDir, destDir, vars) {
   }
 }
 
-// Append a preset's plugins to the scaffolded sandbox.config.json. Each entry is
-// the same shape install-plugins.sh understands: a wordpress.org slug string, or
-// { source, activate?, version? } where source is a slug or a URL/path to a .zip.
-async function applyPreset(targetDir, preset) {
-  if (!preset.plugins?.length) return;
+// Merge derived settings into the scaffolded sandbox.config.json. `plugins`
+// entries are the same shape install-plugins.sh understands (a wordpress.org
+// slug string, or { source, activate?, version? }); `activate` is an ordered
+// list of slugs to activate after the setup script runs; `defines` is a
+// { NAME: value } map applied to wp-config.php; `setupScript` is a path
+// (relative to the project) to a script run inside the workspace on setup.
+async function applyConfig(targetDir, extra) {
   const cfgPath = join(targetDir, 'sandbox.config.json');
   const cfg = JSON.parse(await readFile(cfgPath, 'utf8'));
-  cfg.plugins = [...(cfg.plugins ?? []), ...preset.plugins];
+  if (extra.plugins?.length) cfg.plugins = [...(cfg.plugins ?? []), ...extra.plugins];
+  if (extra.activate?.length) cfg.activate = [...(cfg.activate ?? []), ...extra.activate];
+  if (extra.defines && Object.keys(extra.defines).length) {
+    cfg.defines = { ...(cfg.defines ?? {}), ...extra.defines };
+  }
+  if (extra.setupScript) cfg.setupScript = extra.setupScript;
   await writeFile(cfgPath, JSON.stringify(cfg, null, 2) + '\n');
+}
+
+// Read a --defines file: JSON object of { NAME: value } constant pairs.
+async function readDefinesFile(path) {
+  const raw = await readFile(resolve(path), 'utf8');
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`--defines file "${path}" is not valid JSON (expected an object of { "WP_CONST": value } pairs).`);
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`--defines file "${path}" must be a JSON object of { "WP_CONST": value } pairs.`);
+  }
+  return parsed;
 }
 
 /**
@@ -114,11 +146,14 @@ async function applyPreset(targetDir, preset) {
  * `npm run setup`.
  *
  * @param {object} [options]
- * @param {object} [options.preset]          Derivative config. MVP: { name?, plugins? }.
- * @param {string} [options.preset.name]     Short name, e.g. "oxygen-wp" — only used to
- *                                           print the right `npm create <name>` in messages.
- * @param {Array}  [options.preset.plugins]  Extra plugins appended to the defaults.
- * @param {string[]} [options.argv]          CLI args (default: process.argv.slice(2)).
+ * @param {object} [options.preset]            Derivative config: { name?, plugins?, activate?, defines?, setupScript? }.
+ * @param {string} [options.preset.name]       Short name, e.g. "oxygen-wp" — only used to
+ *                                             print the right `npm create <name>` in messages.
+ * @param {Array}  [options.preset.plugins]    Extra plugins appended to the defaults.
+ * @param {string[]} [options.preset.activate] Plugin slugs to activate (in order) after the setup script.
+ * @param {object} [options.preset.defines]    { NAME: value } constants written into wp-config.php.
+ * @param {string} [options.preset.setupScript] Shell-script contents run inside the workspace on setup.
+ * @param {string[]} [options.argv]            CLI args (default: process.argv.slice(2)).
  */
 export async function create({ preset = {}, argv = process.argv.slice(2) } = {}) {
   // What to call this command in help/error text — wrappers pass preset.name.
@@ -133,6 +168,13 @@ export async function create({ preset = {}, argv = process.argv.slice(2) } = {})
 
   const targetDir = resolve(args.dir ?? '.');
   const projectName = basename(targetDir);
+
+  // Read & validate the file-backed inputs first, so a bad --setup-script /
+  // --defines path fails before we create or write anything into targetDir.
+  const setupScriptContent = args.setupScript
+    ? await readFile(resolve(args.setupScript), 'utf8')
+    : (preset.setupScript ?? null);
+  const cliDefines = args.defines ? await readDefinesFile(args.defines) : null;
 
   await mkdir(targetDir, { recursive: true });
 
@@ -155,7 +197,22 @@ export async function create({ preset = {}, argv = process.argv.slice(2) } = {})
     wpAdminPassword: userConfig.wpAdminPassword || 'password',
     wpAdminEmail: userConfig.wpAdminEmail || 'admin@example.com',
   });
-  await applyPreset(targetDir, preset);
+
+  // A setup script (CLI --setup-script, or a preset's inline script) is copied
+  // into the project's scripts/ so the generated project is self-contained — it
+  // re-runs on `npm run setup` / `npm run reset` without the original file.
+  let setupScriptRel = null;
+  if (setupScriptContent != null) {
+    setupScriptRel = 'scripts/user-setup.sh';
+    await writeFile(join(targetDir, setupScriptRel), setupScriptContent);
+  }
+
+  await applyConfig(targetDir, {
+    plugins: preset.plugins ?? [],
+    activate: [...(preset.activate ?? []), ...args.activate],
+    defines: { ...(preset.defines ?? {}), ...(cliDefines ?? {}) },
+    setupScript: setupScriptRel,
+  });
 
   // Pre-create the bind-mount host dirs (see docker-compose.yml). If they don't
   // exist when the stack first comes up, Docker creates them as root — on Linux

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,32 @@
+# Examples
+
+Sample inputs for the scaffolder's setup flags. Point the `create-` command at
+them from the repo root, or copy them next to your own project and adapt.
+
+## Files
+
+- **`breakdance-setup.sh`** — a `--setup-script`: runs inside the workspace
+  container (as `node`, cwd `/home/node`, WordPress at `/home/node/wp`). It
+  clones `soflyy/breakdance` and runs its installer against the site.
+- **`breakdance-defines.json`** — a `--defines` file: a JSON object of
+  `{ "WP_CONST": value }` pairs written into `wp-config.php` as constants
+  (booleans/numbers become raw PHP literals; strings are quoted).
+
+## Run it
+
+```bash
+npm create wp-local-dev-agent-sandbox@latest my-breakdance -- \
+  --port=8090 \
+  --setup-script=./examples/breakdance-setup.sh \
+  --defines=./examples/breakdance-defines.json \
+  --activate=oxygen-elements,breakdance-elements,breakdance-main
+```
+
+Order of operations on first setup: install WordPress → write the `--defines`
+constants → run the setup script (clone + Breakdance installer, which drops the
+plugins into `wp-content`) → activate `oxygen-elements`, then
+`breakdance-elements`, then `breakdance-main`, in that order.
+
+`soflyy/breakdance` is private, so `gh` needs auth in the workspace — run
+`gh auth login` once inside (`npm run bash`), or export `GH_TOKEN` on your host
+before setup (it's forwarded into the container).

--- a/examples/breakdance-defines.json
+++ b/examples/breakdance-defines.json
@@ -1,0 +1,8 @@
+{
+  "WP_DEBUG": true,
+  "WP_DEBUG_LOG": true,
+  "WP_DEBUG_DISPLAY": false,
+  "SCRIPT_DEBUG": true,
+  "WP_MEMORY_LIMIT": "512M",
+  "DISALLOW_FILE_MODS": false
+}

--- a/examples/breakdance-setup.sh
+++ b/examples/breakdance-setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Sample --setup-script for create-wp-local-dev-agent-sandbox.
+#
+# It runs INSIDE the workspace container as the `node` user (the same place
+# `npm run bash` drops you), with the working directory at /home/node and
+# WordPress at /home/node/wp. Here it checks out Breakdance next to ./wp and
+# runs Breakdance's own installer against that WordPress.
+#
+# Try it:
+#   npm create wp-local-dev-agent-sandbox@latest my-breakdance -- \
+#     --port=8090 \
+#     --setup-script=./examples/breakdance-setup.sh \
+#     --defines=./examples/breakdance-defines.json \
+#     --activate=oxygen-elements,breakdance-elements,breakdance-main
+#
+# `soflyy/breakdance` is private, so `gh` must be authenticated in the workspace
+# — either run `gh auth login` once inside (`npm run bash`; it persists in
+# workspace/), or export GH_TOKEN on your host before setup (it's forwarded in).
+set -euo pipefail
+
+cd /home/node
+
+# Idempotent: `npm run setup` may run this again, so don't re-clone over an
+# existing checkout.
+if [ ! -d /home/node/breakdance ]; then
+  gh repo clone soflyy/breakdance
+fi
+
+cd /home/node/breakdance && ./scripts/setup.sh --wp-root=/home/node/wp

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@
  * and plugin install). Pass --scaffold-only to write files and skip Docker.
  *
  * Usage:
- *   npm create wp-local-dev-agent-sandbox -- [dir] [--port=8080] [--scaffold-only]
- *   npx create-wp-local-dev-agent-sandbox [dir] [--port=8080] [--scaffold-only]
+ *   npm create wp-local-dev-agent-sandbox -- [dir] [--port=8080] [--setup-script=PATH] [--defines=PATH] [--activate=a,b,c] [--scaffold-only]
+ *   npx create-wp-local-dev-agent-sandbox [dir] [--port=8080] [--setup-script=PATH] [--defines=PATH] [--activate=a,b,c] [--scaffold-only]
  *
  * The scaffolding logic lives in engine.js, which is also exported for
  * downstream `create-<brand>` packages — see the README.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "files": [
     "index.js",
     "engine.js",
-    "templates"
+    "templates",
+    "examples"
   ],
   "engines": {
     "node": ">=18"

--- a/templates/scripts/apply-defines.sh
+++ b/templates/scripts/apply-defines.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Write the constants declared under "defines" in sandbox.config.json into
+# wp-config.php (run via `npm run setup`, before the setup script so it sees
+# them). Idempotent — `wp config set` updates an existing constant in place and
+# inserts new ones in the right spot (above the "stop editing" marker), so we
+# don't have to know where in the file they belong.
+#
+# sandbox.config.json format:
+#   { "defines": {
+#       "WP_DEBUG": true,                       // bool/number -> raw PHP literal
+#       "WP_MEMORY_LIMIT": "256M",              // string      -> quoted
+#       "MY_FLAG": { "value": "X", "raw": true } // force a raw (unquoted) value
+#   }}
+#
+set -euo pipefail
+
+# This script lives in scripts/ — operate from the project root.
+cd "$(dirname "$0")/.."
+
+CONFIG="sandbox.config.json"
+if [ ! -f "$CONFIG" ]; then
+  echo "→ No $CONFIG — skipping defines."
+  exit 0
+fi
+
+# Flatten "defines" to tab-separated rows: name<TAB>raw(0|1)<TAB>value.
+# JSON booleans/numbers become raw PHP literals (true/false/256); strings are
+# quoted by WP-CLI; an object { value, raw } lets you force either.
+rows="$(node -e '
+  const fs = require("fs");
+  const cfg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  const defines = cfg.defines || {};
+  for (const [name, v] of Object.entries(defines)) {
+    let value, raw;
+    if (v !== null && typeof v === "object") { value = String(v.value); raw = v.raw ? "1" : "0"; }
+    else if (typeof v === "boolean" || typeof v === "number") { value = String(v); raw = "1"; }
+    else { value = String(v); raw = "0"; }
+    process.stdout.write([name, raw, value].join("\t") + "\n");
+  }
+' "$CONFIG")"
+
+if [ -z "$rows" ]; then
+  echo "→ No defines listed in $CONFIG."
+  exit 0
+fi
+
+printf '%s\n' "$rows" | while IFS=$'\t' read -r name raw value; do
+  [ -n "$name" ] || continue
+  args=(config set "$name" "$value" --type=constant)
+  [ "$raw" = "1" ] && args+=(--raw)
+  echo "→ define( '$name', … )"
+  # </dev/null so `docker compose exec` doesn't swallow the loop's remaining rows.
+  docker compose exec -T workspace wp "${args[@]}" </dev/null
+done
+
+echo "✓ wp-config.php constants applied."

--- a/templates/scripts/initial-setup.sh
+++ b/templates/scripts/initial-setup.sh
@@ -28,6 +28,8 @@ done
 # Provisioning steps — each is an idempotent host-side script that runs WP-CLI
 # in the workspace container. Add more steps here as setup grows.
 bash scripts/install-wp.sh
+bash scripts/apply-defines.sh
+bash scripts/run-setup-script.sh
 bash scripts/install-plugins.sh
 bash scripts/install-agent-connector.sh
 bash scripts/connect-mcp.sh

--- a/templates/scripts/install-plugins.sh
+++ b/templates/scripts/install-plugins.sh
@@ -9,9 +9,16 @@
 #       "ai",                                  // shorthand: wordpress.org slug
 #       { "source": "akismet", "activate": false, "version": "5.3" },
 #       { "source": "https://example.com/plugin.zip", "activate": true }
-#   ]}
+#   ],
+#     "activate": ["oxygen-elements", "breakdance-main"]  // see below
+#   }
 # "source" is a wordpress.org slug or a URL/path to a plugin zip. "activate"
-# defaults to true; "version" is optional (wordpress.org slugs only).
+# (the per-plugin flag) defaults to true; "version" is optional (slugs only).
+#
+# The top-level "activate" array activates already-present plugins — ones a
+# setup script dropped into wp-content (so there's nothing to install) — in the
+# exact order listed. It runs after the install loop, and after the setup
+# script, so the plugins exist by then.
 #
 set -euo pipefail
 
@@ -37,24 +44,43 @@ rows="$(node -e '
 ' "$CONFIG")"
 
 if [ -z "$rows" ]; then
-  echo "→ No plugins listed in $CONFIG."
-  exit 0
+  echo "→ No plugins to install from $CONFIG."
+else
+  printf '%s\n' "$rows" | while IFS=$'\t' read -r source activate version; do
+    [ -n "$source" ] || continue
+    args=(plugin install "$source")
+    label="$source${version:+ @$version}"
+    # wordpress.org slugs are idempotent (already-installed exits 0), but a zip URL
+    # errors on reinstall ("destination folder already exists") — --force fixes it.
+    case "$source" in
+      *://*) args+=(--force) ;;
+    esac
+    if [ -n "$version" ]; then args+=(--version="$version"); fi
+    if [ "$activate" = "1" ]; then args+=(--activate); label="$label (activate)"; fi
+    echo "→ Plugin: $label"
+    # </dev/null so `docker compose exec` doesn't swallow the loop's remaining rows.
+    docker compose exec -T workspace wp "${args[@]}" </dev/null
+  done
 fi
 
-printf '%s\n' "$rows" | while IFS=$'\t' read -r source activate version; do
-  [ -n "$source" ] || continue
-  args=(plugin install "$source")
-  label="$source${version:+ @$version}"
-  # wordpress.org slugs are idempotent (already-installed exits 0), but a zip URL
-  # errors on reinstall ("destination folder already exists") — --force fixes it.
-  case "$source" in
-    *://*) args+=(--force) ;;
-  esac
-  if [ -n "$version" ]; then args+=(--version="$version"); fi
-  if [ "$activate" = "1" ]; then args+=(--activate); label="$label (activate)"; fi
-  echo "→ Plugin: $label"
-  # </dev/null so `docker compose exec` doesn't swallow the loop's remaining rows.
-  docker compose exec -T workspace wp "${args[@]}" </dev/null
-done
+# Activate already-present plugins (e.g. dropped into wp-content by the setup
+# script) in the exact order listed under "activate". `wp plugin activate` is
+# idempotent — an already-active plugin just reports so and exits 0.
+activate_rows="$(node -e '
+  const fs = require("fs");
+  const cfg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  for (const slug of cfg.activate ?? []) {
+    if (typeof slug === "string" && slug) process.stdout.write(slug + "\n");
+  }
+' "$CONFIG")"
+
+if [ -n "$activate_rows" ]; then
+  printf '%s\n' "$activate_rows" | while IFS= read -r slug; do
+    [ -n "$slug" ] || continue
+    echo "→ Activate: $slug"
+    # </dev/null so `docker compose exec` doesn't swallow the loop's remaining rows.
+    docker compose exec -T workspace wp plugin activate "$slug" </dev/null
+  done
+fi
 
 echo "✓ Plugins processed."

--- a/templates/scripts/run-setup-script.sh
+++ b/templates/scripts/run-setup-script.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Run the user-provided setup script (sandbox.config.json "setupScript") inside
+# the workspace container as the `node` user — the same place `npm run bash`
+# drops you, with the WordPress tree at /home/node/wp. Use it to clone a repo
+# and run its installer, build a plugin/theme, seed content, etc. Run via
+# `npm run setup`, after wp-config defines and before plugin activation, so a
+# plugin the script drops into wp-content can then be activated.
+#
+# The script is piped in over stdin (bash -s) and runs with cwd /home/node, so
+# `gh repo clone <repo>` lands a checkout right next to ./wp. Re-runnability is
+# up to the script — `npm run setup` may run it again, so guard side effects
+# (e.g. skip a clone if the directory already exists).
+#
+set -euo pipefail
+
+# This script lives in scripts/ — operate from the project root.
+cd "$(dirname "$0")/.."
+
+CONFIG="sandbox.config.json"
+if [ ! -f "$CONFIG" ]; then
+  echo "→ No $CONFIG — skipping setup script."
+  exit 0
+fi
+
+SCRIPT="$(node -e '
+  const fs = require("fs");
+  const cfg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  process.stdout.write(typeof cfg.setupScript === "string" ? cfg.setupScript : "");
+' "$CONFIG")"
+
+if [ -z "$SCRIPT" ]; then
+  echo "→ No setupScript in $CONFIG — skipping."
+  exit 0
+fi
+if [ ! -f "$SCRIPT" ]; then
+  echo "✖ setupScript \"$SCRIPT\" not found (relative to the project root)." >&2
+  exit 1
+fi
+
+echo "→ Running setup script ($SCRIPT) in the workspace as node…"
+
+# Forward GitHub credentials from the host env when present, so the script can
+# clone private repos (gh / git) without an interactive login in the container.
+# (`gh auth login` inside the workspace also works and persists in workspace/.)
+exec_args=(-T -w /home/node)
+for v in GH_TOKEN GITHUB_TOKEN; do
+  if [ -n "${!v:-}" ]; then exec_args+=(-e "$v"); fi
+done
+
+docker compose exec "${exec_args[@]}" workspace bash -s < "$SCRIPT"
+
+echo "✓ Setup script complete."


### PR DESCRIPTION
Adds three create-time customizations so you can stand up a fully provisioned site (clone a repo, run its installer, set wp-config constants, activate plugins in a chosen order) in one `npm create`. All three are flags that get persisted into the project's `sandbox.config.json`, so they also re-run on `npm run setup` / `npm run reset` — the project stays self-contained.

```bash
npm create wp-local-dev-agent-sandbox@latest my-breakdance -- \
  --port=8090 \
  --setup-script=./examples/breakdance-setup.sh \
  --defines=./examples/breakdance-defines.json \
  --activate=oxygen-elements,breakdance-elements,breakdance-main
```

## What's new

- **`--setup-script=PATH`** — a shell script run **inside the workspace container as `node`** (cwd `/home/node`, WordPress at `/home/node/wp`) — the same place `npm run bash` drops you. Use it to clone a repo and run its installer, build a plugin/theme, seed content, etc. It's piped in over stdin (so `gh repo clone` lands a checkout next to `./wp`), and `GH_TOKEN`/`GITHUB_TOKEN` are forwarded from the host so private clones work. The file is copied into the project as `scripts/user-setup.sh` and run by the new `scripts/run-setup-script.sh`.

- **`--defines=PATH`** — a JSON file of `{ "WP_CONST": value }` pairs written into `wp-config.php` as constants via `wp config set` (new `scripts/apply-defines.sh`). Booleans/numbers become raw PHP literals (`define( 'WP_DEBUG', true )`); strings are quoted; `{ "value": "...", "raw": true }` forces a raw value.
  - **Why key:value over a raw `wp-config` snippet** (the open question in the ask): `wp config set` handles *placement* (above the "stop editing" marker) and is idempotent, so you don't manage where each `define()` lands or worry about duplicates. Cleaner and re-runnable.

- **`--activate=a,b,c`** — plugin slugs to activate, **in this exact order**, after the setup script (handled in `install-plugins.sh`). This is for plugins that are already present — e.g. ones the setup script dropped into `wp-content` — so there's nothing to download, just activate.

### Setup order
`install-wp` → **`apply-defines`** → **`run-setup-script`** → `install-plugins` (install bundled `plugins`, then activate the ordered `activate` list) → agent-connector → mcp → skills. So a plugin the script installs exists by the time it's activated.

### Port
`--port` was already wired through (`__WP_PORT__` → `.env` `WP_PORT` → compose + install-wp), so it's left as-is — port is configurable today, default 8080.

## Presets
`create()` presets gain matching fields (`activate`, `defines`, `setupScript` as inline contents), merged with anything the end user passes.

## Example
`examples/` ships a worked Breakdance sample (`breakdance-setup.sh` + `breakdance-defines.json`) — clones `soflyy/breakdance`, runs `./scripts/setup.sh --wp-root=/home/node/wp`, then activates `oxygen-elements` → `breakdance-elements` → `breakdance-main`.

## Testing
- `bash -n` on all new/changed scripts; `node --check` on `engine.js`/`index.js`.
- Scaffolded (`--scaffold-only`) with all flags → verified `sandbox.config.json` (ordered `activate`, typed `defines`, `setupScript`), `.env` port, and the copied `scripts/user-setup.sh`.
- Verified the default (no flags) path is unchanged (`{ "plugins": [] }`, no `user-setup.sh`, port 8080) and that the `node` flatteners emit correct raw/quoted + ordered rows.
- Verified bad `--defines` (non-JSON / array) fails up-front **without** creating the target dir.
- Did **not** boot Docker (no end-to-end `npm run setup` run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)