### PR TITLE
feat(server): sessions tied to environments, nested in UI, renameable

### DIFF
--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -1,7 +1,7 @@
 // Endpoint handlers — thin: validate input, call the manager/session engine,
 // shape the response. `sessions` bundles { store, engine, bus }.
 
-import { readFile } from 'node:fs/promises';
+import { readFile, rm } from 'node:fs/promises';
 import { route } from './http.js';
 import { hostInfo } from './docker.js';
 import { AllocationError } from './allocator.js';
@@ -23,6 +23,14 @@ export function buildRoutes(config, registry, manager, sessions, presets) {
   };
   const assertUsable = async (env) => {
     if (!(await manager.usable(env))) throw httpErr(409, `environment "${env.name}" is not running`);
+  };
+  // Fully remove a session: stop any active turn, drop its event stream + log
+  // file, and delete the record. Used by DELETE /sessions/:id and env destroy.
+  const deleteSession = async (s) => {
+    sessions.engine.interrupt(s.id);
+    sessions.bus.clear(s.id);
+    await sessions.store.remove(s.id);
+    if (s.eventLogPath) await rm(s.eventLogPath, { force: true }).catch(() => {});
   };
   const sshHint = (s) => {
     const env = registry.get(s.envId);
@@ -83,8 +91,9 @@ export function buildRoutes(config, registry, manager, sessions, presets) {
     route('POST', '/environments/:id/start', async (ctx) => ctx.send(200, await manager.start(envOr404(ctx)))),
     route('DELETE', '/environments/:id', async (ctx) => {
       const env = envOr404(ctx);
+      // Sessions are tied to their environment: destroying it deletes them all.
       sessions.engine.killEnvSessions(env.id);
-      for (const s of sessions.store.listByEnv(env.id)) await sessions.store.update(s.id, { status: 'env-destroyed' });
+      for (const s of sessions.store.listByEnv(env.id)) await deleteSession(s);
       await manager.destroy(env);
       ctx.send(200, { deleted: true });
     }),
@@ -138,6 +147,14 @@ export function buildRoutes(config, registry, manager, sessions, presets) {
 
     route('GET', '/sessions/:id', async (ctx) => ctx.send(200, publicSession(sessionOr404(ctx)))),
 
+    route('PATCH', '/sessions/:id', async (ctx) => {
+      const s = sessionOr404(ctx);
+      const title = String(ctx.body.title || '').replace(/\s+/g, ' ').trim();
+      if (!title) throw httpErr(400, 'title is required');
+      const updated = await sessions.store.update(s.id, { title: title.slice(0, 200) });
+      ctx.send(200, publicSession(updated));
+    }),
+
     route('GET', '/sessions/:id/transcript', async (ctx) => {
       const s = sessionOr404(ctx);
       const tail = Math.min(parseInt(ctx.query.get('tail') || '2000', 10) || 2000, 20000);
@@ -167,10 +184,7 @@ export function buildRoutes(config, registry, manager, sessions, presets) {
     }),
 
     route('DELETE', '/sessions/:id', async (ctx) => {
-      const s = sessionOr404(ctx);
-      sessions.engine.interrupt(s.id);
-      sessions.bus.clear(s.id);
-      await sessions.store.remove(s.id);
+      await deleteSession(sessionOr404(ctx));
       ctx.send(200, { deleted: true });
     }),
 

--- a/server/ui/app.js
+++ b/server/ui/app.js
@@ -111,29 +111,36 @@ function EnvRow({ env, onAction }) {
     </div>`;
 }
 
-function Sidebar({ sessions, envs, selectedId, onSelect, onNewSession, onNewEnv, onEnvAction, onSettings }) {
+function SessionItem({ s, selectedId, onSelect }) {
+  return html`
+    <div class=${`sess ${s.id === selectedId ? 'active' : ''}`} onClick=${() => onSelect(s.id)}>
+      <div class="sess-top"><${StatusDot} status=${s.status} /> <span class="sess-title">${s.title || s.id}</span></div>
+      <div class="sess-sub muted">${s.turnCount} turn${s.turnCount === 1 ? '' : 's'} · $${(s.costUsd || 0).toFixed(3)}</div>
+    </div>`;
+}
+
+function Sidebar({ sessions, envs, selectedId, onSelect, onNewEnv, onEnvAction, onSettings }) {
   return html`
     <aside class="sidebar">
       <div class="side-head">
         <strong>Devbox</strong>
         <button class="btn small ghost" onClick=${onSettings} title="API token">⚙</button>
       </div>
-      <div class="side-section">
-        <div class="section-head"><span>Environments</span><button class="btn small" onClick=${onNewEnv}>+ Env</button></div>
-        ${envs.length === 0 && html`<div class="muted pad small">No environments — create one.</div>`}
-        ${envs.map((e) => html`<${EnvRow} env=${e} key=${e.id} onAction=${onEnvAction} />`)}
-      </div>
       <div class="side-section grow">
-        <div class="section-head"><span>Sessions</span><button class="btn small" onClick=${onNewSession}>+ Session</button></div>
+        <div class="section-head"><span>Environments</span><button class="btn small" onClick=${onNewEnv}>+ Env</button></div>
         <div class="side-list">
-          ${sessions.length === 0 && html`<div class="muted pad small">No sessions yet.</div>`}
-          ${sessions.map(
-            (s) => html`
-              <div class=${`sess ${s.id === selectedId ? 'active' : ''}`} key=${s.id} onClick=${() => onSelect(s.id)}>
-                <div class="sess-top"><${StatusDot} status=${s.status} /> <span class="sess-title">${s.title || s.id}</span></div>
-                <div class="sess-sub muted">${s.envName} · ${s.turnCount} turn${s.turnCount === 1 ? '' : 's'} · $${(s.costUsd || 0).toFixed(3)}</div>
-              </div>`,
-          )}
+          ${envs.length === 0 && html`<div class="muted pad small">No environments — create one.</div>`}
+          ${envs.map((e) => {
+            const envSessions = sessions.filter((s) => s.envId === e.id);
+            return html`
+              <div class="env-group" key=${e.id}>
+                <${EnvRow} env=${e} onAction=${onEnvAction} />
+                <div class="env-sessions">
+                  ${envSessions.length === 0 && html`<div class="muted pad small no-sess">No sessions yet.</div>`}
+                  ${envSessions.map((s) => html`<${SessionItem} s=${s} key=${s.id} selectedId=${selectedId} onSelect=${onSelect} />`)}
+                </div>
+              </div>`;
+          })}
         </div>
       </div>
     </aside>`;
@@ -161,6 +168,8 @@ function SessionView({ session, onChanged, onBack }) {
   const [partial, setPartial] = useState('');
   const [busy, setBusy] = useState(false);
   const [input, setInput] = useState('');
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
   const partialRef = useRef({ text: '' });
   const seen = useRef(new Set());
   const scroller = useRef(null);
@@ -205,13 +214,29 @@ function SessionView({ session, onChanged, onBack }) {
     catch (e) { setBusy(false); alert(`Send failed: ${e.message}`); }
   }, [input, running, id]);
   const interrupt = async () => { try { await api(`/sessions/${id}/interrupt`, { method: 'POST' }); } catch (e) { alert(e.message); } };
+  const startEdit = () => { setDraft(session.title || ''); setEditing(true); };
+  const saveTitle = async () => {
+    const t = draft.replace(/\s+/g, ' ').trim();
+    setEditing(false);
+    if (!t || t === session.title) return;
+    try { await api(`/sessions/${id}`, { method: 'PATCH', body: JSON.stringify({ title: t }) }); onChanged && onChanged(); }
+    catch (e) { alert(`Rename failed: ${e.message}`); }
+  };
 
   return html`
     <section class="main">
       <header class="bar">
         <div class="bar-title">
           <button class="back btn small ghost" onClick=${onBack} title="Back to list">‹</button>
-          <${StatusDot} status=${session.status} /> <strong>${session.title || id}</strong>
+          <${StatusDot} status=${session.status} />
+          ${editing
+            ? html`<input class="rename" value=${draft}
+                ref=${(el) => { if (el && document.activeElement !== el) { el.focus(); el.select(); } }}
+                onInput=${(e) => setDraft(e.target.value)}
+                onKeyDown=${(e) => { if (e.key === 'Enter') { e.preventDefault(); saveTitle(); } else if (e.key === 'Escape') setEditing(false); }}
+                onBlur=${saveTitle} />`
+            : html`<strong title="Double-click to rename" onDblClick=${startEdit}>${session.title || id}</strong>
+                <button class="lnk small" onClick=${startEdit} title="Rename">✎</button>`}
         </div>
         <div class="bar-meta muted">
           ${session.envName} · ${session.model || 'default model'} · $${(session.costUsd || 0).toFixed(4)}
@@ -505,7 +530,7 @@ function App() {
   return html`
     <div class=${`layout ${selected ? 'has-selection' : ''}`}>
       <${Sidebar} sessions=${sessions} envs=${envs} selectedId=${selectedId}
-        onSelect=${setSelectedId} onNewSession=${() => setNewSession({})} onNewEnv=${() => setShowNewEnv(true)}
+        onSelect=${setSelectedId} onNewEnv=${() => setShowNewEnv(true)}
         onEnvAction=${envAction} onSettings=${() => setAuthed(false)} />
       ${selected
         ? html`<${SessionView} session=${selected} key=${selected.id} onChanged=${refresh} onBack=${() => setSelectedId(null)} />`

--- a/server/ui/style.css
+++ b/server/ui/style.css
@@ -32,6 +32,13 @@ pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12.5px/1.5
 .lnk { background: none; border: 0; color: var(--accent); cursor: pointer; font-size: 12px; padding: 0; }
 .lnk:hover { text-decoration: underline; }
 .lnk.danger { color: var(--red); margin-left: auto; }
+.env-group { border-top: 1px solid var(--line); }
+.env-group .env { border-top: 0; }
+.env-sessions { padding-left: 12px; border-left: 2px solid var(--line); margin: 0 0 6px 16px; }
+.env-sessions .no-sess { padding: 4px 8px; }
+.env-sessions .sess { border-bottom: 0; border-radius: 6px; padding: 6px 8px; }
+.rename { font: inherit; font-weight: 600; background: var(--bg); color: var(--text);
+  border: 1px solid var(--accent); border-radius: 6px; padding: 2px 6px; min-width: 200px; }
 .sess { padding: 10px 12px; border-bottom: 1px solid var(--line); cursor: pointer; }
 .sess:hover { background: var(--panel2); }
 .sess.active { background: var(--accent2); }


### PR DESCRIPTION
Makes Claude sessions belong to their environment, for organization.

- **Cascade delete**: destroying an environment now **deletes all its sessions** (registry record + per-session event-log file) via a shared `deleteSession` helper, instead of leaving them around marked `env-destroyed`.
- **Nested UI**: the sidebar shows each environment with **its own sessions nested beneath it** — the old flat list that mixed sessions from every environment is gone. `+ session` remains a per-env action.
- **Rename**: new `PATCH /sessions/:id { title }` (trims/collapses whitespace, 400 on empty, caps at 200 chars). In the UI, the session-header title is inline-editable (✎ button or double-click; Enter saves, Esc cancels). Titles are only set at creation and never overwritten by later turns, so a rename persists.

## Verification
Against a throwaway instance: rename → 404 (missing) / 400 (empty) / 200 with normalized, persisted title; `DELETE /sessions/:id` removes the record **and** its `.ndjson` log file (the same helper the env-destroy cascade uses). UI parses.

Needs a server restart (backend) + browser refresh (UI) to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)