### PR TITLE
feat(server): optional first prompt on env create → auto-start a session

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -47,6 +47,14 @@ async function main() {
   const claudeEngine = new ClaudeEngine(config, sessionStore, sessionBus);
   const sessions = { store: sessionStore, engine: claudeEngine, bus: sessionBus };
 
+  // When an env finishes provisioning, optionally kick off its initial session
+  // (the prompt passed to POST /environments). Decoupled via this hook so the
+  // manager doesn't depend on the session engine directly.
+  manager.onEnvReady = async (env, { prompt, model }) => {
+    const s = await claudeEngine.newSession(env, { prompt, model });
+    log.info(`[${env.name}] started initial session ${s.id}`);
+  };
+
   const routes = buildRoutes(config, registry, manager, sessions, presets);
   const server = createServer(config, routes);
 

--- a/server/src/manager.js
+++ b/server/src/manager.js
@@ -46,7 +46,7 @@ export class Manager {
 
   // ---- create -------------------------------------------------------------
 
-  async createEnvironment({ name, provision } = {}) {
+  async createEnvironment({ name, provision, prompt, model } = {}) {
     const record = await allocate(this.registry, this.config, { nameHint: name });
     this.jobs.set(record.id, 'scaffolding');
     // Materialize the provisioning inputs to files the scaffolder can read, and
@@ -57,8 +57,11 @@ export class Manager {
       provisionPlan = await this._materializeProvision(record, provision);
       if (provision.presetName) await this.registry.update(record.id, { preset: provision.presetName });
     }
+    // Optional: once the env is up, start a Claude session with this prompt
+    // (carried in-memory through the pipeline; see onEnvReady).
+    const initial = prompt ? { prompt, model } : null;
     // Fire-and-forget pipeline; status is observable via GET.
-    this._pipeline(record, provisionPlan).catch((err) => log.error(`[${record.name}] pipeline crashed:`, err));
+    this._pipeline(record, provisionPlan, initial).catch((err) => log.error(`[${record.name}] pipeline crashed:`, err));
     return record;
   }
 
@@ -91,7 +94,7 @@ export class Manager {
     return { args, scratchDir };
   }
 
-  async _pipeline(record, provisionPlan = null) {
+  async _pipeline(record, provisionPlan = null, initial = null) {
     const { config, registry } = this;
     try {
       await mkdir(config.envsDir, { recursive: true });
@@ -141,6 +144,12 @@ export class Manager {
         workerStartedAt: config.cursorWorkerAutostart ? new Date().toISOString() : null,
         lastError: null,
       });
+      // Env is up — fire the optional initial session. Best-effort: its failure
+      // must not fail the environment (the env itself is fine).
+      if (initial?.prompt) {
+        try { await this.onEnvReady?.(record, initial); }
+        catch (err) { log.warn(`[${record.name}] initial session failed:`, err.message); }
+      }
     } catch (err) {
       log.error(`[${record.name}] setup failed:`, err.message);
       await registry.update(record.id, { status: 'failed', lastError: truncate(redactErr(err)) });

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -73,7 +73,9 @@ export function buildRoutes(config, registry, manager, sessions, presets) {
     route('POST', '/environments', async (ctx) => {
       try {
         const provision = normalizeProvision(ctx.body.provision);
-        const record = await manager.createEnvironment({ name: ctx.body.name, provision });
+        const prompt = typeof ctx.body.prompt === 'string' ? ctx.body.prompt.trim() : '';
+        const model = typeof ctx.body.model === 'string' && ctx.body.model.trim() ? ctx.body.model.trim() : undefined;
+        const record = await manager.createEnvironment({ name: ctx.body.name, provision, prompt: prompt || undefined, model });
         ctx.send(202, { id: record.id, name: record.name, port: record.port, wpUrl: record.wpUrl, status: record.status });
       } catch (err) {
         if (err instanceof AllocationError) throw httpErr(err.status, err.message);

--- a/server/ui/app.js
+++ b/server/ui/app.js
@@ -376,6 +376,7 @@ function LogViewer({ env, onClose }) {
 
 function NewEnvModal({ presets, onClose, onCreate, onSavePreset, onDeletePreset }) {
   const [name, setName] = useState('');
+  const [prompt, setPrompt] = useState('');
   const [presetId, setPresetId] = useState('');
   const [setupScript, setSetupScript] = useState('');
   const [devScript, setDevScript] = useState('');
@@ -417,7 +418,7 @@ function NewEnvModal({ presets, onClose, onCreate, onSavePreset, onDeletePreset 
     let provision;
     try { provision = isEmpty ? undefined : buildProvision(); } catch (e) { setErr(e.message); return; }
     setBusy(true);
-    try { await onCreate(name.trim() || undefined, provision); } catch (e) { setErr(e.message); setBusy(false); }
+    try { await onCreate(name.trim() || undefined, provision, prompt.trim() || undefined); } catch (e) { setErr(e.message); setBusy(false); }
   };
   const savePreset = async () => {
     setErr('');
@@ -443,6 +444,9 @@ function NewEnvModal({ presets, onClose, onCreate, onSavePreset, onDeletePreset 
         <p class="muted">Builds a fresh WordPress devbox (≈1 min) with the target plugin checked out. Leave everything below blank for a plain site, or provision it with a setup script, wp-config defines, and plugins to activate — saved as reusable presets in this browser's server.</p>
         <label>Name (optional)
           <input value=${name} placeholder="my-devbox (a-z, 0-9, -)" onInput=${(e) => setName(e.target.value)} />
+        </label>
+        <label>First prompt <span class="muted small">— optional; once the env is ready, a Claude session starts with this</span>
+          <textarea rows="3" value=${prompt} placeholder="e.g. Add a custom field to the Oxygen builder and verify it renders." onInput=${(e) => setPrompt(e.target.value)}></textarea>
         </label>
         <label>Preset
           <div class="row">
@@ -520,8 +524,8 @@ function App() {
     const s = await api(`/environments/${envId}/sessions`, { method: 'POST', body: JSON.stringify({ prompt, model }) });
     setNewSession(null); await refresh(); setSelectedId(s.id);
   };
-  const createEnv = async (name, provision) => {
-    await api('/environments', { method: 'POST', body: JSON.stringify({ name, provision }) });
+  const createEnv = async (name, provision, prompt) => {
+    await api('/environments', { method: 'POST', body: JSON.stringify({ name, provision, prompt }) });
     setShowNewEnv(false); refresh();
   };
   const savePreset = async (preset) => {


### PR DESCRIPTION
Adds an optional prompt to environment creation: the env does its normal provisioning, and once it's `running`, a Claude session is started in it with that prompt.

- **`POST /environments`** accepts `prompt` (and optional `model`). The manager carries it in-memory through the create pipeline and, right after the env reaches `running`, fires a new `onEnvReady(env, { prompt, model })` hook.
- **`index.js`** wires that hook to `claudeEngine.newSession(env, …)` — kept as a hook so the manager doesn't depend on the session engine directly.
- **Best-effort**: a session-start failure logs a warning and does **not** fail the environment. The hook fires only on a successful build, and not at all when no prompt is given.
- **UI**: the New Environment modal gains an optional "First prompt" field; the session appears nested under the env once the build completes.

## Verification
Stubbed-pipeline unit check: with a prompt → env `running` + hook fires with the prompt/model/dir; without a prompt → no fire; on a failed build → no fire. Route accepts/normalizes `prompt`/`model`. Full parse check on all changed files.

Note: the pending prompt is in-memory only — if the server restarts mid-build, the session won't auto-start (the env still finishes). Can persist it if that matters.

Not merged — opening for review/live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)