### PR TITLE
feat(server): Settings page — manage tokens + WP-admin defaults in a config file

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -3,16 +3,23 @@
 # `.env` is gitignored. `npm start` loads it automatically. Real environment
 # variables already set take precedence over .env (so systemd/export still work).
 
-# --- Required: shared credentials applied to every environment ---------------
-# Cursor service-account / user API key (Cursor dashboard → Settings → API Keys).
-CURSOR_API_KEY=
-# GitHub token so the workers can clone/commit/push (repo scope).
+# --- Required: API password --------------------------------------------------
+# Bearer token for THIS server's API (you invent it) — the password to reach the
+# server/UI. If set, every request must send `Authorization: Bearer <value>`.
+# Required to bind a non-loopback address. Generate one: openssl rand -hex 32
+DEVBOX_API_TOKEN=
+
+# --- Optional: credential seeds (managed on the Settings page now) -----------
+# The GitHub + Claude tokens and the WP-admin defaults live in data/settings.json
+# and are edited in the UI (gear icon → Settings). These env vars only SEED that
+# file on first run, so you can pre-provision a fresh deploy; after that, Settings
+# is authoritative. Leave blank to set them in the UI instead.
 GITHUB_TOKEN=
+CLAUDE_CODE_OAUTH_TOKEN=
+# Cursor key stays env-only (optional; the Cursor worker reads it).
+CURSOR_API_KEY=
 
 # --- Recommended ------------------------------------------------------------
-# Bearer token for THIS server's API (you invent it). If set, every request must
-# send `Authorization: Bearer <value>`. Generate one with: openssl rand -hex 32
-DEVBOX_API_TOKEN=
 
 # Commit identity the workers use.
 GIT_AUTHOR_NAME=devbox

--- a/server/src/claude.js
+++ b/server/src/claude.js
@@ -18,10 +18,11 @@ import { log, redact } from './log.js';
 const CLAUDE_CWD = '/home/node'; // in-workspace.sh runs claude here (container WORKDIR)
 
 export class ClaudeEngine {
-  constructor(config, store, bus) {
+  constructor(config, store, bus, settings) {
     this.config = config;
     this.store = store;
     this.bus = bus;
+    this.settings = settings;
     this.active = new Map(); // sessionId -> { child, ndjson }
   }
 
@@ -85,7 +86,12 @@ export class ClaudeEngine {
     this.bus.publish(session.id, promptEvt);
 
     // stdin ignored → in-workspace.sh sees a non-TTY → adds -T → clean stream-json.
-    const child = spawn('bash', args, { cwd: env.dir, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
+    // Inject the Claude token from Settings (if set) so in-workspace.sh resolves
+    // CLAUDE_CODE_OAUTH_TOKEN from it; otherwise it falls back to the host's env /
+    // ~/.agent-sandbox/oauth-token exactly as before.
+    const claudeToken = this.settings && this.settings.get().claudeToken;
+    const childEnv = claudeToken ? { ...process.env, CLAUDE_CODE_OAUTH_TOKEN: claudeToken } : process.env;
+    const child = spawn('bash', args, { cwd: env.dir, env: childEnv, stdio: ['ignore', 'pipe', 'pipe'] });
     const entry = { child, ndjson, interrupting: false };
     this.active.set(session.id, entry);
 

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -26,16 +26,10 @@ function parseRange(raw, fallback) {
 }
 
 export function loadConfig(env = process.env) {
-  const missing = [];
-  if (!env.CURSOR_API_KEY) missing.push('CURSOR_API_KEY');
-  if (!env.GITHUB_TOKEN) missing.push('GITHUB_TOKEN');
-  if (missing.length) {
-    throw new Error(
-      `Missing required env: ${missing.join(', ')}. ` +
-        `These are the shared Cursor + GitHub credentials applied to every environment.`,
-    );
-  }
-
+  // Credentials (GitHub + Claude tokens, WP admin defaults) are managed on the
+  // Settings page now and stored in data/settings.json — env vars only SEED that
+  // file on first run, so none are required to boot. (DEVBOX_API_TOKEN is the
+  // exception — it gates this very API, so it must be set before start.)
   const dataDir = abs(env.DEVBOX_DATA_DIR, join(SERVER_ROOT, 'data'));
 
   const config = {
@@ -51,6 +45,11 @@ export function loadConfig(env = process.env) {
     envsDir: abs(env.DEVBOX_ENVS_DIR, join(dataDir, 'envs')),
     registryPath: join(dataDir, 'registry.json'),
     presetsPath: join(dataDir, 'presets.json'),
+    settingsPath: join(dataDir, 'settings.json'),
+    // Server-scoped XDG_CONFIG_HOME handed to the scaffolder so the WP-admin
+    // defaults from Settings seed new sites WITHOUT touching the operator's real
+    // ~/.config/create-wp-local-dev-agent-sandbox/config.json.
+    scaffolderConfigHome: join(dataDir, 'xdg'),
     // Scratch space where the server materializes a create's setup-script /
     // defines files to hand the scaffolder as --setup-script / --defines paths.
     // The scaffolder copies their contents into the project (scripts/user-setup.sh
@@ -63,9 +62,12 @@ export function loadConfig(env = process.env) {
     buildConcurrency: Math.max(1, parseInt(env.BUILD_CONCURRENCY || '2', 10)),
     reconcileIntervalMs: parseInt(env.RECONCILE_INTERVAL_MS || '45000', 10),
 
-    // Credentials (shared across all environments)
-    cursorApiKey: env.CURSOR_API_KEY,
-    githubToken: env.GITHUB_TOKEN,
+    // Cursor key stays env-sourced (optional; the worker reads it). GitHub +
+    // Claude tokens are managed in Settings — these env values only seed the
+    // settings file on first run.
+    cursorApiKey: env.CURSOR_API_KEY || null,
+    seedGithubToken: env.GITHUB_TOKEN || '',
+    seedClaudeToken: env.CLAUDE_CODE_OAUTH_TOKEN || '',
     gitAuthorName: env.GIT_AUTHOR_NAME || 'devbox',
     gitAuthorEmail: env.GIT_AUTHOR_EMAIL || 'devbox@localhost',
 
@@ -112,7 +114,8 @@ export function loadConfig(env = process.env) {
     );
   }
 
-  // The set of secret strings the logger must redact.
-  config.secrets = [config.cursorApiKey, config.githubToken].filter(Boolean);
+  // Initial secret strings for the log redactor (env-seeded). Tokens managed in
+  // Settings are added to the redactor after the settings store loads.
+  config.secrets = [config.cursorApiKey, config.seedGithubToken, config.seedClaudeToken].filter(Boolean);
   return Object.freeze(config);
 }

--- a/server/src/gitauth.js
+++ b/server/src/gitauth.js
@@ -23,12 +23,16 @@ const SCRIPT = [
   'git config --global user.email "$GIT_AUTHOR_EMAIL"',
 ].join(' && ');
 
-export async function configure(env, config) {
+export async function configure(env, config, githubToken) {
+  if (!githubToken) {
+    log.warn(`[${env.name}] no GitHub token set (Settings) — skipping git auth; clone/push of private repos will fail.`);
+    return false;
+  }
   try {
     await exec(env, 'workspace', ['sh', '-lc', SCRIPT], {
       envNames: ['DEVBOX_GH_TOKEN', 'GIT_AUTHOR_NAME', 'GIT_AUTHOR_EMAIL'],
       envValues: {
-        DEVBOX_GH_TOKEN: config.githubToken,
+        DEVBOX_GH_TOKEN: githubToken,
         GIT_AUTHOR_NAME: config.gitAuthorName,
         GIT_AUTHOR_EMAIL: config.gitAuthorEmail,
       },

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -7,9 +7,10 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
 
 import { loadConfig } from './config.js';
-import { initLog, log } from './log.js';
+import { initLog, addSecrets, log } from './log.js';
 import { Registry } from './registry.js';
 import { PresetStore } from './presets.js';
+import { SettingsStore } from './settings.js';
 import { Manager } from './manager.js';
 import { SessionStore } from './sessions.js';
 import { SessionBus } from './sessionbus.js';
@@ -38,13 +39,19 @@ async function main() {
 
   const registry = await new Registry(config.registryPath).load();
   const presets = await new PresetStore(config.presetsPath).load();
-  const manager = new Manager(config, registry);
+  // Mutable settings (tokens + WP-admin defaults), seeded from env on first run.
+  const settings = await new SettingsStore(config.settingsPath, {
+    githubToken: config.seedGithubToken,
+    claudeToken: config.seedClaudeToken,
+  }).load();
+  addSecrets(settings.secrets()); // redact the stored tokens from logs too
+  const manager = new Manager(config, registry, settings);
 
   // Claude session subsystem.
   const sessionStore = await new SessionStore(config.sessionsPath).load();
   await sessionStore.reconcile(); // running → interrupted (resumable; jsonl persists)
   const sessionBus = new SessionBus(config.sessionRingBufferSize);
-  const claudeEngine = new ClaudeEngine(config, sessionStore, sessionBus);
+  const claudeEngine = new ClaudeEngine(config, sessionStore, sessionBus, settings);
   const sessions = { store: sessionStore, engine: claudeEngine, bus: sessionBus };
 
   // When an env finishes provisioning, optionally kick off its initial session
@@ -55,7 +62,7 @@ async function main() {
     log.info(`[${env.name}] started initial session ${s.id}`);
   };
 
-  const routes = buildRoutes(config, registry, manager, sessions, presets);
+  const routes = buildRoutes(config, registry, manager, sessions, presets, settings);
   const server = createServer(config, routes);
 
   server.listen(config.port, config.bind, () => {

--- a/server/src/log.js
+++ b/server/src/log.js
@@ -14,6 +14,14 @@ export function initLog(secrets = []) {
   SECRETS = secrets.filter((s) => typeof s === 'string' && s.length >= 6);
 }
 
+// Merge more secret values into the redaction set at runtime (e.g. after a token
+// is changed on the Settings page), so they're scrubbed from subsequent logs.
+export function addSecrets(secrets = []) {
+  for (const s of secrets) {
+    if (typeof s === 'string' && s.length >= 6 && !SECRETS.includes(s)) SECRETS.push(s);
+  }
+}
+
 export function redact(value) {
   let s = typeof value === 'string' ? value : safeStringify(value);
   for (const secret of SECRETS) s = s.split(secret).join('***');

--- a/server/src/manager.js
+++ b/server/src/manager.js
@@ -36,11 +36,25 @@ class Semaphore {
 }
 
 export class Manager {
-  constructor(config, registry) {
+  constructor(config, registry, settings) {
     this.config = config;
     this.registry = registry;
+    this.settings = settings;
     this.jobs = new Map(); // id -> transient state string
     this.buildSem = new Semaphore(config.buildConcurrency);
+  }
+
+  // Write the WP-admin defaults from Settings into a server-scoped
+  // XDG_CONFIG_HOME config.json that the scaffolder reads (seeds each new site's
+  // admin account). Kept out of the operator's real ~/.config.
+  async _writeScaffolderConfig() {
+    const s = this.settings.get();
+    const dir = join(this.config.scaffolderConfigHome, 'create-wp-local-dev-agent-sandbox');
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, 'config.json'),
+      JSON.stringify({ wpAdminUser: s.wpAdminUser, wpAdminPassword: s.wpAdminPassword, wpAdminEmail: s.wpAdminEmail }, null, 2),
+    );
   }
 
   // ---- create -------------------------------------------------------------
@@ -105,6 +119,7 @@ export class Manager {
       //    Bounded by the build semaphore; output captured to the setup log.
       this.jobs.set(record.id, 'setting-up');
       await registry.update(record.id, { status: 'setting-up', setupStartedAt: new Date().toISOString() });
+      await this._writeScaffolderConfig(); // seed WP-admin defaults for the scaffolder
       const scaffoldArgs = [
         join(config.scaffolderDir, 'index.js'),
         record.dir,
@@ -116,6 +131,7 @@ export class Manager {
           logPath: record.setupLogPath,
           truncate: true,
           timeout: 30 * 60 * 1000,
+          env: { XDG_CONFIG_HOME: config.scaffolderConfigHome },
         }),
       );
       // The scaffolder has copied the provisioning inputs into the project
@@ -130,7 +146,7 @@ export class Manager {
       //    plugin for a git checkout — is done by presets during setup now.)
       this.jobs.set(record.id, 'configuring');
       await registry.update(record.id, { status: 'configuring' });
-      await gitauth.configure(record, config);
+      await gitauth.configure(record, config, this.settings.get().githubToken);
 
       // 3. Optionally start the named Cursor worker.
       if (config.cursorWorkerAutostart) {
@@ -201,7 +217,7 @@ export class Manager {
     this.jobs.set(record.id, 'starting-worker');
     try {
       await docker.npmRun(record, 'start', { timeout: 600_000 }); // up -d --build (cached)
-      await gitauth.configure(record, this.config);
+      await gitauth.configure(record, this.config, this.settings.get().githubToken);
       if (this.config.cursorWorkerAutostart) await workerMod.start(record, this.config);
       await this.registry.update(record.id, {
         status: 'running',
@@ -269,7 +285,7 @@ export class Manager {
         const alive = await workerMod.isRunning(record, this.config);
         if (!alive && record.status !== 'stopped') {
           log.info(`[${record.name}] worker not running but stack is up — relaunching`);
-          await gitauth.configure(record, this.config);
+          await gitauth.configure(record, this.config, this.settings.get().githubToken);
           await workerMod.start(record, this.config);
           await this.registry.update(record.id, { status: 'running', workerStartedAt: new Date().toISOString() });
         } else if (alive && record.status !== 'running') {

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -3,12 +3,13 @@
 
 import { readFile, rm } from 'node:fs/promises';
 import { route } from './http.js';
+import { addSecrets } from './log.js';
 import { hostInfo } from './docker.js';
 import { AllocationError } from './allocator.js';
 import { openSse } from './sse.js';
 import { makeStaticHandler } from './static.js';
 
-export function buildRoutes(config, registry, manager, sessions, presets) {
+export function buildRoutes(config, registry, manager, sessions, presets, settings) {
   const staticHandler = makeStaticHandler(config.uiRoot);
 
   const envOr404 = (ctx) => {
@@ -106,6 +107,14 @@ export function buildRoutes(config, registry, manager, sessions, presets) {
       for (const s of sessions.store.listByEnv(env.id)) await deleteSession(s);
       await manager.destroy(env);
       ctx.send(200, { deleted: true });
+    }),
+
+    // ---- settings (tokens + WP-admin defaults; secrets masked in responses) --
+    route('GET', '/settings', async (ctx) => ctx.send(200, settings.publicView())),
+    route('PUT', '/settings', async (ctx) => {
+      const view = await settings.update(ctx.body || {});
+      addSecrets(settings.secrets()); // keep the log redactor current
+      ctx.send(200, view);
     }),
 
     // ---- provisioning presets (saved blueprints, stored in the data dir) ---

--- a/server/src/settings.js
+++ b/server/src/settings.js
@@ -1,0 +1,104 @@
+// Mutable app settings — the secrets + defaults a user edits on the Settings
+// page, persisted to data/settings.json. Mirrors registry.js (async mutex +
+// atomic temp+rename write).
+//
+// Holds the GitHub token (git auth in the workspace), the Claude OAuth token
+// (injected into the `claude` spawn env), and the default WordPress admin
+// account seeded into new sites. The DEVBOX_API_TOKEN (the app's bearer
+// password) is NOT here — it gates access to this very API, so it stays an env
+// var set before the server starts.
+//
+// On first run the file is seeded from the environment (GITHUB_TOKEN,
+// CLAUDE_CODE_OAUTH_TOKEN) so existing .env-based setups keep working; after
+// that the file is authoritative.
+
+import { readFile, writeFile, rename, mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { createMutex } from './registry.js';
+
+// Fields treated as secrets: masked in API responses, only overwritten when a
+// non-empty value is supplied, and fed to the log redactor.
+const SECRET_FIELDS = ['githubToken', 'claudeToken', 'wpAdminPassword'];
+
+function defaults() {
+  return {
+    githubToken: '',
+    claudeToken: '',
+    wpAdminUser: 'admin',
+    wpAdminPassword: 'password',
+    wpAdminEmail: 'admin@example.com',
+  };
+}
+
+export class SettingsStore {
+  // `seed` supplies env-derived initial values used only when the file is absent.
+  constructor(path, seed = {}) {
+    this.path = path;
+    this.seed = seed;
+    this.data = { version: 1, settings: defaults() };
+    this.mutex = createMutex();
+  }
+
+  async load() {
+    try {
+      const parsed = JSON.parse(await readFile(this.path, 'utf8'));
+      if (parsed && parsed.settings) this.data = { version: 1, settings: { ...defaults(), ...parsed.settings } };
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err;
+      await mkdir(dirname(this.path), { recursive: true });
+      const seeded = {};
+      for (const [k, v] of Object.entries(this.seed)) if (typeof v === 'string' && v) seeded[k] = v;
+      this.data = { version: 1, settings: { ...defaults(), ...seeded } };
+      await this._persist();
+    }
+    return this;
+  }
+
+  // Full settings incl. secret values — server-side use only (never sent to a client).
+  get() {
+    return { ...this.data.settings };
+  }
+
+  // Current secret strings, for the log redactor.
+  secrets() {
+    return SECRET_FIELDS.map((k) => this.data.settings[k]).filter((s) => typeof s === 'string' && s.length >= 6);
+  }
+
+  // Client-safe view: secrets masked to { set, hint }, never the raw value.
+  publicView() {
+    const s = this.data.settings;
+    const mask = (v) => (v ? { set: true, hint: `••••${String(v).slice(-4)}` } : { set: false });
+    return {
+      githubToken: mask(s.githubToken),
+      claudeToken: mask(s.claudeToken),
+      wpAdminUser: s.wpAdminUser,
+      wpAdminEmail: s.wpAdminEmail,
+      wpAdminPassword: mask(s.wpAdminPassword),
+    };
+  }
+
+  // Apply a patch from the Settings form. Non-secret fields are set when a
+  // non-empty value is given; secret fields are overwritten only when non-empty
+  // (a blank field means "leave the stored secret unchanged"), so saving the
+  // form doesn't wipe a token you didn't retype.
+  update(patch = {}) {
+    return this.mutex(async () => {
+      const next = { ...this.data.settings };
+      for (const k of ['wpAdminUser', 'wpAdminEmail']) {
+        if (typeof patch[k] === 'string' && patch[k].trim()) next[k] = patch[k].trim();
+      }
+      for (const k of SECRET_FIELDS) {
+        if (typeof patch[k] === 'string' && patch[k] !== '') next[k] = patch[k];
+      }
+      this.data.settings = next;
+      await this._persist();
+      return this.publicView();
+    });
+  }
+
+  async _persist() {
+    const tmp = join(dirname(this.path), `.settings.${process.pid}.tmp`);
+    await writeFile(tmp, JSON.stringify(this.data, null, 2));
+    await rename(tmp, this.path);
+  }
+}

--- a/server/ui/app.js
+++ b/server/ui/app.js
@@ -480,6 +480,72 @@ function NewEnvModal({ presets, onClose, onCreate, onSavePreset, onDeletePreset 
     </div>`;
 }
 
+function SettingsModal({ onClose, onLogout }) {
+  const [s, setS] = useState(null);
+  const [ghToken, setGh] = useState('');
+  const [clToken, setCl] = useState('');
+  const [wpUser, setWpUser] = useState('');
+  const [wpEmail, setWpEmail] = useState('');
+  const [wpPass, setWpPass] = useState('');
+  const [err, setErr] = useState('');
+  const [saved, setSaved] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try { const d = await api('/settings'); setS(d); setWpUser(d.wpAdminUser || ''); setWpEmail(d.wpAdminEmail || ''); }
+      catch (e) { setErr(e.message); }
+    })();
+  }, []);
+
+  const hint = (f) => (s && s[f] && s[f].set ? `configured ${s[f].hint} · leave blank to keep` : 'not set');
+  const save = async () => {
+    setBusy(true); setErr(''); setSaved(false);
+    try {
+      const body = { wpAdminUser: wpUser, wpAdminEmail: wpEmail };
+      if (ghToken) body.githubToken = ghToken;
+      if (clToken) body.claudeToken = clToken;
+      if (wpPass) body.wpAdminPassword = wpPass;
+      const d = await api('/settings', { method: 'PUT', body: JSON.stringify(body) });
+      setS(d); setGh(''); setCl(''); setWpPass(''); setSaved(true);
+    } catch (e) { setErr(e.message); } finally { setBusy(false); }
+  };
+
+  return html`
+    <div class="modal-bg" onClick=${onClose}>
+      <div class="modal" onClick=${(e) => e.stopPropagation()}>
+        <h3>Settings</h3>
+        ${!s && !err && html`<div class="muted">Loading…</div>`}
+        ${s && html`
+          <p class="muted small">Saved on the server (<code>data/settings.json</code>). Tokens are write-only — set or replace them here; they're never shown back.</p>
+          <label>GitHub token <span class="muted small">— ${hint('githubToken')}</span>
+            <input type="password" value=${ghToken} placeholder="ghp_… / github_pat_…" onInput=${(e) => setGh(e.target.value)} />
+          </label>
+          <label>Claude token <span class="muted small">— ${hint('claudeToken')}</span>
+            <input type="password" value=${clToken} placeholder="sk-ant-oat… (from claude setup-token)" onInput=${(e) => setCl(e.target.value)} />
+          </label>
+          <label>WordPress admin username
+            <input value=${wpUser} onInput=${(e) => setWpUser(e.target.value)} />
+          </label>
+          <label>WordPress admin password <span class="muted small">— ${hint('wpAdminPassword')}</span>
+            <input type="password" value=${wpPass} placeholder="leave blank to keep" onInput=${(e) => setWpPass(e.target.value)} />
+          </label>
+          <label>WordPress admin email
+            <input value=${wpEmail} onInput=${(e) => setWpEmail(e.target.value)} />
+          </label>
+          <p class="muted small">Token changes apply to newly-created environments and new Claude turns. WP-admin defaults seed new sites.</p>`}
+        ${err && html`<div class="err-msg">${err}</div>`}
+        ${saved && html`<div class="ok-msg">Saved.</div>`}
+        <div class="modal-foot">
+          <button class="lnk" onClick=${onLogout} title="Forget the API token on this device">Log out</button>
+          <span class="spacer"></span>
+          <button class="btn ghost" onClick=${onClose}>Close</button>
+          <button class="btn" onClick=${save} disabled=${!s || busy}>${busy ? 'Saving…' : 'Save'}</button>
+        </div>
+      </div>
+    </div>`;
+}
+
 function TokenGate({ onSave }) {
   const [val, setVal] = useState(token.get());
   return html`
@@ -503,6 +569,7 @@ function App() {
   const [logEnvId, setLogEnvId] = useState(null);
   const [needToken, setNeedToken] = useState(false);
   const [authed, setAuthed] = useState(!!token.get());
+  const [showSettings, setShowSettings] = useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -561,7 +628,7 @@ function App() {
     <div class=${`layout ${selected ? 'has-selection' : ''}`}>
       <${Sidebar} sessions=${sessions} envs=${envs} selectedId=${selectedId}
         onSelect=${setSelectedId} onNewEnv=${() => setShowNewEnv(true)}
-        onEnvAction=${envAction} onSettings=${() => setAuthed(false)} onDeleteSession=${deleteSession} />
+        onEnvAction=${envAction} onSettings=${() => setShowSettings(true)} onDeleteSession=${deleteSession} />
       ${selected
         ? html`<${SessionView} session=${selected} key=${selected.id} onChanged=${refresh} onBack=${() => setSelectedId(null)} onDelete=${() => deleteSession(selected)} />`
         : html`<section class="main empty"><div class="muted">
@@ -572,6 +639,8 @@ function App() {
       ${newSession && html`<${NewSessionModal} envs=${envs} preselect=${newSession.preselect} onClose=${() => setNewSession(null)} onCreate=${createSession} />`}
       ${showNewEnv && html`<${NewEnvModal} presets=${presets} onClose=${() => setShowNewEnv(false)} onCreate=${createEnv} onSavePreset=${savePreset} onDeletePreset=${deletePreset} />`}
       ${logEnvId && logEnv && html`<${LogViewer} env=${logEnv} onClose=${() => setLogEnvId(null)} />`}
+      ${showSettings && html`<${SettingsModal} onClose=${() => setShowSettings(false)}
+        onLogout=${() => { token.set(''); setShowSettings(false); setAuthed(false); setNeedToken(true); }} />`}
     </div>`;
 }
 

--- a/server/ui/style.css
+++ b/server/ui/style.css
@@ -114,6 +114,8 @@ pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12.5px/1.5
   border: 1px solid var(--line); border-radius: 8px; padding: 9px; font: inherit; }
 .modal-foot { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; }
 .err-msg { color: var(--red); margin-top: 10px; font-size: 13px; }
+.ok-msg { color: var(--green); margin-top: 10px; font-size: 13px; }
+.modal-foot .spacer { flex: 1; }
 .modal.wide { width: 560px; max-height: 90vh; overflow-y: auto; }
 .modal textarea.mono { resize: vertical; font: 12.5px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .modal .row { display: flex; gap: 8px; align-items: center; }


### PR DESCRIPTION
Adds a **Settings** screen (gear icon, behind the existing API-token login) backed by `data/settings.json`, so the **GitHub token**, **Claude token**, and **default WP admin username / password / email** are editable in the UI instead of baked into env vars.

## Where things came from before
- GitHub token: `GITHUB_TOKEN` env (required at boot) → `gitauth`.
- Claude token: not held by the server — `in-workspace.sh` resolved it from the spawned child's inherited env.
- WP admin: the scaffolder read `~/.config/create-wp-local-dev-agent-sandbox/config.json`.

## Now
- **`SettingsStore`** → `data/settings.json` (mutex + atomic write). **Seeded on first run** from `GITHUB_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` env, so existing `.env` setups keep working; authoritative after that.
- **Consumers read live settings**: `gitauth` uses `settings.githubToken` (warns + skips if unset); the `claude` spawn injects `CLAUDE_CODE_OAUTH_TOKEN=settings.claudeToken`; env-create writes the WP-admin defaults into a **server-scoped `XDG_CONFIG_HOME`** `config.json` the scaffolder reads — so it never clobbers the operator's real `~/.config`.
- **`config.js`** no longer requires `GITHUB_TOKEN`/`CURSOR_API_KEY` at boot (only `DEVBOX_API_TOKEN`, and only for non-loopback binds).
- **Logging**: `addSecrets()` keeps the redactor current when a token is changed at runtime.
- **API**: `GET /settings` returns non-secrets in full and secrets **masked** (`{set, hint:"••••1234"}`, never plaintext — per the existing "no secrets in responses" rule); `PUT /settings` saves (a blank secret field means "leave unchanged", so saving the form never wipes a token).
- **UI**: `SettingsModal` — token fields are write-only with a "configured ••••1234 · leave blank to keep" hint; WP-admin fields prefilled. Opened from the gear; a "Log out" action inside it clears the locally-stored API token.

## Verification (throwaway instance + unit checks)
- First-run seeding from env; `GET` masks all three secrets; `PUT` changes user/email/password + a new Claude token while leaving a blank GitHub field **unchanged**; re-`GET` reflects that; **no plaintext secret appears in any response**; `data/settings.json` holds the real values.
- `manager._writeScaffolderConfig()` writes `<xdg>/create-wp-local-dev-agent-sandbox/config.json` (exactly the scaffolder's `USER_CONFIG_PATH`) with the WP-admin fields.
- All files parse; config boots with **no** token env vars set.

Not merged — opening for review/live test. Needs a server restart + browser refresh.

Note: WP-admin passwords flow into the project `.env` (sourced by `install-wp.sh`), so a password with spaces or shell metacharacters could break that sourcing — a pre-existing scaffolder `.env` limitation, worth keeping in mind when choosing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)