### PR TITLE
feat: headless Codex agent alongside Claude (choose per session)

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -16,6 +16,7 @@ DEVBOX_API_TOKEN=
 # is authoritative. Leave blank to set them in the UI instead.
 GITHUB_TOKEN=
 CLAUDE_CODE_OAUTH_TOKEN=
+CODEX_API_KEY=
 
 # --- Recommended ------------------------------------------------------------
 
@@ -35,7 +36,8 @@ GIT_AUTHOR_EMAIL=devbox@localhost
 # the env's own scripts/in-workspace.sh, which resolves the token the same way
 # `npm run claude` does — so set CLAUDE_CODE_OAUTH_TOKEN above (or have it in
 # ~/.agent-sandbox/oauth-token). The server keeps no Claude token of its own.
-# CLAUDE_DEFAULT_MODEL=opus      # default model for sessions (opus → latest Opus 4.8); set any model id to override
+# CLAUDE_DEFAULT_MODEL=opus      # default model for Claude sessions (opus → latest Opus 4.8); set any model id to override
+# CODEX_DEFAULT_MODEL=           # default model for Codex sessions (blank → codex's own default)
 # SESSION_RING_BUFFER=500        # live events buffered per session for late SSE subscribers
 
 # --- Optional (defaults shown) ----------------------------------------------

--- a/server/src/claude.js
+++ b/server/src/claude.js
@@ -1,13 +1,17 @@
-// Claude headless turn engine. Each turn spawns the environment's OWN
-// scripts/in-workspace.sh to run `claude -p … --output-format stream-json` in
-// the workspace container — reusing the proven auth path (token resolution +
-// -e forwarding + the onboarding seed). No Claude token is handled here; it's
-// resolved by in-workspace.sh from this process's env (server/.env) or
-// ~/.agent-sandbox/oauth-token, exactly like `npm run claude`.
+// Headless agent turn engine. Each turn spawns the environment's OWN
+// scripts/in-workspace.sh to run a coding agent (`claude -p …` or `codex exec …`)
+// in the workspace container — reusing the proven auth path (token resolution +
+// -e forwarding). The agent's own session/thread id is captured for --resume.
 //
-// Claude runs with the container's default cwd (/home/node) every turn, so its
-// session jsonl is consistently scoped and --resume works (and an operator can
-// `bash scripts/in-workspace.sh claude --resume <id>` to take over).
+// Two agents are supported (chosen per session). Claude's stream-json is recorded
+// raw; Codex's `--json` events are normalized into the same event vocabulary the
+// UI already renders, so the transcript UI is agent-agnostic.
+//
+// An agent turn runs INSIDE the workspace container (via `docker compose exec`),
+// so it does NOT die when the server / exec client dies — it's reparented to the
+// container's init and keeps running. We reap it explicitly on interrupt,
+// shutdown, and restart; otherwise a later resume spawns a second agent that
+// races the orphan. The slim image has no pkill, so we sweep /proc.
 
 import { spawn } from 'node:child_process';
 import { createWriteStream, mkdirSync } from 'node:fs';
@@ -16,29 +20,107 @@ import { join } from 'node:path';
 import { exec } from './docker.js';
 import { log, redact } from './log.js';
 
-const CLAUDE_CWD = '/home/node'; // in-workspace.sh runs claude here (container WORKDIR)
+const AGENT_CWD = '/home/node'; // in-workspace.sh runs the agent here (container WORKDIR)
 
-// A `claude -p` turn runs INSIDE the workspace container (via `docker compose
-// exec`), so it does NOT die when the server / the exec client dies — it's
-// reparented to the container's init and keeps running. We must reap it
-// explicitly on interrupt, shutdown, and restart; otherwise a later --resume
-// spawns a SECOND claude that races the orphan over the same WordPress install.
-// The slim image has no pkill, so sweep /proc. TERM, then KILL stragglers.
-const REAP_CLAUDE = `self=$$
+// Per-agent specifics: how to build the command, which token to inject, and how
+// to turn one stdout line into { records[], sessionId?, result?, addCost?, errorText? }.
+// `records` are events in the UI's vocabulary (system/assistant/user/result/stderr/raw).
+export const AGENTS = {
+  claude: {
+    label: 'Claude',
+    procMatch: 'claude -p ', // cmdline prefix used to reap the in-container turn
+    settingsKey: 'claudeToken',
+    tokenEnv: 'CLAUDE_CODE_OAUTH_TOKEN',
+    defaultModel: (config) => config.claudeDefaultModel || null,
+    resumeHint: (dir, sid) => `cd ${dir} && bash scripts/in-workspace.sh claude --resume ${sid}`,
+    buildArgs(session, prompt) {
+      const a = ['claude', '-p', prompt, '--output-format', 'stream-json', '--verbose', '--include-partial-messages', '--dangerously-skip-permissions'];
+      if (session.model) a.push('--model', session.model);
+      if (session.claudeSessionId) a.push('--resume', session.claudeSessionId);
+      return a;
+    },
+    parseLine(line) {
+      let evt;
+      try { evt = JSON.parse(line); } catch { return { records: [{ type: 'raw', text: line }] }; }
+      const out = { records: [evt] };
+      if (evt.type === 'system' && evt.subtype === 'init' && evt.session_id) out.sessionId = evt.session_id;
+      if (evt.type === 'result') {
+        if (typeof evt.result === 'string') out.result = evt.result;
+        if (typeof evt.total_cost_usd === 'number') out.addCost = evt.total_cost_usd;
+        if (evt.session_id) out.sessionId = evt.session_id;
+        if (evt.is_error) out.errorText = typeof evt.result === 'string' ? evt.result : 'claude reported an error';
+      }
+      return out;
+    },
+  },
+  codex: {
+    label: 'Codex',
+    procMatch: 'codex exec', // cmdline prefix used to reap the in-container turn
+    settingsKey: 'codexToken',
+    tokenEnv: 'CODEX_API_KEY',
+    defaultModel: (config) => config.codexDefaultModel || null,
+    resumeHint: (dir, sid) => `cd ${dir} && bash scripts/in-workspace.sh codex exec resume ${sid}`,
+    buildArgs(session, prompt) {
+      const a = ['codex', 'exec'];
+      if (session.claudeSessionId) a.push('resume', session.claudeSessionId);
+      a.push('--json', '--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check', '-C', AGENT_CWD);
+      if (session.model) a.push('-m', session.model);
+      a.push(prompt);
+      return a;
+    },
+    // Normalize codex --json events → the UI's claude-shaped vocabulary.
+    parseLine(line) {
+      let evt;
+      try { evt = JSON.parse(line); } catch { return { records: [{ type: 'raw', text: line }] }; }
+      const out = { records: [] };
+      const assistantText = (text) => ({ type: 'assistant', message: { content: [{ type: 'text', text }] } });
+      const toolUse = (name, input) => ({ type: 'assistant', message: { content: [{ type: 'tool_use', name, input }] } });
+      switch (evt.type) {
+        case 'thread.started':
+          if (evt.thread_id) { out.sessionId = evt.thread_id; out.records.push({ type: 'system', subtype: 'init', session_id: evt.thread_id, model: 'codex' }); }
+          break;
+        case 'item.completed': {
+          const it = evt.item || {};
+          if (it.type === 'agent_message' && it.text) { out.records.push(assistantText(it.text)); out.result = it.text; }
+          else if (it.type === 'reasoning' && (it.text || it.summary)) out.records.push(assistantText(it.text || it.summary));
+          else if (it.type) out.records.push(toolUse(it.type, it)); // command_execution / file_change / tool_call / mcp_tool_call …
+          break;
+        }
+        case 'error':
+          out.errorText = String(evt.message || JSON.stringify(evt));
+          out.records.push({ type: 'stderr', text: out.errorText });
+          break;
+        case 'turn.failed':
+          out.errorText = `turn failed: ${JSON.stringify(evt.error || evt)}`;
+          out.records.push({ type: 'stderr', text: out.errorText });
+          break;
+        case 'turn.completed':
+          out.records.push({ type: 'result', result: '', total_cost_usd: 0, usage: evt.usage });
+          break;
+        default:
+          break; // turn.started, item.started, etc. — nothing to show
+      }
+      return out;
+    },
+  },
+};
+
+const agentFor = (name) => AGENTS[name] || AGENTS.claude;
+
+// Reap any in-container agent turn (claude OR codex) for this env. Best-effort.
+const REAP_AGENTS = `self=$$
 for sig in TERM KILL; do
   for d in /proc/[0-9]*; do
     pid=\${d#/proc/}; [ "$pid" = "$self" ] && continue
     c=$(tr '\\0' ' ' < "$d/cmdline" 2>/dev/null)
-    case "$c" in "claude -p "*) kill -$sig "$pid" 2>/dev/null ;; esac
+    case "$c" in "claude -p "*|"codex exec"*) kill -$sig "$pid" 2>/dev/null ;; esac
   done
   [ "$sig" = TERM ] && sleep 1
 done`;
 
-// Kill any in-container claude turn for this env (best-effort; no-op if the
-// container is down or nothing matches).
-export async function reapClaude(env) {
+export async function reapAgents(env) {
   try {
-    await exec(env, 'workspace', ['sh', '-c', REAP_CLAUDE], { timeout: 15_000 });
+    await exec(env, 'workspace', ['sh', '-c', REAP_AGENTS], { timeout: 15_000 });
   } catch { /* container gone or nothing to kill */ }
 }
 
@@ -48,23 +130,25 @@ export class ClaudeEngine {
     this.store = store;
     this.bus = bus;
     this.settings = settings;
-    this.active = new Map(); // sessionId -> { child, ndjson }
+    this.active = new Map(); // sessionId -> { child, ndjson, interrupting, env }
   }
 
   isActive(id) {
     return this.active.has(id);
   }
 
-  // Start a brand-new session (turn 1, no --resume). Returns the session record.
-  async newSession(env, { prompt, model }) {
+  // Start a brand-new session (turn 1). `agent` is 'claude' (default) or 'codex'.
+  async newSession(env, { prompt, model, agent } = {}) {
+    const name = AGENTS[agent] ? agent : 'claude';
     const id = `sess_${randomBytes(5).toString('hex')}`;
     const record = {
       id,
       envId: env.id,
       envName: env.name,
-      claudeSessionId: null,
-      cwd: CLAUDE_CWD,
-      model: model || this.config.claudeDefaultModel || null,
+      agent: name,
+      claudeSessionId: null, // the agent's own resume id (claude session_id / codex thread_id)
+      cwd: AGENT_CWD,
+      model: model || agentFor(name).defaultModel(this.config) || null,
       title: title(prompt),
       status: 'running',
       turnCount: 0,
@@ -80,49 +164,38 @@ export class ClaudeEngine {
     return record;
   }
 
-  // Continue an existing session (turn 2+, with --resume). Caller ensures the
-  // session isn't already running.
+  // Continue an existing session (resume). Caller ensures it isn't already running.
   async sendMessage(env, session, { prompt }) {
     await this.store.update(session.id, { status: 'running', lastActivityAt: new Date().toISOString() });
     this._runTurn(env, { ...session, status: 'running' }, prompt);
   }
 
   _runTurn(env, session, prompt) {
-    const args = [
-      join(env.dir, 'scripts', 'in-workspace.sh'),
-      'claude', '-p', prompt,
-      '--output-format', 'stream-json', '--verbose', '--include-partial-messages',
-      '--dangerously-skip-permissions',
-    ];
-    if (session.model) args.push('--model', session.model);
-    if (session.claudeSessionId) args.push('--resume', session.claudeSessionId);
+    const agent = agentFor(session.agent);
+    const args = [join(env.dir, 'scripts', 'in-workspace.sh'), ...agent.buildArgs(session, prompt)];
 
     mkdirSync(this.config.sessionsDir, { recursive: true });
     const ndjson = createWriteStream(session.eventLogPath, { flags: 'a' });
     ndjson.on('error', (e) => log.warn(`[${session.id}] event log write error:`, e.message));
     ndjson.write(`${JSON.stringify({ type: 'control', subtype: 'turn-start', at: new Date().toISOString() })}\n`);
 
-    // `claude -p` doesn't echo the prompt in its output (it's argv), so record it
-    // ourselves — to the ndjson (shows on transcript reload) and the live bus —
-    // otherwise the UI only ever shows Claude's side, never the user's message.
-    // uuid lets the UI dedupe the transcript-replay vs the SSE backlog copy.
+    // The agent doesn't echo the prompt (it's argv), so record it ourselves — to
+    // the ndjson (transcript reload) and the live bus. uuid dedupes replay vs SSE.
     const promptEvt = { type: 'user_prompt', text: prompt, uuid: randomUUID() };
     ndjson.write(JSON.stringify(promptEvt) + '\n');
     this.bus.publish(session.id, promptEvt);
 
-    // stdin ignored → in-workspace.sh sees a non-TTY → adds -T → clean stream-json.
-    // Inject the Claude token from Settings (if set) so in-workspace.sh resolves
-    // CLAUDE_CODE_OAUTH_TOKEN from it; otherwise it falls back to the host's env /
-    // ~/.agent-sandbox/oauth-token exactly as before.
-    const claudeToken = this.settings && this.settings.get().claudeToken;
-    const childEnv = claudeToken ? { ...process.env, CLAUDE_CODE_OAUTH_TOKEN: claudeToken } : process.env;
+    // Inject the agent's token from Settings (if set); else in-workspace.sh falls
+    // back to the host env / ~/.agent-sandbox file. stdin ignored → non-TTY → -T.
+    const token = this.settings && this.settings.get()[agent.settingsKey];
+    const childEnv = token ? { ...process.env, [agent.tokenEnv]: token } : process.env;
     const child = spawn('bash', args, { cwd: env.dir, env: childEnv, stdio: ['ignore', 'pipe', 'pipe'] });
     const entry = { child, ndjson, interrupting: false, env };
     this.active.set(session.id, entry);
 
     let buf = '';
     let stderr = '';
-    const pending = { claudeSessionId: session.claudeSessionId, lastResult: null, addCost: 0 };
+    const pending = { sessionId: session.claudeSessionId, lastResult: null, addCost: 0, errorText: null };
 
     child.stdout.setEncoding('utf8');
     child.stdout.on('data', (chunk) => {
@@ -131,7 +204,7 @@ export class ClaudeEngine {
       while ((nl = buf.indexOf('\n')) !== -1) {
         const line = buf.slice(0, nl);
         buf = buf.slice(nl + 1);
-        if (line.trim()) this._handleLine(session, line, ndjson, pending);
+        if (line.trim()) this._handleLine(session, agent, line, ndjson, pending);
       }
     });
     child.stderr.on('data', (d) => {
@@ -141,27 +214,25 @@ export class ClaudeEngine {
     });
 
     const finalize = async (code, signal) => {
-      if (buf.trim()) this._handleLine(session, buf, ndjson, pending); // trailing partial line
+      if (buf.trim()) this._handleLine(session, agent, buf, ndjson, pending); // trailing partial line
       buf = '';
       ndjson.end();
       this.active.delete(session.id);
-      // docker compose exec translates SIGINT to a non-zero exit code, so detect
-      // interruption from the flag we set, not the signal.
       const interrupted = entry.interrupting || signal === 'SIGINT' || signal === 'SIGTERM';
       const status = interrupted ? 'interrupted' : code === 0 ? 'idle' : 'error';
       const patch = {
         status,
         turnCount: (session.turnCount || 0) + 1,
         lastActivityAt: new Date().toISOString(),
-        claudeSessionId: pending.claudeSessionId || session.claudeSessionId || null,
+        claudeSessionId: pending.sessionId || session.claudeSessionId || null,
         costUsd: (session.costUsd || 0) + pending.addCost,
       };
       if (pending.lastResult != null) patch.lastResult = trunc(pending.lastResult, 4000);
-      if (status === 'error') patch.lastError = trunc(redact(stderr) || `claude exited with code ${code}`, 800);
+      if (status === 'error') patch.lastError = trunc(redact(pending.errorText || stderr) || `${agent.label} exited with code ${code}`, 800);
       else if (status === 'idle') patch.lastError = null;
       await this.store.update(session.id, patch);
       this.bus.publish(session.id, { type: 'control', subtype: 'turn-end', code, status });
-      log.info(`[${session.id}] turn ended (${status}, code ${code})`);
+      log.info(`[${session.id}] ${agent.label} turn ended (${status}, code ${code})`);
     };
 
     child.on('error', (err) => {
@@ -171,28 +242,20 @@ export class ClaudeEngine {
     child.on('close', (code, signal) => finalize(code, signal).catch((e) => log.warn(`[${session.id}] finalize:`, e.message)));
   }
 
-  // Record one stdout line: append to ndjson, publish to the bus, and capture
-  // session_id / result / cost into `pending`.
-  _handleLine(session, line, ndjson, pending) {
-    let evt;
-    try {
-      evt = JSON.parse(line);
-    } catch {
-      evt = { type: 'raw', text: line };
+  // Parse one stdout line via the agent, record its events, capture state.
+  _handleLine(session, agent, line, ndjson, pending) {
+    const { records = [], sessionId, result, addCost, errorText } = agent.parseLine(line);
+    for (const rec of records) {
+      ndjson.write(JSON.stringify(rec) + '\n');
+      this.bus.publish(session.id, rec);
     }
-    ndjson.write(line + '\n');
-    this.bus.publish(session.id, evt);
-
-    if (evt.type === 'system' && evt.subtype === 'init' && evt.session_id && !pending.claudeSessionId) {
-      pending.claudeSessionId = evt.session_id;
-      // Persist the resume id immediately so a crash mid-turn stays resumable.
-      this.store.update(session.id, { claudeSessionId: evt.session_id }).catch(() => {});
+    if (sessionId && !pending.sessionId) {
+      pending.sessionId = sessionId;
+      this.store.update(session.id, { claudeSessionId: sessionId }).catch(() => {}); // persist immediately → resumable
     }
-    if (evt.type === 'result') {
-      if (typeof evt.result === 'string') pending.lastResult = evt.result;
-      if (typeof evt.total_cost_usd === 'number') pending.addCost += evt.total_cost_usd;
-      if (evt.session_id && !pending.claudeSessionId) pending.claudeSessionId = evt.session_id;
-    }
+    if (typeof result === 'string') pending.lastResult = result;
+    if (typeof addCost === 'number') pending.addCost += addCost;
+    if (errorText) pending.errorText = errorText;
   }
 
   interrupt(id) {
@@ -200,11 +263,10 @@ export class ClaudeEngine {
     if (!a) return false;
     a.interrupting = true;
     a.child.kill('SIGINT'); // the local docker-exec client
-    if (a.env) reapClaude(a.env).catch(() => {}); // the in-container turn (survives the client)
+    if (a.env) reapAgents(a.env).catch(() => {}); // the in-container turn (survives the client)
     return true;
   }
 
-  // Interrupt every active turn (local client + in-container). Returns the count.
   interruptAll() {
     const ids = [...this.active.keys()];
     for (const id of ids) this.interrupt(id);
@@ -217,7 +279,7 @@ export class ClaudeEngine {
       const a = this.active.get(s.id);
       if (a) { a.interrupting = true; a.child.kill('SIGTERM'); env = a.env; }
     }
-    if (env) reapClaude(env).catch(() => {});
+    if (env) reapAgents(env).catch(() => {});
   }
 }
 

--- a/server/src/claude.js
+++ b/server/src/claude.js
@@ -61,10 +61,12 @@ export const AGENTS = {
     defaultModel: (config) => config.codexDefaultModel || null,
     resumeHint: (dir, sid) => `cd ${dir} && bash scripts/in-workspace.sh codex exec resume ${sid}`,
     buildArgs(session, prompt) {
-      const a = ['codex', 'exec'];
-      if (session.claudeSessionId) a.push('resume', session.claudeSessionId);
-      a.push('--json', '--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check', '-C', AGENT_CWD);
+      // exec-level flags (--json, -C, -m, sandbox bypass) MUST come before the
+      // `resume` subcommand — `codex exec resume` has a narrow option set and
+      // rejects them. So: codex exec <exec-flags> [resume <id>] <prompt>.
+      const a = ['codex', 'exec', '--json', '--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check', '-C', AGENT_CWD];
       if (session.model) a.push('-m', session.model);
+      if (session.claudeSessionId) a.push('resume', session.claudeSessionId);
       a.push(prompt);
       return a;
     },

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -66,6 +66,7 @@ export function loadConfig(env = process.env) {
     // seed the settings file on first run.
     seedGithubToken: env.GITHUB_TOKEN || '',
     seedClaudeToken: env.CLAUDE_CODE_OAUTH_TOKEN || '',
+    seedCodexToken: env.CODEX_API_KEY || '',
     gitAuthorName: env.GIT_AUTHOR_NAME || 'devbox',
     gitAuthorEmail: env.GIT_AUTHOR_EMAIL || 'devbox@localhost',
 
@@ -80,6 +81,8 @@ export function loadConfig(env = process.env) {
     // since these are throwaway dev boxes where capability matters. Override with
     // any model id via CLAUDE_DEFAULT_MODEL, or per-session in the UI/API.
     claudeDefaultModel: env.CLAUDE_DEFAULT_MODEL || 'opus',
+    // Codex (OpenAI) default model. null → let `codex exec` use its own default.
+    codexDefaultModel: env.CODEX_DEFAULT_MODEL || null,
     sessionRingBufferSize: parseInt(env.SESSION_RING_BUFFER || '500', 10),
   };
 
@@ -96,6 +99,6 @@ export function loadConfig(env = process.env) {
 
   // Initial secret strings for the log redactor (env-seeded). Tokens managed in
   // Settings are added to the redactor after the settings store loads.
-  config.secrets = [config.seedGithubToken, config.seedClaudeToken].filter(Boolean);
+  config.secrets = [config.seedGithubToken, config.seedClaudeToken, config.seedCodexToken].filter(Boolean);
   return Object.freeze(config);
 }

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -55,10 +55,10 @@ async function main() {
   const claudeEngine = new ClaudeEngine(config, sessionStore, sessionBus, settings);
   const sessions = { store: sessionStore, engine: claudeEngine, bus: sessionBus };
 
-  // A `claude -p` turn runs inside the workspace container and SURVIVES a server
-  // restart. This new server owns no turns yet, so any `claude -p` still running
-  // in a container is an orphan from a previous run — reap them, otherwise a
-  // resume would spawn a second claude that races the orphan. Best-effort.
+  // An agent turn (`claude -p` / `codex exec`) runs inside the workspace container
+  // and SURVIVES a server restart. This new server owns no turns yet, so any still
+  // running in a container is an orphan from a previous run — reap them, otherwise
+  // a resume would spawn a second agent that races the orphan. Best-effort.
   await Promise.allSettled(registry.list().map((e) => reapAgents(e)));
 
   // When an env finishes provisioning, optionally kick off its initial session
@@ -81,15 +81,15 @@ async function main() {
     manager.startReconcileLoop();
   });
 
-  // On a plain restart (Ctrl+C / SIGTERM) we reap the in-container Claude turns
-  // so they don't orphan — but leave the env CONTAINERS running, so a restart is
-  // seamless and sessions resume cleanly (no duplicate). Full teardown incl.
-  // stopping containers is the explicit /control/shutdown action.
+  // On a plain restart (Ctrl+C / SIGTERM) we reap the in-container agent turns
+  // (claude/codex) so they don't orphan — but leave the env CONTAINERS running, so
+  // a restart is seamless and sessions resume cleanly (no duplicate). Full teardown
+  // incl. stopping containers is the explicit /control/shutdown action.
   let shuttingDown = false;
   const shutdown = async () => {
     if (shuttingDown) return;
     shuttingDown = true;
-    log.info('shutting down — reaping active Claude turns (containers stay up)');
+    log.info('shutting down — reaping active agent turns (containers stay up)');
     try {
       claudeEngine.interruptAll();
       await Promise.race([

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -14,7 +14,7 @@ import { SettingsStore } from './settings.js';
 import { Manager } from './manager.js';
 import { SessionStore } from './sessions.js';
 import { SessionBus } from './sessionbus.js';
-import { ClaudeEngine, reapClaude } from './claude.js';
+import { ClaudeEngine, reapAgents } from './claude.js';
 import { buildRoutes } from './routes.js';
 import { createServer } from './http.js';
 
@@ -43,6 +43,7 @@ async function main() {
   const settings = await new SettingsStore(config.settingsPath, {
     githubToken: config.seedGithubToken,
     claudeToken: config.seedClaudeToken,
+    codexToken: config.seedCodexToken,
   }).load();
   addSecrets(settings.secrets()); // redact the stored tokens from logs too
   const manager = new Manager(config, registry, settings);
@@ -58,7 +59,7 @@ async function main() {
   // restart. This new server owns no turns yet, so any `claude -p` still running
   // in a container is an orphan from a previous run — reap them, otherwise a
   // resume would spawn a second claude that races the orphan. Best-effort.
-  await Promise.allSettled(registry.list().map((e) => reapClaude(e)));
+  await Promise.allSettled(registry.list().map((e) => reapAgents(e)));
 
   // When an env finishes provisioning, optionally kick off its initial session
   // (the prompt passed to POST /environments). Decoupled via this hook so the
@@ -92,7 +93,7 @@ async function main() {
     try {
       claudeEngine.interruptAll();
       await Promise.race([
-        Promise.allSettled(registry.list().map((e) => reapClaude(e))),
+        Promise.allSettled(registry.list().map((e) => reapAgents(e))),
         new Promise((r) => setTimeout(r, 4000)),
       ]);
     } catch { /* exiting regardless */ }

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -6,6 +6,7 @@ import { route } from './http.js';
 import { addSecrets } from './log.js';
 import { exec } from './docker.js';
 import { systemHealth } from './health.js';
+import { AGENTS } from './claude.js';
 import { AllocationError } from './allocator.js';
 import { openSse } from './sse.js';
 import { makeStaticHandler } from './static.js';
@@ -37,12 +38,13 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
   const sshHint = (s) => {
     const env = registry.get(s.envId);
     if (!env || !s.claudeSessionId) return null;
-    return `cd ${env.dir} && bash scripts/in-workspace.sh claude --resume ${s.claudeSessionId}`;
+    return (AGENTS[s.agent] || AGENTS.claude).resumeHint(env.dir, s.claudeSessionId);
   };
   const publicSession = (s) => ({
     id: s.id,
     envId: s.envId,
     envName: s.envName,
+    agent: s.agent || 'claude',
     claudeSessionId: s.claudeSessionId,
     cwd: s.cwd,
     model: s.model,
@@ -170,13 +172,14 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
       ctx.send(200, { deleted: true });
     }),
 
-    // ---- claude sessions --------------------------------------------------
+    // ---- agent sessions (claude | codex) ----------------------------------
     route('POST', '/environments/:id/sessions', async (ctx) => {
       const env = envOr404(ctx);
       await assertUsable(env);
       const prompt = (ctx.body.prompt || '').trim();
       if (!prompt) throw httpErr(400, 'prompt is required');
-      const record = await sessions.engine.newSession(env, { prompt, model: ctx.body.model });
+      const agent = AGENTS[ctx.body.agent] ? ctx.body.agent : 'claude';
+      const record = await sessions.engine.newSession(env, { prompt, model: ctx.body.model, agent });
       ctx.send(202, publicSession(record));
     }),
 

--- a/server/src/settings.js
+++ b/server/src/settings.js
@@ -18,12 +18,13 @@ import { createMutex } from './registry.js';
 
 // Fields treated as secrets: masked in API responses, only overwritten when a
 // non-empty value is supplied, and fed to the log redactor.
-const SECRET_FIELDS = ['githubToken', 'claudeToken', 'wpAdminPassword'];
+const SECRET_FIELDS = ['githubToken', 'claudeToken', 'codexToken', 'wpAdminPassword'];
 
 function defaults() {
   return {
     githubToken: '',
     claudeToken: '',
+    codexToken: '',
     wpAdminUser: 'admin',
     wpAdminPassword: 'password',
     wpAdminEmail: 'admin@example.com',
@@ -71,6 +72,7 @@ export class SettingsStore {
     return {
       githubToken: mask(s.githubToken),
       claudeToken: mask(s.claudeToken),
+      codexToken: mask(s.codexToken),
       wpAdminUser: s.wpAdminUser,
       wpAdminEmail: s.wpAdminEmail,
       wpAdminPassword: mask(s.wpAdminPassword),

--- a/server/ui/app.js
+++ b/server/ui/app.js
@@ -130,7 +130,7 @@ function SessionItem({ s, selectedId, onSelect, onDelete, now }) {
           : html`<span class="sess-time" title=${`last active ${fullTime(s.lastActivityAt)}`}>${fmtAgo(s.lastActivityAt)}</span>`}
         <button class="sess-del lnk" title="Delete session" onClick=${(e) => { e.stopPropagation(); onDelete(s); }}>🗑</button>
       </div>
-      <div class="sess-sub muted">started ${fmtAgo(s.createdAt, true)} · ${s.turnCount} turn${s.turnCount === 1 ? '' : 's'} · $${(s.costUsd || 0).toFixed(3)}</div>
+      <div class="sess-sub muted"><span class="agent-tag">${s.agent === 'codex' ? 'Codex' : 'Claude'}</span> · started ${fmtAgo(s.createdAt, true)} · ${s.turnCount} turn${s.turnCount === 1 ? '' : 's'} · $${(s.costUsd || 0).toFixed(3)}</div>
     </div>`;
 }
 
@@ -299,8 +299,8 @@ function SessionView({ session, now, onChanged, onBack, onDelete }) {
                 <button class="lnk small danger" onClick=${onDelete} title="Delete session">🗑</button>`}
         </div>
         <div class="bar-meta muted">
-          ${session.envName} · ${session.model || 'default model'} · $${(session.costUsd || 0).toFixed(4)}
-          ${session.claudeSessionId && html`· <code title="claude session id">${session.claudeSessionId.slice(0, 8)}</code>`}
+          ${session.envName} · <span class="agent-tag">${session.agent === 'codex' ? 'Codex' : 'Claude'}</span> · ${session.model || 'default model'} · $${(session.costUsd || 0).toFixed(4)}
+          ${session.claudeSessionId && html`· <code title="agent session id">${session.claudeSessionId.slice(0, 8)}</code>`}
         </div>
         <div class="bar-meta muted" title=${`started ${fullTime(session.createdAt)}\nlast active ${fullTime(session.lastActivityAt)}`}>
           started ${fmtAgo(session.createdAt, true)} ·${' '}
@@ -334,21 +334,31 @@ function SessionView({ session, now, onChanged, onBack, onDelete }) {
 function NewSessionModal({ envs, preselect, onClose, onCreate }) {
   const usable = envs.filter((e) => e.status === 'running' || e.status === 'degraded');
   const [envId, setEnvId] = useState(preselect || (usable[0] && usable[0].id));
+  const [agent, setAgent] = useState('claude');
   const [prompt, setPrompt] = useState('');
   const [err, setErr] = useState('');
   const create = async () => {
     if (!envId || !prompt.trim()) return;
-    try { await onCreate(envId, prompt.trim()); } catch (e) { setErr(e.message); }
+    try { await onCreate(envId, prompt.trim(), agent); } catch (e) { setErr(e.message); }
   };
   return html`
     <div class="modal-bg" onClick=${onClose}>
       <div class="modal" onClick=${(e) => e.stopPropagation()}>
-        <h3>New Claude session</h3>
+        <h3>New session</h3>
         ${usable.length === 0 && html`<div class="muted">No running environments. Create/start one first.</div>`}
         <label>Environment
           <select value=${envId} onChange=${(e) => setEnvId(e.target.value)}>
             ${usable.map((e) => html`<option value=${e.id} key=${e.id}>${e.name} (:${e.port})</option>`)}
           </select>
+        </label>
+        <label>Agent
+          <div class="agent-pick">
+            ${['claude', 'codex'].map((a) => html`
+              <label class=${`agent-opt ${agent === a ? 'sel' : ''}`} key=${a}>
+                <input type="radio" name="agent" checked=${agent === a} onChange=${() => setAgent(a)} />
+                ${a === 'claude' ? 'Claude' : 'Codex'}
+              </label>`)}
+          </div>
         </label>
         <label>First message
           <textarea value=${prompt} rows="4" onInput=${(e) => setPrompt(e.target.value)} placeholder="Describe the task…"></textarea>
@@ -549,6 +559,7 @@ function SettingsModal({ onClose, onLogout }) {
   const [s, setS] = useState(null);
   const [ghToken, setGh] = useState('');
   const [clToken, setCl] = useState('');
+  const [cxToken, setCx] = useState('');
   const [wpUser, setWpUser] = useState('');
   const [wpEmail, setWpEmail] = useState('');
   const [wpPass, setWpPass] = useState('');
@@ -570,9 +581,10 @@ function SettingsModal({ onClose, onLogout }) {
       const body = { wpAdminUser: wpUser, wpAdminEmail: wpEmail };
       if (ghToken) body.githubToken = ghToken;
       if (clToken) body.claudeToken = clToken;
+      if (cxToken) body.codexToken = cxToken;
       if (wpPass) body.wpAdminPassword = wpPass;
       const d = await api('/settings', { method: 'PUT', body: JSON.stringify(body) });
-      setS(d); setGh(''); setCl(''); setWpPass(''); setSaved(true);
+      setS(d); setGh(''); setCl(''); setCx(''); setWpPass(''); setSaved(true);
     } catch (e) { setErr(e.message); } finally { setBusy(false); }
   };
 
@@ -588,6 +600,9 @@ function SettingsModal({ onClose, onLogout }) {
           </label>
           <label>Claude token <span class="muted small">— ${hint('claudeToken')}</span>
             <input type="password" value=${clToken} placeholder="sk-ant-oat… (from claude setup-token)" onInput=${(e) => setCl(e.target.value)} />
+          </label>
+          <label>Codex token <span class="muted small">— ${hint('codexToken')}</span>
+            <input type="password" value=${cxToken} placeholder="sk-… (OpenAI API key)" onInput=${(e) => setCx(e.target.value)} />
           </label>
           <label>WordPress admin username
             <input value=${wpUser} onInput=${(e) => setWpUser(e.target.value)} />
@@ -762,8 +777,8 @@ function App() {
   const selected = sessions.find((s) => s.id === selectedId);
   const logEnv = envs.find((e) => e.id === logEnvId);
 
-  const createSession = async (envId, prompt, model) => {
-    const s = await api(`/environments/${envId}/sessions`, { method: 'POST', body: JSON.stringify({ prompt, model }) });
+  const createSession = async (envId, prompt, agent) => {
+    const s = await api(`/environments/${envId}/sessions`, { method: 'POST', body: JSON.stringify({ prompt, agent }) });
     setNewSession(null); await refresh(); setSelectedId(s.id);
   };
   const createEnv = async (name, provision, prompt, presetIds) => {

--- a/server/ui/style.css
+++ b/server/ui/style.css
@@ -122,6 +122,12 @@ pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12.5px/1.5
 .modal-foot { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; }
 .err-msg { color: var(--red); margin-top: 10px; font-size: 13px; }
 .ok-msg { color: var(--green); margin-top: 10px; font-size: 13px; }
+.agent-pick { display: flex; gap: 8px; }
+.agent-opt { display: flex; align-items: center; gap: 6px; flex: 1; margin: 0; padding: 8px 10px;
+  border: 1px solid var(--line); border-radius: 8px; cursor: pointer; color: var(--text); }
+.agent-opt.sel { border-color: var(--accent); background: var(--accent2); }
+.agent-opt input { width: auto; }
+.agent-tag { color: var(--accent); font-weight: 600; }
 .modal-foot .spacer { flex: 1; }
 .modal.wide { width: 560px; max-height: 90vh; overflow-y: auto; }
 .modal textarea.mono { resize: vertical; font: 12.5px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }

--- a/templates/scripts/connect-mcp.sh
+++ b/templates/scripts/connect-mcp.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# Connect the workspace's agents (Claude Code and Cursor) to the MCP servers in
-# this sandbox, so both can use them out of the box. Idempotent — re-run safe.
+# Connect the workspace's agents (Claude Code, Codex, and Cursor) to the MCP
+# servers in this sandbox, so all can use them out of the box. Idempotent — re-run safe.
 # Run via `npm run setup`.
 #
 #   - wordpress: the site's MCP server (Agent Connector for WP, which bundles
@@ -102,6 +102,35 @@ else
   echo "⚠ Could not write ~/.cursor/mcp.json (is /home/node writable by the node user?)." >&2
   echo "  Skipping Cursor's MCP setup — Claude is registered and unaffected. Fix the" >&2
   echo "  workspace/ ownership (it must be uid 1000) and re-run: bash scripts/connect-mcp.sh" >&2
+fi
+
+# Codex (~/.codex/config.toml, via `codex mcp add`). Same servers as above. Skipped
+# when codex isn't installed (older env images); each add is non-fatal so a Codex
+# hiccup never breaks the Claude/Cursor setup. stdio for wordpress (--env), HTTP
+# (--url) for playwright.
+if command -v codex >/dev/null 2>&1; then
+  echo "→ Connecting Codex to the MCP servers (~/.codex/config.toml)…"
+  if [ "$HAS_WP" = "1" ]; then
+    codex mcp remove wordpress >/dev/null 2>&1 || true
+    if codex mcp add wordpress \
+      --env WP_API_URL="$WP_MCP_URL" \
+      --env WP_API_USERNAME="$ADMIN_USER" \
+      --env WP_API_PASSWORD="$APPPASS" \
+      --env OAUTH_ENABLED=false \
+      -- npx -y @automattic/mcp-wordpress-remote >/dev/null 2>&1; then
+      echo "  ✓ codex: wordpress"
+    else
+      echo "  ⚠ codex: 'mcp add wordpress' failed (continuing)" >&2
+    fi
+  fi
+  codex mcp remove playwright >/dev/null 2>&1 || true
+  if codex mcp add playwright --url "$PLAYWRIGHT_URL" >/dev/null 2>&1; then
+    echo "  ✓ codex: playwright"
+  else
+    echo "  ⚠ codex: 'mcp add playwright' failed (continuing)" >&2
+  fi
+else
+  echo "→ codex not installed in this env — skipping Codex MCP setup."
 fi
 EOF
 

--- a/templates/scripts/in-workspace.sh
+++ b/templates/scripts/in-workspace.sh
@@ -42,6 +42,14 @@ if [ -z "$CURSOR_KEY" ] && [ -f "$CURSOR_KEY_FILE" ]; then
   CURSOR_KEY="$(tr -d '[:space:]' < "$CURSOR_KEY_FILE")"
 fi
 
+# Codex (OpenAI) API key, resolved the same way: $CODEX_API_KEY, then the file.
+# `codex exec` honors CODEX_API_KEY for headless runs.
+CODEX_KEY="${CODEX_API_KEY:-}"
+CODEX_KEY_FILE="${CODEX_API_KEY_FILE:-$HOME/.agent-sandbox/codex-api-key}"
+if [ -z "$CODEX_KEY" ] && [ -f "$CODEX_KEY_FILE" ]; then
+  CODEX_KEY="$(tr -d '[:space:]' < "$CODEX_KEY_FILE")"
+fi
+
 # Only nudge about the credential for the agent actually being launched, so
 # `npm run bash` (and the other agent) stays quiet.
 case "${1:-}" in
@@ -61,11 +69,19 @@ case "${1:-}" in
       echo "  $CURSOR_KEY_FILE (one line), or 'export CURSOR_API_KEY=<key>'." >&2
     fi
     ;;
+  codex)
+    if [ -z "$CODEX_KEY" ]; then
+      echo "ℹ No Codex API key found (\$CODEX_API_KEY or $CODEX_KEY_FILE)." >&2
+      echo "  'codex exec' needs an OpenAI key — save one to $CODEX_KEY_FILE (one line)," >&2
+      echo "  or 'export CODEX_API_KEY=<key>'." >&2
+    fi
+    ;;
 esac
 
 # Export so the values are inherited by the container via name-only -e (off argv).
 export CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_TOKEN"
 export CURSOR_API_KEY="$CURSOR_KEY"
+export CODEX_API_KEY="$CODEX_KEY"
 
 # Allocate a TTY only when we actually have one. Interactive use (`npm run claude`,
 # `npm run bash`) keeps its TTY; piped/headless callers (e.g. driving
@@ -77,4 +93,5 @@ TTY_FLAG=""
 exec docker compose exec $TTY_FLAG \
   -e CLAUDE_CODE_OAUTH_TOKEN \
   -e CURSOR_API_KEY \
+  -e CODEX_API_KEY \
   workspace "$@"

--- a/templates/workspace.Dockerfile
+++ b/templates/workspace.Dockerfile
@@ -32,11 +32,11 @@ RUN printf 'path: /home/node/wp\n' > /etc/wp-cli.yml
 # Composer (PHP dependency manager), available globally as `composer`.
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
-# Claude Code, plus the mcp-wordpress-remote stdio proxy that the workspace's
-# Claude uses to reach the site's MCP server. Pre-installing it means the
-# `npx @automattic/mcp-wordpress-remote` in connect-mcp.sh resolves instantly
-# (and offline) instead of fetching on first connection.
-RUN npm install -g @anthropic-ai/claude-code @automattic/mcp-wordpress-remote
+# Claude Code + OpenAI Codex (both headless agents), plus the mcp-wordpress-remote
+# stdio proxy the workspace's Claude uses to reach the site's MCP server.
+# Pre-installing the proxy means the `npx @automattic/mcp-wordpress-remote` in
+# connect-mcp.sh resolves instantly (and offline) instead of fetching on first use.
+RUN npm install -g @anthropic-ai/claude-code @openai/codex @automattic/mcp-wordpress-remote
 
 # Seed Claude's onboarding flags so a token-authenticated profile
 # (CLAUDE_CODE_OAUTH_TOKEN) goes straight to the prompt instead of stopping on the


### PR DESCRIPTION
Adds **OpenAI Codex** as a second headless agent, driven from the devbox server and **selectable per session** — passing its token the same way we pass the Claude token.

## How Codex headless works (researched)
- Install: `npm install -g @openai/codex`.
- Token: **`CODEX_API_KEY`** (an OpenAI key) — only honored by `codex exec`, our headless path. Direct analog to `CLAUDE_CODE_OAUTH_TOKEN`.
- Run: `codex exec --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check -C /home/node [-m <model>] "<prompt>"` → newline-delimited JSON events.
- Resume: `codex exec resume <thread_id> "<prompt>"` (thread id from the `thread.started` event).

## Changes
**Scaffolder (published):** workspace image installs `@openai/codex`; `in-workspace.sh` resolves + forwards `CODEX_API_KEY` (env → `~/.agent-sandbox/codex-api-key`), same pattern as the Claude token.

**Server:** the turn engine is generalized over an `agent` ('claude' | 'codex') — per-agent command builder, token env var, and stdout parser. Codex's `--json` events (`thread.started` / `item.completed` / `turn.*` / `error`) are **normalized into the UI's existing event vocabulary**, so the transcript renders agent-agnostically and the Claude path is untouched. Sessions carry an `agent` field; `reapClaude → reapAgents` reaps both `claude -p` and `codex exec` in-container turns. Settings gains a masked **`codexToken`** (seeded from `CODEX_API_KEY`). `POST .../sessions` accepts `agent`; `publicSession` exposes it; the SSH resume hint is agent-aware.

**UI:** New Session modal has a **Claude / Codex** picker; the session list + header show the agent; Settings has a Codex token field.

## Verified
All files parse; `in-workspace.sh` passes `bash -n`. Throwaway boot: settings seed/mask `codexToken`; Codex `buildArgs` produce correct new + resume commands; the `--json` parser normalizes `thread.started`/`agent_message` correctly; Claude args unchanged.

## ⚠️ Not yet verified end-to-end (needs your input)
1. **A rebuilt env image** — existing envs' images predate this, so Codex only exists in **newly created** envs.
2. **A real `CODEX_API_KEY`** (set it in Settings) to actually run a turn.
3. Codex reports **token usage, not $ cost**, so codex sessions display `$0`.
4. Codex **tool-item** rendering (command/file-change/tool-call) is best-effort from the docs — once we see real `codex exec --json` output we can refine the mapping. A couple of flags (`--skip-git-repo-check`, the exact bypass combo) are from docs and worth confirming on first run.

Not merged — opening for review + a live smoke test once you drop in an OpenAI key and create a fresh env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)