### PR TITLE
feat: headless opencode agent (OpenCode Zen) alongside Claude & Codex

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -17,6 +17,7 @@ DEVBOX_API_TOKEN=
 GITHUB_TOKEN=
 CLAUDE_CODE_OAUTH_TOKEN=
 CODEX_API_KEY=
+OPENCODE_API_KEY=
 
 # --- Recommended ------------------------------------------------------------
 
@@ -38,6 +39,7 @@ GIT_AUTHOR_EMAIL=devbox@localhost
 # ~/.agent-sandbox/oauth-token). The server keeps no Claude token of its own.
 # CLAUDE_DEFAULT_MODEL=opus      # default model for Claude sessions (opus → latest Opus 4.8); set any model id to override
 # CODEX_DEFAULT_MODEL=           # default model for Codex sessions (blank → codex's own default)
+# OPENCODE_DEFAULT_MODEL=opencode/claude-sonnet-4-6   # default model for OpenCode sessions (Zen)
 # SESSION_RING_BUFFER=500        # live events buffered per session for late SSE subscribers
 
 # --- Optional (defaults shown) ----------------------------------------------

--- a/server/src/claude.js
+++ b/server/src/claude.js
@@ -105,6 +105,59 @@ export const AGENTS = {
       return out;
     },
   },
+  opencode: {
+    label: 'OpenCode',
+    procMatch: 'opencode run', // cmdline prefix used to reap the in-container turn
+    settingsKey: 'opencodeToken',
+    tokenEnv: 'OPENCODE_API_KEY', // OpenCode Zen gateway key
+    defaultModel: (config) => config.opencodeDefaultModel || 'opencode/claude-sonnet-4-6',
+    resumeHint: (dir, sid) => `cd ${dir} && bash scripts/in-workspace.sh opencode run -s ${sid}`,
+    buildArgs(session, prompt) {
+      const a = ['opencode', 'run', '--format', 'json', '--dangerously-skip-permissions', '--dir', AGENT_CWD];
+      if (session.model) a.push('-m', session.model);
+      if (session.claudeSessionId) a.push('-s', session.claudeSessionId);
+      a.push(prompt);
+      return a;
+    },
+    // PROVISIONAL mapping. opencode `run --format json` emits {type, properties}
+    // events. Confirmed: error = {type:'error', sessionID, error:{data:{message},statusCode}}.
+    // Text/tool shapes (message.part.updated → properties.part) are best-effort and
+    // get tightened against a real capture. Text streams as growing parts → emit deltas;
+    // finalize on session.idle.
+    parseLine(line, pending) {
+      let evt;
+      try { evt = JSON.parse(line); } catch { return { records: [{ type: 'raw', text: line }] }; }
+      const out = { records: [] };
+      const p = evt.properties || {};
+      const part = p.part || evt.part || {};
+      const sid = evt.sessionID || p.sessionID || part.sessionID || (p.info && p.info.id);
+      if (sid) out.sessionId = sid;
+      const t = String(evt.type || '');
+      if (t === 'error' || t === 'session.error') {
+        out.errorText = String((evt.error && (evt.error.data?.message || evt.error.message || evt.error.name)) || p.error?.data?.message || 'opencode error');
+        out.records.push({ type: 'stderr', text: out.errorText });
+      } else if (t.startsWith('message.part') || t === 'part.updated') {
+        if (part.type === 'text' && typeof part.text === 'string') {
+          pending.oc = pending.oc || {};
+          const key = part.id || 'text';
+          const prev = pending.oc[key] || '';
+          if (part.text.length >= prev.length) {
+            const delta = part.text.slice(prev.length);
+            pending.oc[key] = part.text;
+            pending.ocLast = part.text;
+            out.result = part.text;
+            if (delta) out.records.push({ type: 'stream_event', event: { delta: { type: 'text_delta', text: delta } } });
+          }
+        } else if (part.type === 'tool') {
+          out.records.push({ type: 'assistant', message: { content: [{ type: 'tool_use', name: part.tool || 'tool', input: part.state || part }] } });
+        }
+      } else if (t === 'session.idle' || t === 'session.completed') {
+        if (pending.ocLast) out.records.push({ type: 'assistant', message: { content: [{ type: 'text', text: pending.ocLast }] } });
+        out.records.push({ type: 'result', result: pending.ocLast || '', total_cost_usd: 0 });
+      }
+      return out;
+    },
+  },
 };
 
 const agentFor = (name) => AGENTS[name] || AGENTS.claude;
@@ -115,7 +168,7 @@ for sig in TERM KILL; do
   for d in /proc/[0-9]*; do
     pid=\${d#/proc/}; [ "$pid" = "$self" ] && continue
     c=$(tr '\\0' ' ' < "$d/cmdline" 2>/dev/null)
-    case "$c" in "claude -p "*|"codex exec"*) kill -$sig "$pid" 2>/dev/null ;; esac
+    case "$c" in "claude -p "*|"codex exec"*|"opencode run"*) kill -$sig "$pid" 2>/dev/null ;; esac
   done
   [ "$sig" = TERM ] && sleep 1
 done`;
@@ -246,7 +299,7 @@ export class ClaudeEngine {
 
   // Parse one stdout line via the agent, record its events, capture state.
   _handleLine(session, agent, line, ndjson, pending) {
-    const { records = [], sessionId, result, addCost, errorText } = agent.parseLine(line);
+    const { records = [], sessionId, result, addCost, errorText } = agent.parseLine(line, pending);
     for (const rec of records) {
       ndjson.write(JSON.stringify(rec) + '\n');
       this.bus.publish(session.id, rec);

--- a/server/src/claude.js
+++ b/server/src/claude.js
@@ -119,41 +119,65 @@ export const AGENTS = {
       a.push(prompt);
       return a;
     },
-    // PROVISIONAL mapping. opencode `run --format json` emits {type, properties}
-    // events. Confirmed: error = {type:'error', sessionID, error:{data:{message},statusCode}}.
-    // Text/tool shapes (message.part.updated → properties.part) are best-effort and
-    // get tightened against a real capture. Text streams as growing parts → emit deltas;
-    // finalize on session.idle.
+    // Normalize `opencode run --format json` events → the UI's claude-shaped
+    // vocabulary. Event shapes confirmed against opencode 1.17.11 + the source
+    // (sst/opencode cli/cmd/run.ts emits {type, timestamp, sessionID, ...{part|error}}).
+    // Top-level types: step_start, text, reasoning, tool_use, step_finish, error.
+    // opencode is NOT a token stream here — `text`/`reasoning` carry the COMPLETE
+    // segment when it finishes, and `tool_use` fires only when the tool completes
+    // or errors. So we emit one assistant bubble per segment (like Codex's
+    // item.completed) and an empty `result` footer on the terminal step_finish.
     parseLine(line, pending) {
       let evt;
       try { evt = JSON.parse(line); } catch { return { records: [{ type: 'raw', text: line }] }; }
       const out = { records: [] };
-      const p = evt.properties || {};
-      const part = p.part || evt.part || {};
-      const sid = evt.sessionID || p.sessionID || part.sessionID || (p.info && p.info.id);
+      const part = evt.part || {};
+      const sid = evt.sessionID || part.sessionID;
       if (sid) out.sessionId = sid;
-      const t = String(evt.type || '');
-      if (t === 'error' || t === 'session.error') {
-        out.errorText = String((evt.error && (evt.error.data?.message || evt.error.message || evt.error.name)) || p.error?.data?.message || 'opencode error');
-        out.records.push({ type: 'stderr', text: out.errorText });
-      } else if (t.startsWith('message.part') || t === 'part.updated') {
-        if (part.type === 'text' && typeof part.text === 'string') {
-          pending.oc = pending.oc || {};
-          const key = part.id || 'text';
-          const prev = pending.oc[key] || '';
-          if (part.text.length >= prev.length) {
-            const delta = part.text.slice(prev.length);
-            pending.oc[key] = part.text;
-            pending.ocLast = part.text;
-            out.result = part.text;
-            if (delta) out.records.push({ type: 'stream_event', event: { delta: { type: 'text_delta', text: delta } } });
+      const assistantText = (text) => ({ type: 'assistant', message: { content: [{ type: 'text', text }] } });
+      switch (String(evt.type || '')) {
+        case 'step_start':
+          // session chip, once — sessionID rides on every event so guard on pending.
+          if (sid && !pending.ocInit) { pending.ocInit = true; out.records.push({ type: 'system', subtype: 'init', session_id: sid, model: 'opencode' }); }
+          break;
+        case 'text':
+          if (typeof part.text === 'string' && part.text) {
+            out.records.push(assistantText(part.text));
+            pending.ocText = (pending.ocText ? `${pending.ocText}\n\n` : '') + part.text;
+            out.result = pending.ocText; // store.lastResult = full answer
           }
-        } else if (part.type === 'tool') {
-          out.records.push({ type: 'assistant', message: { content: [{ type: 'tool_use', name: part.tool || 'tool', input: part.state || part }] } });
+          break;
+        case 'reasoning':
+          if (typeof part.text === 'string' && part.text) out.records.push(assistantText(part.text));
+          break;
+        case 'tool_use': {
+          const st = (part.state && typeof part.state === 'object') ? part.state : {};
+          const input = st.input || part.input || {};
+          const output = typeof st.output === 'string' ? trunc(st.output, 2000) : st.output;
+          out.records.push({ type: 'assistant', message: { content: [{ type: 'tool_use', name: part.tool || 'tool', input: { ...input, _status: st.status, _output: output } }] } });
+          break;
         }
-      } else if (t === 'session.idle' || t === 'session.completed') {
-        if (pending.ocLast) out.records.push({ type: 'assistant', message: { content: [{ type: 'text', text: pending.ocLast }] } });
-        out.records.push({ type: 'result', result: pending.ocLast || '', total_cost_usd: 0 });
+        case 'step_finish': {
+          const cost = Number(part.cost) || 0;
+          if (cost) out.addCost = cost;
+          pending.ocCost = (pending.ocCost || 0) + cost;
+          // reason 'tool-calls' = an intermediate step (more turns follow); anything
+          // else (stop/length/…) is terminal → emit the footer. Text lives in the
+          // assistant bubbles above, so result is empty (mirrors Codex).
+          if (part.reason && part.reason !== 'tool-calls') {
+            out.records.push({ type: 'result', result: '', total_cost_usd: pending.ocCost, usage: part.tokens });
+          }
+          break;
+        }
+        case 'error':
+        case 'session.error': {
+          const e = evt.error || {};
+          out.errorText = String((e.data && e.data.message) || e.message || e.name || (typeof e === 'string' ? e : JSON.stringify(e)) || 'opencode error');
+          out.records.push({ type: 'stderr', text: out.errorText });
+          break;
+        }
+        default:
+          break; // step parts we don't render
       }
       return out;
     },
@@ -162,7 +186,7 @@ export const AGENTS = {
 
 const agentFor = (name) => AGENTS[name] || AGENTS.claude;
 
-// Reap any in-container agent turn (claude OR codex) for this env. Best-effort.
+// Reap any in-container agent turn (claude / codex / opencode) for this env. Best-effort.
 const REAP_AGENTS = `self=$$
 for sig in TERM KILL; do
   for d in /proc/[0-9]*; do

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -67,6 +67,7 @@ export function loadConfig(env = process.env) {
     seedGithubToken: env.GITHUB_TOKEN || '',
     seedClaudeToken: env.CLAUDE_CODE_OAUTH_TOKEN || '',
     seedCodexToken: env.CODEX_API_KEY || '',
+    seedOpencodeToken: env.OPENCODE_API_KEY || '',
     gitAuthorName: env.GIT_AUTHOR_NAME || 'devbox',
     gitAuthorEmail: env.GIT_AUTHOR_EMAIL || 'devbox@localhost',
 
@@ -83,6 +84,8 @@ export function loadConfig(env = process.env) {
     claudeDefaultModel: env.CLAUDE_DEFAULT_MODEL || 'opus',
     // Codex (OpenAI) default model. null → let `codex exec` use its own default.
     codexDefaultModel: env.CODEX_DEFAULT_MODEL || null,
+    // OpenCode (Zen gateway) default model, format opencode/<model>.
+    opencodeDefaultModel: env.OPENCODE_DEFAULT_MODEL || 'opencode/claude-sonnet-4-6',
     sessionRingBufferSize: parseInt(env.SESSION_RING_BUFFER || '500', 10),
   };
 
@@ -99,6 +102,6 @@ export function loadConfig(env = process.env) {
 
   // Initial secret strings for the log redactor (env-seeded). Tokens managed in
   // Settings are added to the redactor after the settings store loads.
-  config.secrets = [config.seedGithubToken, config.seedClaudeToken, config.seedCodexToken].filter(Boolean);
+  config.secrets = [config.seedGithubToken, config.seedClaudeToken, config.seedCodexToken, config.seedOpencodeToken].filter(Boolean);
   return Object.freeze(config);
 }

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -44,6 +44,7 @@ async function main() {
     githubToken: config.seedGithubToken,
     claudeToken: config.seedClaudeToken,
     codexToken: config.seedCodexToken,
+    opencodeToken: config.seedOpencodeToken,
   }).load();
   addSecrets(settings.secrets()); // redact the stored tokens from logs too
   const manager = new Manager(config, registry, settings);

--- a/server/src/settings.js
+++ b/server/src/settings.js
@@ -18,13 +18,14 @@ import { createMutex } from './registry.js';
 
 // Fields treated as secrets: masked in API responses, only overwritten when a
 // non-empty value is supplied, and fed to the log redactor.
-const SECRET_FIELDS = ['githubToken', 'claudeToken', 'codexToken', 'wpAdminPassword'];
+const SECRET_FIELDS = ['githubToken', 'claudeToken', 'codexToken', 'opencodeToken', 'wpAdminPassword'];
 
 function defaults() {
   return {
     githubToken: '',
     claudeToken: '',
     codexToken: '',
+    opencodeToken: '',
     wpAdminUser: 'admin',
     wpAdminPassword: 'password',
     wpAdminEmail: 'admin@example.com',
@@ -73,6 +74,7 @@ export class SettingsStore {
       githubToken: mask(s.githubToken),
       claudeToken: mask(s.claudeToken),
       codexToken: mask(s.codexToken),
+      opencodeToken: mask(s.opencodeToken),
       wpAdminUser: s.wpAdminUser,
       wpAdminEmail: s.wpAdminEmail,
       wpAdminPassword: mask(s.wpAdminPassword),

--- a/server/ui/app.js
+++ b/server/ui/app.js
@@ -130,7 +130,7 @@ function SessionItem({ s, selectedId, onSelect, onDelete, now }) {
           : html`<span class="sess-time" title=${`last active ${fullTime(s.lastActivityAt)}`}>${fmtAgo(s.lastActivityAt)}</span>`}
         <button class="sess-del lnk" title="Delete session" onClick=${(e) => { e.stopPropagation(); onDelete(s); }}>🗑</button>
       </div>
-      <div class="sess-sub muted"><span class="agent-tag">${s.agent === 'codex' ? 'Codex' : 'Claude'}</span> · started ${fmtAgo(s.createdAt, true)} · ${s.turnCount} turn${s.turnCount === 1 ? '' : 's'} · $${(s.costUsd || 0).toFixed(3)}</div>
+      <div class="sess-sub muted"><span class="agent-tag">${agentLabel(s.agent)}</span> · started ${fmtAgo(s.createdAt, true)} · ${s.turnCount} turn${s.turnCount === 1 ? '' : 's'} · $${(s.costUsd || 0).toFixed(3)}</div>
     </div>`;
 }
 
@@ -299,7 +299,7 @@ function SessionView({ session, now, onChanged, onBack, onDelete }) {
                 <button class="lnk small danger" onClick=${onDelete} title="Delete session">🗑</button>`}
         </div>
         <div class="bar-meta muted">
-          ${session.envName} · <span class="agent-tag">${session.agent === 'codex' ? 'Codex' : 'Claude'}</span> · ${session.model || 'default model'} · $${(session.costUsd || 0).toFixed(4)}
+          ${session.envName} · <span class="agent-tag">${agentLabel(session.agent)}</span> · ${session.model || 'default model'} · $${(session.costUsd || 0).toFixed(4)}
           ${session.claudeSessionId && html`· <code title="agent session id">${session.claudeSessionId.slice(0, 8)}</code>`}
         </div>
         <div class="bar-meta muted" title=${`started ${fullTime(session.createdAt)}\nlast active ${fullTime(session.lastActivityAt)}`}>
@@ -353,10 +353,10 @@ function NewSessionModal({ envs, preselect, onClose, onCreate }) {
         </label>
         <label>Agent
           <div class="agent-pick">
-            ${['claude', 'codex'].map((a) => html`
+            ${['claude', 'codex', 'opencode'].map((a) => html`
               <label class=${`agent-opt ${agent === a ? 'sel' : ''}`} key=${a}>
                 <input type="radio" name="agent" checked=${agent === a} onChange=${() => setAgent(a)} />
-                ${a === 'claude' ? 'Claude' : 'Codex'}
+                ${agentLabel(a)}
               </label>`)}
           </div>
         </label>
@@ -395,6 +395,8 @@ function fullTime(iso) {
   const t = Date.parse(iso || '');
   return isNaN(t) ? '' : new Date(t).toLocaleString();
 }
+const AGENT_LABELS = { claude: 'Claude', codex: 'Codex', opencode: 'OpenCode' };
+const agentLabel = (a) => AGENT_LABELS[a] || 'Claude';
 
 function LogViewer({ env, onClose }) {
   const [text, setText] = useState('');
@@ -560,6 +562,7 @@ function SettingsModal({ onClose, onLogout }) {
   const [ghToken, setGh] = useState('');
   const [clToken, setCl] = useState('');
   const [cxToken, setCx] = useState('');
+  const [ocToken, setOc] = useState('');
   const [wpUser, setWpUser] = useState('');
   const [wpEmail, setWpEmail] = useState('');
   const [wpPass, setWpPass] = useState('');
@@ -582,9 +585,10 @@ function SettingsModal({ onClose, onLogout }) {
       if (ghToken) body.githubToken = ghToken;
       if (clToken) body.claudeToken = clToken;
       if (cxToken) body.codexToken = cxToken;
+      if (ocToken) body.opencodeToken = ocToken;
       if (wpPass) body.wpAdminPassword = wpPass;
       const d = await api('/settings', { method: 'PUT', body: JSON.stringify(body) });
-      setS(d); setGh(''); setCl(''); setCx(''); setWpPass(''); setSaved(true);
+      setS(d); setGh(''); setCl(''); setCx(''); setOc(''); setWpPass(''); setSaved(true);
     } catch (e) { setErr(e.message); } finally { setBusy(false); }
   };
 
@@ -603,6 +607,9 @@ function SettingsModal({ onClose, onLogout }) {
           </label>
           <label>Codex token <span class="muted small">— ${hint('codexToken')}</span>
             <input type="password" value=${cxToken} placeholder="sk-… (OpenAI API key)" onInput=${(e) => setCx(e.target.value)} />
+          </label>
+          <label>OpenCode token <span class="muted small">— ${hint('opencodeToken')}</span>
+            <input type="password" value=${ocToken} placeholder="OpenCode Zen API key (opencode.ai/auth)" onInput=${(e) => setOc(e.target.value)} />
           </label>
           <label>WordPress admin username
             <input value=${wpUser} onInput=${(e) => setWpUser(e.target.value)} />

--- a/templates/scripts/connect-mcp.sh
+++ b/templates/scripts/connect-mcp.sh
@@ -132,6 +132,46 @@ if command -v codex >/dev/null 2>&1; then
 else
   echo "→ codex not installed in this env — skipping Codex MCP setup."
 fi
+
+# OpenCode (~/.config/opencode/opencode.json). Merge the mcp section (preserving
+# other config). wordpress = local (stdio) with env; playwright = remote (http).
+# Skipped when opencode isn't installed; non-fatal.
+if command -v opencode >/dev/null 2>&1; then
+  echo "→ Connecting OpenCode to the MCP servers (~/.config/opencode/opencode.json)…"
+  if HAS_WP="$HAS_WP" APPPASS="$APPPASS" WP_API_USERNAME="$ADMIN_USER" WP_MCP_URL="$WP_MCP_URL" PLAYWRIGHT_URL="$PLAYWRIGHT_URL" node -e '
+    const fs = require("fs"), os = require("os"), path = require("path");
+    const dir = path.join(os.homedir(), ".config", "opencode");
+    fs.mkdirSync(dir, { recursive: true });
+    const p = path.join(dir, "opencode.json");
+    let c = {};
+    try { c = JSON.parse(fs.readFileSync(p, "utf8")); } catch {}
+    c["$schema"] = "https://opencode.ai/config.json";
+    c.mcp = c.mcp || {};
+    if (process.env.HAS_WP === "1") {
+      c.mcp.wordpress = {
+        type: "local",
+        command: ["npx", "-y", "@automattic/mcp-wordpress-remote"],
+        environment: {
+          WP_API_URL: process.env.WP_MCP_URL,
+          WP_API_USERNAME: process.env.WP_API_USERNAME,
+          WP_API_PASSWORD: process.env.APPPASS,
+          OAUTH_ENABLED: "false",
+        },
+        enabled: true,
+      };
+    } else {
+      delete c.mcp.wordpress;
+    }
+    c.mcp.playwright = { type: "remote", url: process.env.PLAYWRIGHT_URL, enabled: true };
+    fs.writeFileSync(p, JSON.stringify(c, null, 2) + "\n");
+  '; then
+    echo "  ✓ opencode: wordpress + playwright"
+  else
+    echo "  ⚠ opencode: MCP config write failed (continuing)" >&2
+  fi
+else
+  echo "→ opencode not installed in this env — skipping OpenCode MCP setup."
+fi
 EOF
 
 echo "✓ Run 'npm run claude' or 'npm run cursor' and use the MCP servers right away."

--- a/templates/scripts/in-workspace.sh
+++ b/templates/scripts/in-workspace.sh
@@ -50,6 +50,13 @@ if [ -z "$CODEX_KEY" ] && [ -f "$CODEX_KEY_FILE" ]; then
   CODEX_KEY="$(tr -d '[:space:]' < "$CODEX_KEY_FILE")"
 fi
 
+# OpenCode (Zen gateway) API key: $OPENCODE_API_KEY, then the file.
+OPENCODE_KEY="${OPENCODE_API_KEY:-}"
+OPENCODE_KEY_FILE="${OPENCODE_API_KEY_FILE:-$HOME/.agent-sandbox/opencode-api-key}"
+if [ -z "$OPENCODE_KEY" ] && [ -f "$OPENCODE_KEY_FILE" ]; then
+  OPENCODE_KEY="$(tr -d '[:space:]' < "$OPENCODE_KEY_FILE")"
+fi
+
 # Only nudge about the credential for the agent actually being launched, so
 # `npm run bash` (and the other agent) stays quiet.
 case "${1:-}" in
@@ -76,12 +83,20 @@ case "${1:-}" in
       echo "  or 'export CODEX_API_KEY=<key>'." >&2
     fi
     ;;
+  opencode)
+    if [ -z "$OPENCODE_KEY" ]; then
+      echo "ℹ No OpenCode API key found (\$OPENCODE_API_KEY or $OPENCODE_KEY_FILE)." >&2
+      echo "  opencode (Zen) needs a key from opencode.ai/auth — save it to $OPENCODE_KEY_FILE" >&2
+      echo "  (one line), or 'export OPENCODE_API_KEY=<key>'." >&2
+    fi
+    ;;
 esac
 
 # Export so the values are inherited by the container via name-only -e (off argv).
 export CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_TOKEN"
 export CURSOR_API_KEY="$CURSOR_KEY"
 export CODEX_API_KEY="$CODEX_KEY"
+export OPENCODE_API_KEY="$OPENCODE_KEY"
 
 # Allocate a TTY only when we actually have one. Interactive use (`npm run claude`,
 # `npm run bash`) keeps its TTY; piped/headless callers (e.g. driving
@@ -94,4 +109,5 @@ exec docker compose exec $TTY_FLAG \
   -e CLAUDE_CODE_OAUTH_TOKEN \
   -e CURSOR_API_KEY \
   -e CODEX_API_KEY \
+  -e OPENCODE_API_KEY \
   workspace "$@"

--- a/templates/workspace.Dockerfile
+++ b/templates/workspace.Dockerfile
@@ -32,11 +32,11 @@ RUN printf 'path: /home/node/wp\n' > /etc/wp-cli.yml
 # Composer (PHP dependency manager), available globally as `composer`.
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
-# Claude Code + OpenAI Codex (both headless agents), plus the mcp-wordpress-remote
-# stdio proxy the workspace's Claude uses to reach the site's MCP server.
-# Pre-installing the proxy means the `npx @automattic/mcp-wordpress-remote` in
-# connect-mcp.sh resolves instantly (and offline) instead of fetching on first use.
-RUN npm install -g @anthropic-ai/claude-code @openai/codex @automattic/mcp-wordpress-remote
+# Headless coding agents — Claude Code, OpenAI Codex, and opencode — plus the
+# mcp-wordpress-remote stdio proxy the workspace agents use to reach the site's
+# MCP server. Pre-installing the proxy means the `npx @automattic/mcp-wordpress-remote`
+# in connect-mcp.sh resolves instantly (and offline) instead of fetching on first use.
+RUN npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai @automattic/mcp-wordpress-remote
 
 # Seed Claude's onboarding flags so a token-authenticated profile
 # (CLAUDE_CODE_OAUTH_TOKEN) goes straight to the prompt instead of stopping on the


### PR DESCRIPTION
Adds **opencode** as a third selectable headless agent — same shape as Codex, authenticated via the **OpenCode Zen** gateway (one key, like you asked).

## Researched (empirically, by installing opencode in a container)
- Install: `npm install -g opencode-ai`.
- Token: **`OPENCODE_API_KEY`** → Zen — confirmed (a fake key 401s against `opencode.ai/zen/v1/messages`). Direct analog to `CODEX_API_KEY`.
- Run: `opencode run --format json --dangerously-skip-permissions -m opencode/<model> --dir /home/node "<prompt>"`; resume with `-s <session_id>`. Session id is in the `sessionID` field.
- Models: `opencode/<model>` (e.g. `opencode/claude-sonnet-4-6`, `opencode/gpt-5.5`).
- MCP: global config at `~/.config/opencode/opencode.json` (`mcp` → local stdio / remote http) — verified `opencode mcp list` reads it.

## Changes
**Scaffolder (published):** workspace image installs `opencode-ai`; `in-workspace.sh` resolves + forwards `OPENCODE_API_KEY` (env → `~/.agent-sandbox/opencode-api-key`); `connect-mcp.sh` writes the wordpress (stdio+env) + playwright (http) MCP servers into `~/.config/opencode/opencode.json` (merged, guarded, non-fatal).

**Server:** `AGENTS.opencode` (token `OPENCODE_API_KEY`, default model `opencode/claude-sonnet-4-6`); `reapAgents` also kills `opencode run`; Settings gains a masked **OpenCode token**.

**UI:** New Session picker is **Claude / Codex / OpenCode**; agent shown in the list + header; Settings has an OpenCode token field.

## Verified
All files parse; scaffolder scripts pass `bash -n`. opencode `buildArgs` (new + `-s` resume), the error-event parse, and **delta-streaming** of text (Hello → " world" → flush on `session.idle`) all check out; settings seed/mask the token; clean boot.

## ⚠️ Provisional (needs your key to finalize)
The error event shape + `OPENCODE_API_KEY`→Zen auth are confirmed, but opencode's **success** event field names (text/tool parts) aren't documented — the `parseLine` mapping is best-effort and I'll tighten it against a real `opencode run --format json` capture once you drop the Zen key into Settings and run one session on a fresh env. (Same situation as Codex's first run.)

Not merged — for review + a live smoke test (key in Settings + a freshly-built env, since opencode is only in new images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)