### PR TITLE
fix(server): Oxygen preset skips breakdance setup.sh plugin activation

### DIFF
--- a/server/src/presets.js
+++ b/server/src/presets.js
@@ -30,7 +30,10 @@ cd /home/node
 if [ ! -d /home/node/breakdance ]; then
   gh repo clone soflyy/breakdance
 fi
-cd /home/node/breakdance && ./scripts/setup.sh --wp-root=/home/node/wp
+# no-plugin-activate (soflyy/breakdance#9441): build + symlink, but DON'T let
+# setup.sh activate every breakdance plugin — the preset's own \`activate\` list
+# decides which ones go live (oxygen-elements, breakdance-elements, breakdance-main).
+cd /home/node/breakdance && ./scripts/setup.sh --wp-root=/home/node/wp no-plugin-activate
 `;
 
 const OXYGEN_DEFINES = {


### PR DESCRIPTION
The Oxygen preset's setup script ran breakdance's `./scripts/setup.sh`, which activates **every** bundled plugin (breakdance-ai, breakdance-woocommerce, futurelayer-plugin, …) — not just the ones we want.

soflyy/breakdance#9441 adds a `no-plugin-activate` flag that builds + symlinks but skips activation. The preset now passes it:

```
./scripts/setup.sh --wp-root=/home/node/wp no-plugin-activate
```

so our own ordered `activate` list (`oxygen-elements → breakdance-elements → breakdance-main`) is the sole source of truth for what's active. Updated in both the code seed and the live on-disk preset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)