### PR TITLE
fix: no transcript autoscroll when scrolled up; WP site title = project name

### DIFF
--- a/server/ui/app.js
+++ b/server/ui/app.js
@@ -209,11 +209,14 @@ function SessionView({ session, now, onChanged, onBack, onDelete }) {
   const partialRef = useRef({ text: '' });
   const seen = useRef(new Set());
   const scroller = useRef(null);
+  const stick = useRef(true); // follow the stream only while pinned near the bottom
+  const [hasNew, setHasNew] = useState(false);
   const id = session.id;
 
   useEffect(() => {
     // Reset for the newly-selected session, load history, then go live.
     setItems([]); setPartial(''); partialRef.current = { text: '' }; seen.current = new Set();
+    stick.current = true; setHasNew(false);
     let es;
     let cancelled = false;
     (async () => {
@@ -239,7 +242,27 @@ function SessionView({ session, now, onChanged, onBack, onDelete }) {
     return () => { cancelled = true; if (es) es.close(); };
   }, [id]);
 
-  useEffect(() => { if (scroller.current) scroller.current.scrollTop = scroller.current.scrollHeight; }, [items, partial]);
+  // Auto-scroll only while pinned to the bottom. If the user scrolled up to read,
+  // leave them there and just flag that new content arrived.
+  useEffect(() => {
+    const el = scroller.current;
+    if (!el) return;
+    if (stick.current) el.scrollTop = el.scrollHeight;
+    else if (items.length || partial) setHasNew(true);
+  }, [items, partial]);
+  const onTranscriptScroll = () => {
+    const el = scroller.current;
+    if (!el) return;
+    stick.current = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
+    if (stick.current && hasNew) setHasNew(false);
+  };
+  const jumpToBottom = () => {
+    const el = scroller.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    stick.current = true;
+    setHasNew(false);
+  };
 
   const running = busy || session.status === 'running';
   const send = useCallback(async () => {
@@ -287,11 +310,12 @@ function SessionView({ session, now, onChanged, onBack, onDelete }) {
         </div>
       </header>
       ${session.sshResumeHint && html`<div class="ssh muted" onClick=${() => navigator.clipboard?.writeText(session.sshResumeHint)} title="click to copy">SSH resume: <code>${session.sshResumeHint}</code></div>`}
-      <div class="transcript" ref=${scroller}>
+      <div class="transcript" ref=${scroller} onScroll=${onTranscriptScroll}>
         ${items.map((it, i) => html`<${Bubble} it=${it} key=${i} />`)}
         ${partial && html`<div class="bubble assistant live"><pre>${partial}</pre><span class="cursor">▍</span></div>`}
         ${running && !partial && html`<div class="muted pad">…thinking</div>`}
       </div>
+      ${hasNew && html`<button class="new-msgs" onClick=${jumpToBottom}>↓ New messages</button>`}
       <footer class="composer">
         <textarea
           value=${input}

--- a/server/ui/style.css
+++ b/server/ui/style.css
@@ -58,7 +58,10 @@ pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12.5px/1.5
 .sess-sub { font-size: 12px; margin-top: 2px; }
 
 /* main */
-.main { display: flex; flex-direction: column; min-height: 0; }
+.main { display: flex; flex-direction: column; min-height: 0; position: relative; }
+.new-msgs { position: absolute; left: 50%; transform: translateX(-50%); bottom: 80px; z-index: 5;
+  background: var(--accent); color: #07101f; border: 0; border-radius: 99px; padding: 6px 14px;
+  font-size: 12px; font-weight: 600; cursor: pointer; box-shadow: 0 2px 10px rgba(0,0,0,.45); }
 .main.empty { align-items: center; justify-content: center; }
 .bar { display: flex; justify-content: space-between; align-items: center; gap: 12px;
   padding: 12px 16px; border-bottom: 1px solid var(--line); background: var(--panel); }

--- a/templates/env.example
+++ b/templates/env.example
@@ -4,6 +4,10 @@ MARIADB_PASSWORD=wordpress
 MARIADB_ROOT_PASSWORD=root
 WP_PORT=__WP_PORT__
 
+# WordPress site title (Settings → General). Defaults to this project's name;
+# edit to taste, then `npm run reset` to apply.
+WP_SITE_TITLE="__PROJECT_NAME__"
+
 # WordPress admin account, created on first `npm run setup`. Seeded at scaffold
 # time from your user config (~/.config/create-wp-local-dev-agent-sandbox/
 # config.json), falling back to admin / password. Edit here to override for

--- a/templates/scripts/install-wp.sh
+++ b/templates/scripts/install-wp.sh
@@ -18,6 +18,8 @@ WP_PORT="${WP_PORT:-8080}"
 WP_ADMIN_USER="${WP_ADMIN_USER:-admin}"
 WP_ADMIN_PASSWORD="${WP_ADMIN_PASSWORD:-password}"
 WP_ADMIN_EMAIL="${WP_ADMIN_EMAIL:-admin@example.com}"
+# Site title — defaults to the project name (set at scaffold time), else a generic.
+WP_SITE_TITLE="${WP_SITE_TITLE:-WordPress Dev}"
 
 if docker compose exec -T workspace wp core is-installed >/dev/null 2>&1; then
   echo "✓ WordPress is already installed — nothing to do."
@@ -25,7 +27,7 @@ else
   echo "→ Installing WordPress…"
   docker compose exec -T workspace wp core install \
     --url="http://localhost:${WP_PORT}" \
-    --title="WordPress Dev" \
+    --title="${WP_SITE_TITLE}" \
     --admin_user="${WP_ADMIN_USER}" \
     --admin_password="${WP_ADMIN_PASSWORD}" \
     --admin_email="${WP_ADMIN_EMAIL}" \


### PR DESCRIPTION
Two small fixes.

**1. Don't autoscroll the chat when the user has scrolled up** (`server/ui`)
The session transcript now follows the stream only while you're pinned near the bottom. If you've scrolled up to read, new messages don't yank you down — a **"↓ New messages"** pill appears; click it (or scroll back down) to resume following. (Same sticky-scroll pattern already used by the log viewer.)

**2. WP site title defaults to the environment name** (scaffolder / published package)
`wp core install` used a hardcoded `--title="WordPress Dev"`. Now `install-wp.sh` reads `WP_SITE_TITLE`, seeded from `__PROJECT_NAME__` in `.env` at scaffold time (so it's the project/env name), falling back to "WordPress Dev" and editable in `.env`. For server-created envs the project name *is* the environment name, so a new env's site title matches it. Verified: scaffolding `titletest-box` yields `WP_SITE_TITLE="titletest-box"` and `--title="${WP_SITE_TITLE}"`.

UI parses; `install-wp.sh` passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)