### PR TITLE
feat(server): system health screen (memory/CPU/disk/docker + RAM headroom)

### DIFF
--- a/server/src/docker.js
+++ b/server/src/docker.js
@@ -77,33 +77,4 @@ export async function listProjects() {
   }
 }
 
-// Host pressure snapshot for GET /host.
-export async function hostInfo() {
-  const out = {};
-  await Promise.all([
-    run('docker', ['system', 'df', '--format', 'json'])
-      .then(({ stdout }) => {
-        out.dockerDf = stdout.trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
-      })
-      .catch(() => {
-        out.dockerDf = null;
-      }),
-    run('docker', ['ps', '-q'])
-      .then(({ stdout }) => {
-        out.runningContainers = stdout.trim() ? stdout.trim().split('\n').length : 0;
-      })
-      .catch(() => {
-        out.runningContainers = null;
-      }),
-    run('df', ['-h', '/'])
-      .then(({ stdout }) => {
-        out.diskRoot = stdout.trim().split('\n').slice(1).join('\n');
-      })
-      .catch(() => {
-        out.diskRoot = null;
-      }),
-  ]);
-  return out;
-}
-
 export { join };

--- a/server/src/health.js
+++ b/server/src/health.js
@@ -1,0 +1,115 @@
+// System-health snapshot: memory, CPU load, disk, and Docker resource usage,
+// plus per-environment container memory and a "how many more envs fit" estimate.
+//
+// The crash vector on a typical (swap-less) cloud box is MEMORY — once RAM is
+// exhausted the OOM killer starts dropping processes — so RAM headroom is the
+// headline. Disk is the slower-burning second risk (image layers + build cache +
+// each env's bind-mounted WordPress/node_modules).
+
+import os from 'node:os';
+import { readFile } from 'node:fs/promises';
+import { run } from './docker.js';
+
+// /proc/meminfo (kB) → bytes. MemAvailable is the kernel's own estimate of how
+// much can be allocated before swapping/OOM — the number that matters.
+function parseMeminfo(text) {
+  const kv = {};
+  for (const line of text.split('\n')) {
+    const m = line.match(/^(\w+):\s+(\d+)\s*kB/);
+    if (m) kv[m[1]] = parseInt(m[2], 10) * 1024;
+  }
+  const total = kv.MemTotal || 0;
+  const available = kv.MemAvailable != null ? kv.MemAvailable : kv.MemFree || 0;
+  return {
+    totalBytes: total,
+    availableBytes: available,
+    usedBytes: Math.max(0, total - available),
+    usedPct: total ? Math.round(((total - available) / total) * 100) : null,
+    swapTotalBytes: kv.SwapTotal || 0,
+    swapUsedBytes: Math.max(0, (kv.SwapTotal || 0) - (kv.SwapFree || 0)),
+  };
+}
+
+// "1.151GiB / 31.34GiB" → bytes (the used part).
+function parseMemUsage(s) {
+  const m = String(s).match(/([\d.]+)\s*([KMGT]?i?B)/i);
+  if (!m) return 0;
+  const mult = { B: 1, KIB: 1024, MIB: 1024 ** 2, GIB: 1024 ** 3, TIB: 1024 ** 4,
+    KB: 1e3, MB: 1e6, GB: 1e9, TB: 1e12 }[m[2].toUpperCase()] || 1;
+  return Math.round(parseFloat(m[1]) * mult);
+}
+
+async function diskFor(path) {
+  try {
+    const { stdout } = await run('df', ['-PB1', path]);
+    const f = stdout.trim().split('\n').slice(-1)[0].split(/\s+/);
+    const totalBytes = parseInt(f[1], 10);
+    const usedBytes = parseInt(f[2], 10);
+    const availBytes = parseInt(f[3], 10);
+    return { totalBytes, usedBytes, availBytes, usedPct: totalBytes ? Math.round((usedBytes / totalBytes) * 100) : null };
+  } catch { return null; }
+}
+
+async function dockerStats() {
+  try {
+    const { stdout } = await run('docker', ['stats', '--no-stream', '--format', '{{.Name}}\t{{.MemUsage}}\t{{.CPUPerc}}'], { timeout: 25_000 });
+    return stdout.trim().split('\n').filter(Boolean).map((l) => {
+      const [name, mem, cpu] = l.split('\t');
+      return { name, memBytes: parseMemUsage(mem), cpuPct: parseFloat(cpu) || 0 };
+    });
+  } catch { return []; }
+}
+
+async function dockerDf() {
+  try {
+    const { stdout } = await run('docker', ['system', 'df', '--format', 'json']);
+    return stdout.trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+  } catch { return null; }
+}
+
+async function count(args) {
+  try {
+    const { stdout } = await run('docker', args);
+    return stdout.trim() ? stdout.trim().split('\n').length : 0;
+  } catch { return null; }
+}
+
+export async function systemHealth(config, registry) {
+  const envs = registry.list();
+  const [meminfoText, disk, stats, df, running, total] = await Promise.all([
+    readFile('/proc/meminfo', 'utf8').catch(() => ''),
+    diskFor(config.dataDir),
+    dockerStats(),
+    dockerDf(),
+    count(['ps', '-q']),
+    count(['ps', '-aq']),
+  ]);
+
+  const memory = parseMeminfo(meminfoText);
+  const cpu = { cores: os.cpus().length, loadavg: os.loadavg() };
+
+  // Per-env container memory: a container belongs to env <name> when its name is
+  // "<name>" or "<name>-<service>-N" (compose default project = the env name).
+  const perEnv = envs
+    .map((e) => {
+      const cs = stats.filter((s) => s.name === e.name || s.name.startsWith(`${e.name}-`));
+      return { name: e.name, status: e.status, containers: cs.length, memBytes: cs.reduce((a, c) => a + c.memBytes, 0) };
+    })
+    .sort((a, b) => b.memBytes - a.memBytes);
+
+  const liveEnvs = perEnv.filter((e) => e.containers > 0);
+  const envMemBytes = liveEnvs.reduce((a, e) => a + e.memBytes, 0);
+  const avgEnvMemBytes = liveEnvs.length ? Math.round(envMemBytes / liveEnvs.length) : 0;
+  // How many more like-sized envs fit in the currently-available RAM.
+  const ramHeadroomEnvs = avgEnvMemBytes ? Math.floor(memory.availableBytes / avgEnvMemBytes) : null;
+
+  return {
+    memory,
+    cpu,
+    disk,
+    docker: { df, containersRunning: running, containersTotal: total },
+    environments: { count: envs.length, max: config.maxEnvironments, running: liveEnvs.length },
+    perEnv,
+    estimate: { avgEnvMemBytes, ramHeadroomEnvs },
+  };
+}

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -4,7 +4,8 @@
 import { readFile, rm } from 'node:fs/promises';
 import { route } from './http.js';
 import { addSecrets } from './log.js';
-import { hostInfo, exec } from './docker.js';
+import { exec } from './docker.js';
+import { systemHealth } from './health.js';
 import { AllocationError } from './allocator.js';
 import { openSse } from './sse.js';
 import { makeStaticHandler } from './static.js';
@@ -60,14 +61,8 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
     route('GET', '/health', async (ctx) => ctx.send(200, { ok: true, version: 1 })),
 
     route('GET', '/host', async (ctx) => {
-      const info = await hostInfo();
-      ctx.send(200, {
-        ...info,
-        environments: registry.list().length,
-        sessions: sessions.store.list().length,
-        maxEnvironments: config.maxEnvironments,
-        loadavg: (await import('node:os')).loadavg(),
-      });
+      const h = await systemHealth(config, registry);
+      ctx.send(200, { ...h, sessions: sessions.store.list().length });
     }),
 
     // ---- environments -----------------------------------------------------

--- a/server/ui/app.js
+++ b/server/ui/app.js
@@ -134,7 +134,7 @@ function SessionItem({ s, selectedId, onSelect, onDelete, now }) {
     </div>`;
 }
 
-function Sidebar({ sessions, envs, selectedId, now, onSelect, onNewEnv, onEnvAction, onSettings, onDeleteSession }) {
+function Sidebar({ sessions, envs, selectedId, now, onSelect, onNewEnv, onEnvAction, onSettings, onHealth, onDeleteSession }) {
   const [expanded, setExpanded] = useState(() => new Set());
   const toggle = (id) => setExpanded((prev) => {
     const next = new Set(prev);
@@ -149,7 +149,10 @@ function Sidebar({ sessions, envs, selectedId, now, onSelect, onNewEnv, onEnvAct
     <aside class="sidebar">
       <div class="side-head">
         <strong>Devbox</strong>
-        <button class="btn small ghost" onClick=${onSettings} title="API token">⚙</button>
+        <div class="side-head-btns">
+          <button class="btn small ghost" onClick=${onHealth} title="System health">📊</button>
+          <button class="btn small ghost" onClick=${onSettings} title="Settings">⚙</button>
+        </div>
       </div>
       <div class="side-section grow">
         <div class="section-head"><span>Environments</span><button class="btn small" onClick=${onNewEnv}>+ Env</button></div>
@@ -584,6 +587,81 @@ function SettingsModal({ onClose, onLogout }) {
     </div>`;
 }
 
+function HealthBar({ pct, tone }) {
+  const w = Math.min(100, Math.max(0, Math.round(pct || 0)));
+  return html`<div class="hbar"><div class=${`hbar-fill ${tone}`} style=${`width:${w}%`}></div></div>`;
+}
+
+function HealthModal({ onClose }) {
+  const [h, setH] = useState(null);
+  const [err, setErr] = useState('');
+  useEffect(() => {
+    let stop = false;
+    const tick = async () => {
+      try { const d = await api('/host'); if (!stop) { setH(d); setErr(''); } }
+      catch (e) { if (!stop) setErr(e.message); }
+    };
+    tick();
+    const t = setInterval(tick, 5000); // docker stats is ~2s; poll gently
+    return () => { stop = true; clearInterval(t); };
+  }, []);
+
+  const gb = (b) => (b == null ? '—' : `${(b / 1024 ** 3).toFixed(b < 10 * 1024 ** 3 ? 1 : 0)} GB`);
+  const tone = (v, warn, bad) => (v >= bad ? 'bad' : v >= warn ? 'warn' : 'ok');
+  const dfRow = (t) => (h && h.docker.df ? h.docker.df.find((r) => r.Type === t) : null);
+  const m = h && h.memory, c = h && h.cpu, dsk = h && h.disk, est = h && h.estimate;
+  const load1 = c ? c.loadavg[0] : 0;
+
+  return html`
+    <div class="modal-bg" onClick=${onClose}>
+      <div class="modal wide health" onClick=${(e) => e.stopPropagation()}>
+        <h3>System health</h3>
+        ${err && html`<div class="err-msg">${err}</div>`}
+        ${!h && !err && html`<div class="muted">Loading… (gathering docker stats, ~2s)</div>`}
+        ${h && html`
+          <div class="hrow">
+            <span class="hlabel">Memory</span>
+            <${HealthBar} pct=${m.usedPct} tone=${tone(m.usedPct, 75, 90)} />
+            <span class="hval">${gb(m.usedBytes)} used · <b>${gb(m.availableBytes)} free</b> of ${gb(m.totalBytes)}${m.swapTotalBytes ? '' : ' · no swap'}</span>
+          </div>
+          <div class="hrow">
+            <span class="hlabel">CPU load</span>
+            <${HealthBar} pct=${(load1 / c.cores) * 100} tone=${tone(load1 / c.cores, 0.7, 1)} />
+            <span class="hval">${load1.toFixed(2)} (1m) of ${c.cores} cores · ${c.loadavg.map((x) => x.toFixed(2)).join(' / ')}</span>
+          </div>
+          ${dsk && html`<div class="hrow">
+            <span class="hlabel">Disk</span>
+            <${HealthBar} pct=${dsk.usedPct} tone=${tone(dsk.usedPct, 75, 90)} />
+            <span class="hval">${gb(dsk.usedBytes)} used · <b>${gb(dsk.availBytes)} free</b> of ${gb(dsk.totalBytes)}</span>
+          </div>`}
+          <div class="hrow">
+            <span class="hlabel">Docker</span>
+            <span class="hval wide-val">${h.docker.containersRunning}/${h.docker.containersTotal} containers${dfRow('Images') ? ` · images ${dfRow('Images').Size}` : ''}${dfRow('Build Cache') ? html` · build cache ${dfRow('Build Cache').Size} <span class="muted">(${dfRow('Build Cache').Reclaimable} reclaimable — run docker system prune)</span>` : ''}</span>
+          </div>
+          <div class=${`health-callout ${est.ramHeadroomEnvs != null && est.ramHeadroomEnvs <= 1 ? 'bad' : ''}`}>
+            ${est.ramHeadroomEnvs != null
+              ? html`Room for ≈ <b>${est.ramHeadroomEnvs}</b> more environment${est.ramHeadroomEnvs === 1 ? '' : 's'} in RAM — avg <b>${gb(est.avgEnvMemBytes)}</b>/env, ${h.environments.running} running.${m.swapTotalBytes ? '' : ' No swap: when free RAM hits zero the box starts OOM-killing processes, so keep headroom.'}`
+              : html`${h.environments.running} environments running.`}
+          </div>
+          <div class="muted small">Environments: ${h.environments.running} running · ${h.environments.count} total · cap ${h.environments.max}</div>
+          ${h.perEnv.length > 0 && html`
+            <table class="health-table">
+              <thead><tr><th>Environment</th><th>Status</th><th>Containers</th><th>Memory</th></tr></thead>
+              <tbody>
+                ${h.perEnv.map((e) => html`<tr key=${e.name}>
+                  <td>${e.name}</td>
+                  <td><${StatusDot} status=${e.status} /> ${e.status}</td>
+                  <td>${e.containers}</td>
+                  <td>${gb(e.memBytes)}</td>
+                </tr>`)}
+              </tbody>
+            </table>`}
+        `}
+        <div class="modal-foot"><button class="btn ghost" onClick=${onClose}>Close</button></div>
+      </div>
+    </div>`;
+}
+
 function TokenGate({ onSave }) {
   const [val, setVal] = useState(token.get());
   return html`
@@ -608,6 +686,7 @@ function App() {
   const [needToken, setNeedToken] = useState(false);
   const [authed, setAuthed] = useState(!!token.get());
   const [showSettings, setShowSettings] = useState(false);
+  const [showHealth, setShowHealth] = useState(false);
   const [now, setNow] = useState(() => Date.now());
 
   const refresh = useCallback(async () => {
@@ -693,7 +772,7 @@ function App() {
     <div class=${`layout ${selected ? 'has-selection' : ''}`}>
       <${Sidebar} sessions=${sessions} envs=${envs} selectedId=${selectedId} now=${now}
         onSelect=${setSelectedId} onNewEnv=${() => setShowNewEnv(true)}
-        onEnvAction=${envAction} onSettings=${() => setShowSettings(true)} onDeleteSession=${deleteSession} />
+        onEnvAction=${envAction} onSettings=${() => setShowSettings(true)} onHealth=${() => setShowHealth(true)} onDeleteSession=${deleteSession} />
       ${selected
         ? html`<${SessionView} session=${selected} key=${selected.id} now=${now} onChanged=${refresh} onBack=${() => setSelectedId(null)} onDelete=${() => deleteSession(selected)} />`
         : html`<section class="main empty"><div class="muted">
@@ -706,6 +785,7 @@ function App() {
       ${logEnvId && logEnv && html`<${LogViewer} env=${logEnv} onClose=${() => setLogEnvId(null)} />`}
       ${showSettings && html`<${SettingsModal} onClose=${() => setShowSettings(false)}
         onLogout=${() => { token.set(''); setShowSettings(false); setAuthed(false); setNeedToken(true); }} />`}
+      ${showHealth && html`<${HealthModal} onClose=${() => setShowHealth(false)} />`}
     </div>`;
 }
 

--- a/server/ui/style.css
+++ b/server/ui/style.css
@@ -16,6 +16,7 @@ pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12.5px/1.5
 /* sidebar */
 .sidebar { background: var(--panel); border-right: 1px solid var(--line); display: flex; flex-direction: column; min-height: 0; }
 .side-head { display: flex; justify-content: space-between; align-items: center; padding: 12px; border-bottom: 1px solid var(--line); }
+.side-head-btns { display: flex; gap: 6px; }
 .side-list { overflow-y: auto; flex: 1; }
 .side-section { border-bottom: 1px solid var(--line); display: flex; flex-direction: column; min-height: 0; }
 .side-section.grow { flex: 1; }
@@ -143,6 +144,23 @@ pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12.5px/1.5
 /* preset badge on an env row */
 .badge { font-size: 10px; text-transform: uppercase; letter-spacing: .03em; color: var(--accent);
   background: var(--accent2); border-radius: 99px; padding: 1px 7px; flex: none; }
+
+/* system health */
+.modal.health { width: 660px; }
+.hrow { display: grid; grid-template-columns: 92px 130px 1fr; align-items: center; gap: 12px; margin: 10px 0; font-size: 13px; }
+.hlabel { color: var(--muted); }
+.hval { color: var(--text); }
+.hval.wide-val { grid-column: 2 / 4; }
+.hbar { height: 8px; background: var(--panel2); border-radius: 99px; overflow: hidden; }
+.hbar-fill { height: 100%; background: var(--green); transition: width .3s; }
+.hbar-fill.warn { background: var(--amber); }
+.hbar-fill.bad { background: var(--red); }
+.health-callout { margin: 14px 0 8px; padding: 10px 12px; border: 1px solid var(--line);
+  border-left: 3px solid var(--accent); border-radius: 8px; background: var(--panel2); font-size: 13px; }
+.health-callout.bad { border-left-color: var(--red); }
+.health-table { width: 100%; border-collapse: collapse; margin-top: 10px; font-size: 12.5px; }
+.health-table th { text-align: left; color: var(--muted); font-weight: 600; padding: 5px 8px; border-bottom: 1px solid var(--line); }
+.health-table td { padding: 5px 8px; border-bottom: 1px solid var(--line); }
 
 /* ---- mobile / narrow screens -------------------------------------------- */
 @media (max-width: 760px) {


### PR DESCRIPTION
A **Health** screen (📊 in the sidebar header) so you can tell how close the box is to its limits before stacking on environments — the question being "how do I know I'm about to crash the box?"

## What it shows
- **Memory** bar — used / available / total, from `/proc/meminfo` (`MemAvailable` is the kernel's real "before OOM" number). Flags **no swap**.
- **CPU load** — 1-min load vs core count (warn ≥0.7×cores, bad ≥1×).
- **Disk** — used/free on the data dir's filesystem (where bind mounts + docker live).
- **Docker** — running/total containers, image size, and **build-cache size + reclaimable** with a `docker system prune` hint.
- **RAM headroom callout** (the headline): average RAM per running env and **≈ how many more envs fit in available RAM** — plus a no-swap OOM warning.
- **Per-environment memory table** — each env's container count + total memory, so you can see which ones are heavy (the `dev` watcher container is ~1 GB on its own).

## Implementation
- `src/health.js` `systemHealth()` gathers it all in parallel; `docker stats --no-stream` (~2s) gives per-container memory, grouped to envs by the compose-project name. `GET /host` returns the snapshot (replaces/removes the old `hostInfo`).
- UI `HealthModal` polls `/host` every 5s while open.

## Verified
Against this live box: 31% mem used / ~22 GB free / no swap; 8 cores; disk 23%; 25/31 containers; **avg ~2.5 GB/env → ~8 envs of RAM headroom** (not 200). Per-env table shows petlodge/cardealer ~2.9 GB, devbox1 ~1.6 GB. All files parse; no stale `hostInfo` refs.

Not merged — opening for review. Needs a server restart + browser refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)