### PR TITLE
Long-running dev script in a dedicated container

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ npm run cursor     # launch the Cursor CLI agent in the workspace
 ```
 my-site/
 ├── docker-compose.yml      # db + wordpress + workspace + playwright services
+├── docker-compose.override.yml  # only if a dev script was set — adds the long-running `dev` service
 ├── workspace.Dockerfile    # Node + Claude Code + Cursor CLI + PHP + WP-CLI (runs as non-root)
 ├── .env                    # DB creds + WP_PORT
 ├── .gitignore              # ignores the bind-mounted data dirs
 ├── package.json            # the npm-scripts UX (setup/start/stop/bash/claude/cursor/wp/reset)
-├── sandbox.config.json     # plugins to install, wp-config defines, setup script & activation order for `npm run setup`
+├── sandbox.config.json     # plugins to install, wp-config defines, setup/dev scripts & activation order for `npm run setup`
 ├── php/php.ini             # custom PHP overrides for the wordpress container (upload limits, etc.)
 ├── scripts/                # provisioning steps run by initial-setup.sh (install-wp, defines, user setup script, plugins, agent-connector, mcp, skills) + in-workspace.sh (credential-resolving launcher for bash/claude/cursor)
 ├── bin/                    # cursor-wp-mcp-helper — Node CLI for the WordPress MCP server, baked onto the workspace PATH
@@ -65,19 +66,22 @@ WordPress data, the database, and the workspace home are bind-mounted into `wp/`
 
 ## Customizing setup
 
-Beyond the bundled plugins, you can run your own setup script, add `wp-config.php` constants, and activate plugins in a chosen order. All three are flags on the create command and are persisted into the project's `sandbox.config.json`, so they re-run on `npm run setup` (and `npm run reset`) — the project stays self-contained.
+Beyond the bundled plugins, you can run a one-time setup script, add `wp-config.php` constants, activate plugins in a chosen order, and keep a long-running dev script (a watcher, say) alive alongside the stack. These are flags on the create command, persisted into the project's `sandbox.config.json` (and, for the dev service, a generated `docker-compose.override.yml`), so they re-apply on `npm run setup` / `npm run reset` — the project stays self-contained.
 
 ```bash
 npx create-wp-local-dev-agent-sandbox my-site \
   --port=8090 \
   --setup-script=./setup.sh \
+  --dev-script=./dev.sh \
   --defines=./defines.json \
   --activate=oxygen-elements,breakdance-elements,breakdance-main
 ```
 
-On the first `npm run setup` these run **in order**: install WordPress → apply `--defines` → run `--setup-script` → install bundled `plugins` and activate the `--activate` list. So a plugin your script drops into `wp-content` exists by the time it's activated.
+On the first `npm run setup` the **one-time** steps run in order: install WordPress → apply `--defines` → run `--setup-script` → install bundled `plugins` and activate the `--activate` list. So a plugin your script drops into `wp-content` exists by the time it's activated. The `--dev-script` runs separately and continuously (see below).
 
 - **`--setup-script=PATH`** — a shell script run **inside the workspace container as `node`** — the same environment `npm run bash` gives you, with the working directory at `/home/node` and WordPress at `/home/node/wp`. Use it to clone a repo and run its installer, build a plugin/theme, seed content, etc. It's piped in over stdin, so `gh repo clone <repo>` lands a checkout right next to `./wp`. `npm run setup` may run it again, so guard side effects (e.g. skip a clone when the directory already exists). To clone a **private** repo, authenticate `gh` once inside (`npm run bash` → `gh auth login`; it persists in `workspace/`), or export `GH_TOKEN` on your host before setup — it's forwarded into the container.
+
+- **`--dev-script=PATH`** (or **`--dev-command="…"`** for a one-liner) — a shell script that runs in its **own long-running `dev` container** for as long as the stack is up — e.g. `cd /home/node/my-plugin && npm run watch`. It reuses the workspace image, so it runs as `node` with the same `/home/node` mount (a checkout your setup script cloned at `/home/node/<repo>` is visible to it). It's supervised: started by `npm run start`, stopped by `npm run stop`, and **restarted if it exits** — so a crashed watcher, or one whose target directory isn't there yet (setup still running), self-heals. Follow it with `npm run dev:logs`. Adding it generates a `docker-compose.override.yml` (auto-merged by Compose) and `scripts/dev.sh`.
 
 - **`--defines=PATH`** — a JSON file of `{ "WP_CONST": value }` pairs written into `wp-config.php` as constants via `wp config set`, which places them correctly (above the "stop editing" marker) and updates them in place on re-run. Booleans and numbers become raw PHP literals (`define( 'WP_DEBUG', true )`); strings are quoted (`define( 'WP_MEMORY_LIMIT', '512M' )`). Use `{ "value": "...", "raw": true }` to force a raw (unquoted) value.
 
@@ -107,13 +111,15 @@ The flags above just write into this file; you can also edit it directly and `np
   ],
   "defines": { "WP_DEBUG": true, "WP_MEMORY_LIMIT": "512M" },
   "setupScript": "scripts/user-setup.sh",
+  "devScript": "scripts/dev.sh",
   "activate": ["oxygen-elements", "breakdance-elements", "breakdance-main"]
 }
 ```
 
 - `plugins` — installed (and activated unless `"activate": false`) from a wordpress.org slug or a URL/path to a `.zip`. `version` is optional (slugs only).
 - `defines` — `wp-config.php` constants (see `--defines` above).
-- `setupScript` — project-relative path to the script run in the workspace (`--setup-script` copies your file here as `scripts/user-setup.sh`).
+- `setupScript` — project-relative path to the one-time script run in the workspace (`--setup-script` copies your file here as `scripts/user-setup.sh`).
+- `devScript` — project-relative path to the long-running dev script (`--dev-script` / `--dev-command` writes it to `scripts/dev.sh` and adds the `dev` service via `docker-compose.override.yml`). Edit `scripts/dev.sh` and `npm run restart` to change what it runs.
 - `activate` — slugs activated in order, after `setupScript` (see `--activate` above).
 
 ## Requirements
@@ -192,11 +198,12 @@ create({
     defines: { WP_DEBUG: true, WP_MEMORY_LIMIT: '512M' },
     activate: ['oxygen-elements', 'breakdance-elements', 'breakdance-main'],
     setupScript: 'set -euo pipefail\ncd /home/node\n# …clone/build/seed here…\n',
+    devScript: 'cd /home/node/breakdance && npm run dev\n',
   },
 });
 ```
 
-`setupScript` here is the script's **contents** (a string), written into the project as `scripts/user-setup.sh`. A user's `--setup-script=PATH` overrides it.
+`setupScript` / `devScript` here are the scripts' **contents** (strings), written into the project as `scripts/user-setup.sh` / `scripts/dev.sh`. A user's `--setup-script=PATH` / `--dev-script=PATH` overrides them.
 
 > **Premium plugins:** a *public* `create-<brand>` can only bake in a `.zip` URL that's publicly reachable. For licensed plugins, point at a gated endpoint you control, or have your wrapper read the URL from a prompt or an env var instead of hardcoding it.
 

--- a/engine.js
+++ b/engine.js
@@ -22,6 +22,10 @@ const RENAME = {
   'gitignore': '.gitignore',
 };
 
+// Templates emitted only on demand (not copied by the blanket walk). The dev
+// service override is written only when the project has a dev script.
+const SKIP_TEMPLATES = new Set(['docker-compose.override.yml']);
+
 // When checking that the target dir is empty, these harmless entries don't count.
 const ALLOWED_EXISTING = new Set([
   '.git', '.gitignore', '.gitkeep', '.hg', '.svn',
@@ -30,10 +34,12 @@ const ALLOWED_EXISTING = new Set([
 ]);
 
 function parseArgs(argv) {
-  const out = { dir: null, port: '8080', setup: true, setupScript: null, defines: null, activate: [] };
+  const out = { dir: null, port: '8080', setup: true, setupScript: null, defines: null, activate: [], devScript: null, devCommand: null };
   for (const a of argv) {
     if (a.startsWith('--port=')) out.port = a.slice('--port='.length);
     else if (a.startsWith('--setup-script=')) out.setupScript = a.slice('--setup-script='.length);
+    else if (a.startsWith('--dev-script=')) out.devScript = a.slice('--dev-script='.length);
+    else if (a.startsWith('--dev-command=')) out.devCommand = a.slice('--dev-command='.length);
     else if (a.startsWith('--defines=')) out.defines = a.slice('--defines='.length);
     else if (a.startsWith('--activate=')) {
       out.activate = a.slice('--activate='.length).split(',').map((s) => s.trim()).filter(Boolean);
@@ -60,6 +66,10 @@ Options:
   --port=NNNN           Host port for WordPress (default: 8080)
   --setup-script=PATH   Shell script to run inside the workspace (as node) on
                         first setup — e.g. clone a repo and run its installer.
+  --dev-script=PATH     Shell script run (as node) in its own long-running 'dev'
+                        container for as long as the stack is up — e.g. a watcher.
+  --dev-command=STR     Inline form of --dev-script, e.g. --dev-command="cd
+                        /home/node/app && npm run watch".
   --defines=PATH        JSON file of { "WP_CONST": value } pairs added to
                         wp-config.php as constants (via \`wp config set\`).
   --activate=a,b,c      Plugin slugs to activate, in this exact order, after the
@@ -90,6 +100,7 @@ async function loadUserConfig() {
 
 async function copyTemplates(srcDir, destDir, vars) {
   for (const entry of await readdir(srcDir, { withFileTypes: true })) {
+    if (SKIP_TEMPLATES.has(entry.name)) continue;
     const src = join(srcDir, entry.name);
     const dest = join(destDir, RENAME[entry.name] ?? entry.name);
     if (entry.isDirectory()) {
@@ -123,6 +134,7 @@ async function applyConfig(targetDir, extra) {
     cfg.defines = { ...(cfg.defines ?? {}), ...extra.defines };
   }
   if (extra.setupScript) cfg.setupScript = extra.setupScript;
+  if (extra.devScript) cfg.devScript = extra.devScript;
   await writeFile(cfgPath, JSON.stringify(cfg, null, 2) + '\n');
 }
 
@@ -153,6 +165,7 @@ async function readDefinesFile(path) {
  * @param {string[]} [options.preset.activate] Plugin slugs to activate (in order) after the setup script.
  * @param {object} [options.preset.defines]    { NAME: value } constants written into wp-config.php.
  * @param {string} [options.preset.setupScript] Shell-script contents run inside the workspace on setup.
+ * @param {string} [options.preset.devScript]  Shell-script contents run in the long-running 'dev' container.
  * @param {string[]} [options.argv]            CLI args (default: process.argv.slice(2)).
  */
 export async function create({ preset = {}, argv = process.argv.slice(2) } = {}) {
@@ -170,10 +183,14 @@ export async function create({ preset = {}, argv = process.argv.slice(2) } = {})
   const projectName = basename(targetDir);
 
   // Read & validate the file-backed inputs first, so a bad --setup-script /
-  // --defines path fails before we create or write anything into targetDir.
+  // --dev-script / --defines path fails before we create or write anything.
   const setupScriptContent = args.setupScript
     ? await readFile(resolve(args.setupScript), 'utf8')
     : (preset.setupScript ?? null);
+  // --dev-script PATH wins over --dev-command STRING wins over a preset.
+  const devScriptContent = args.devScript
+    ? await readFile(resolve(args.devScript), 'utf8')
+    : (args.devCommand != null ? args.devCommand + '\n' : (preset.devScript ?? null));
   const cliDefines = args.defines ? await readDefinesFile(args.defines) : null;
 
   await mkdir(targetDir, { recursive: true });
@@ -207,11 +224,24 @@ export async function create({ preset = {}, argv = process.argv.slice(2) } = {})
     await writeFile(join(targetDir, setupScriptRel), setupScriptContent);
   }
 
+  // A dev script runs in its own long-lived 'dev' container (see
+  // templates/docker-compose.override.yml). We drop the script at scripts/dev.sh
+  // and emit the override that adds the service — both only when one is provided,
+  // so projects without a dev script get neither the file nor the extra service.
+  let devScriptRel = null;
+  if (devScriptContent != null) {
+    devScriptRel = 'scripts/dev.sh';
+    await writeFile(join(targetDir, devScriptRel), devScriptContent);
+    const override = await readFile(join(TEMPLATES, 'docker-compose.override.yml'), 'utf8');
+    await writeFile(join(targetDir, 'docker-compose.override.yml'), override);
+  }
+
   await applyConfig(targetDir, {
     plugins: preset.plugins ?? [],
     activate: [...(preset.activate ?? []), ...args.activate],
     defines: { ...(preset.defines ?? {}), ...(cliDefines ?? {}) },
     setupScript: setupScriptRel,
+    devScript: devScriptRel,
   });
 
   // Pre-create the bind-mount host dirs (see docker-compose.yml). If they don't
@@ -267,6 +297,9 @@ export async function create({ preset = {}, argv = process.argv.slice(2) } = {})
   console.log('  npm run claude       # launch Claude Code in the workspace');
   console.log('  npm run cursor       # launch the Cursor CLI agent in the workspace');
   console.log('  npm run bash         # shell into the workspace container');
+  if (devScriptRel) {
+    console.log('  npm run dev:logs     # follow the dev script running in the dev container');
+  }
   console.log('');
   console.log('───────────────────────────────────────────────');
   console.log('  Your WordPress site is ready:');

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,9 @@ them from the repo root, or copy them next to your own project and adapt.
 - **`breakdance-defines.json`** — a `--defines` file: a JSON object of
   `{ "WP_CONST": value }` pairs written into `wp-config.php` as constants
   (booleans/numbers become raw PHP literals; strings are quoted).
+- **`breakdance-dev.sh`** — a `--dev-script`: runs in the long-lived `dev`
+  container for as long as the stack is up (here, Breakdance's `npm run dev`
+  watch task against the `/home/node/breakdance` checkout).
 
 ## Run it
 
@@ -18,6 +21,7 @@ them from the repo root, or copy them next to your own project and adapt.
 npm create wp-local-dev-agent-sandbox@latest my-breakdance -- \
   --port=8090 \
   --setup-script=./examples/breakdance-setup.sh \
+  --dev-script=./examples/breakdance-dev.sh \
   --defines=./examples/breakdance-defines.json \
   --activate=oxygen-elements,breakdance-elements,breakdance-main
 ```
@@ -25,7 +29,8 @@ npm create wp-local-dev-agent-sandbox@latest my-breakdance -- \
 Order of operations on first setup: install WordPress → write the `--defines`
 constants → run the setup script (clone + Breakdance installer, which drops the
 plugins into `wp-content`) → activate `oxygen-elements`, then
-`breakdance-elements`, then `breakdance-main`, in that order.
+`breakdance-elements`, then `breakdance-main`, in that order. The dev script runs
+in parallel in its own container the whole time (`npm run dev:logs` to watch it).
 
 `soflyy/breakdance` is private, so `gh` needs auth in the workspace — run
 `gh auth login` once inside (`npm run bash`), or export `GH_TOKEN` on your host

--- a/examples/breakdance-dev.sh
+++ b/examples/breakdance-dev.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Sample --dev-script for create-wp-local-dev-agent-sandbox.
+#
+# It runs in the long-lived `dev` container (as `node`, with the same /home/node
+# mount as the workspace), kept alive by dev-supervisor for as long as the stack
+# is up. Here it runs Breakdance's watch task against the checkout the setup
+# script cloned at /home/node/breakdance.
+#
+# Pairs with breakdance-setup.sh:
+#   npm create wp-local-dev-agent-sandbox@latest my-breakdance -- \
+#     --port=8090 \
+#     --setup-script=./examples/breakdance-setup.sh \
+#     --dev-script=./examples/breakdance-dev.sh \
+#     --defines=./examples/breakdance-defines.json \
+#     --activate=oxygen-elements,breakdance-elements,breakdance-main
+#
+# dev-supervisor restarts this if it exits, so if the checkout isn't there yet
+# (setup still running) it simply retries until /home/node/breakdance exists.
+set -euo pipefail
+
+cd /home/node/breakdance && npm run dev

--- a/examples/breakdance-dev.sh
+++ b/examples/breakdance-dev.sh
@@ -19,4 +19,4 @@
 # (setup still running) it simply retries until /home/node/breakdance exists.
 set -euo pipefail
 
-cd /home/node/breakdance && npm run dev
+cd /home/node/breakdance && npm run dev:codespace

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@
  * and plugin install). Pass --scaffold-only to write files and skip Docker.
  *
  * Usage:
- *   npm create wp-local-dev-agent-sandbox -- [dir] [--port=8080] [--setup-script=PATH] [--defines=PATH] [--activate=a,b,c] [--scaffold-only]
- *   npx create-wp-local-dev-agent-sandbox [dir] [--port=8080] [--setup-script=PATH] [--defines=PATH] [--activate=a,b,c] [--scaffold-only]
+ *   npm create wp-local-dev-agent-sandbox -- [dir] [--port=8080] [--setup-script=PATH] [--dev-script=PATH] [--defines=PATH] [--activate=a,b,c] [--scaffold-only]
+ *   npx create-wp-local-dev-agent-sandbox [dir] [--port=8080] [--setup-script=PATH] [--dev-script=PATH] [--defines=PATH] [--activate=a,b,c] [--scaffold-only]
  *
  * The scaffolding logic lives in engine.js, which is also exported for
  * downstream `create-<brand>` packages — see the README.

--- a/templates/docker-compose.override.yml
+++ b/templates/docker-compose.override.yml
@@ -1,0 +1,31 @@
+# Auto-merged by `docker compose` (no -f needed). Present only when this project
+# was scaffolded with a dev script (--dev-script / --dev-command, recorded as
+# "devScript" in sandbox.config.json).
+#
+# It runs scripts/dev.sh in its own long-lived container — reusing the workspace
+# image, so it runs as the `node` user with the same /home/node mount (a checkout
+# your setup script cloned at /home/node/<repo> is visible here too). With
+# restart: unless-stopped it's up for as long as the stack is, started/stopped by
+# `npm run start` / `npm run stop`. Watch it with `npm run dev:logs`.
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: workspace.Dockerfile
+    restart: unless-stopped
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_NAME: ${MARIADB_DATABASE}
+      WORDPRESS_DB_USER: ${MARIADB_USER}
+      WORDPRESS_DB_PASSWORD: ${MARIADB_PASSWORD}
+      WP_ENVIRONMENT_TYPE: local
+    volumes:
+      # Same home as the workspace container, plus the dev script mounted in.
+      - ./workspace:/home/node
+      - ./scripts/dev.sh:/home/node/.dev-script.sh:ro
+    # Bypass the workspace image's Claude-seeding entrypoint — this container only
+    # runs the dev script. dev-supervisor waits until the script (and whatever it
+    # cd's into) is ready, runs it, and restarts it if it exits. See
+    # workspace.Dockerfile.
+    entrypoint: ["dev-supervisor"]
+    command: ["/home/node/.dev-script.sh"]

--- a/templates/package.json
+++ b/templates/package.json
@@ -10,6 +10,7 @@
     "down": "docker compose down",
     "restart": "docker compose restart",
     "logs": "docker compose logs -f",
+    "dev:logs": "docker compose logs -f dev",
     "ps": "docker compose ps",
     "bash": "bash scripts/in-workspace.sh bash",
     "claude": "bash scripts/in-workspace.sh claude --dangerously-skip-permissions",

--- a/templates/workspace.Dockerfile
+++ b/templates/workspace.Dockerfile
@@ -83,6 +83,28 @@ RUN curl https://cursor.com/install -fsS | bash \
 COPY bin/cursor-wp-mcp-helper /usr/local/bin/cursor-wp-mcp-helper
 RUN chmod 0755 /usr/local/bin/cursor-wp-mcp-helper
 
+# dev-supervisor: the entrypoint for the optional 'dev' container (see
+# docker-compose.override.yml). Keeps a project's dev script running for as long
+# as the stack is up — waits until the script exists and is non-empty (it may be
+# empty until the setup script populates a checkout), runs it, and restarts it
+# with a short backoff if it exits, so a watcher that dies (or a path that isn't
+# there yet) self-heals. Baked into the image so it's on the PATH for the dev
+# service, which reuses this same image.
+RUN printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -uo pipefail' \
+  'SCRIPT="${1:-/home/node/.dev-script.sh}"' \
+  'echo "[dev] supervising $SCRIPT"' \
+  'until [ -s "$SCRIPT" ]; do echo "[dev] waiting for $SCRIPT to be ready…"; sleep 3; done' \
+  'while true; do' \
+  '  echo "[dev] ▶ running dev script"' \
+  '  bash "$SCRIPT" || echo "[dev] dev script exited with code $?"' \
+  '  echo "[dev] restarting in 5s (stop with: npm run stop)"' \
+  '  sleep 5' \
+  'done' \
+  > /usr/local/bin/dev-supervisor \
+  && chmod 0755 /usr/local/bin/dev-supervisor
+
 # Run as the image's built-in non-root user (uid 1000) so
 # `claude --dangerously-skip-permissions` is allowed (it refuses to run as root).
 USER node


### PR DESCRIPTION
Adds a way to specify a **dev script** — e.g. `cd /home/node/app && npm run watch` — that runs for **as long as the Docker stack is up**, as you asked.

## Design (the "how")

A dedicated **`dev` Compose service** with `restart: unless-stopped`, which is the cleanest match for "as long as docker is up, run that script":

- **Reuses the workspace image**, so the script runs as `node` with the same `/home/node` mount — a checkout your `--setup-script` cloned at `/home/node/<repo>` is visible to it (same as `npm run bash`).
- **Lifecycle = stack lifecycle**: `npm run start` brings it up, `npm run stop`/`down` takes it down, and it's **restarted if it exits** (crashed watcher, or a target dir that doesn't exist yet because setup is still running — it self-heals).
- **Isolated** from the interactive agent shell (separate container, own logs via `npm run dev:logs`).
- **Conditional**: added via a generated `docker-compose.override.yml` (auto-merged by Compose, no `-f` needed). Projects without a dev script get no override, no `scripts/dev.sh`, and no extra service.

No published port (per our discussion — it's for watchers/build tasks; the dev container still reaches the WordPress/db containers over the Docker network). Exposing one later is a one-line `ports:` add in the override.

## Usage

```bash
npx create-wp-local-dev-agent-sandbox my-site \
  --dev-script=./dev.sh
# or inline:
npx create-wp-local-dev-agent-sandbox my-site \
  --dev-command="cd /home/node/my-plugin && npm run watch"
```

Recorded as `devScript` in `sandbox.config.json`; edit `scripts/dev.sh` + `npm run restart` to change what runs. Presets gain a matching `devScript` field.

## How it works

- `--dev-script`/`--dev-command` → writes `scripts/dev.sh` + emits `docker-compose.override.yml` (`engine.js`).
- `templates/docker-compose.override.yml` defines the `dev` service: reuses `workspace.Dockerfile`, mounts `./workspace:/home/node` + `./scripts/dev.sh`, `entrypoint: dev-supervisor` (bypasses the Claude-seeding entrypoint so there's no race with the workspace container seeding `~/.claude.json`).
- `dev-supervisor` (baked into `workspace.Dockerfile`): waits until the script is non-empty, runs it, restarts with a 5s backoff on exit.

## Testing

- `node --check` on `engine.js`/`index.js`; `bash -n` + a runtime smoke test of `dev-supervisor` (verified it restarts a finished script and waits for a not-yet-present one).
- Scaffolded (`--scaffold-only`) with `--dev-script`, with `--dev-command`, and with neither — verified `scripts/dev.sh`, the override, the `devScript` config field, and `dev:logs` appear only when configured, and that the no-dev path is byte-for-byte unchanged (`{ "plugins": [] }`, no override/dev.sh).
- `docker compose config` on the merged result (Compose v29) — the `dev` service resolves with the right entrypoint/command/volumes/restart policy.
- Did **not** boot Docker end-to-end (no live `npm run start` with a real watcher).

## Notes

- The `dev` service has its own `build:` (same Dockerfile as `workspace`), so `--build` builds a second image — cache-hot, so it's fast, but it is a separate tag. Reusing the workspace's built image would need a reliably-known image name, which Compose doesn't give us portably.
- `examples/breakdance-dev.sh` added (`cd /home/node/breakdance && npm run dev`), pairing with the Breakdance setup example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)