### PR TITLE
Make Playwright screenshots readable by the agent

### DIFF
--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -89,8 +89,18 @@ services:
   # workspace connects to it over HTTP at http://playwright:8931/mcp and drives a
   # browser against the site at http://wordpress. --allowed-hosts must list the
   # host:port Claude uses (the server otherwise only accepts localhost).
+  #
+  # --output-dir writes screenshots/traces into /home/node/.playwright-output.
+  # Because the workspace is bind-mounted here at the SAME path it has in the
+  # workspace container (below), a screenshot Playwright saves is readable by the
+  # agent at the exact path the tool reports — so it can Read the image back and
+  # actually look at it. Without this, files land only inside this container and
+  # the agent can't see them. The image runs as uid 1000 (node), matching the
+  # workspace's owner, so writes succeed.
   playwright:
     image: mcr.microsoft.com/playwright/mcp:latest
     restart: unless-stopped
     init: true
-    command: ["--port", "8931", "--host", "0.0.0.0", "--allowed-hosts", "playwright:8931"]
+    command: ["--port", "8931", "--host", "0.0.0.0", "--allowed-hosts", "playwright:8931", "--output-dir", "/home/node/.playwright-output"]
+    volumes:
+      - ./workspace:/home/node

--- a/templates/skills/wordpress-dev/SKILL.md
+++ b/templates/skills/wordpress-dev/SKILL.md
@@ -19,7 +19,14 @@ This WordPress install is split across Docker containers on a shared network:
 - **db** — MariaDB database (reachable on the network as host `db`).
 - **wordpress** — the Apache/PHP web server serving the site at `http://wordpress/`.
 - **playwright** — a headless-Chromium Playwright MCP server; point its browser
-  at `http://wordpress/`.
+  at `http://wordpress/`. **Use it to *see* rendered pages** — whenever a task
+  involves how something looks (layout, styling, "pixel perfect", does-it-render),
+  drive the browser with the `browser_navigate` / `browser_take_screenshot` MCP
+  tools rather than guessing from source. Screenshots are written to
+  `/home/node/.playwright-output/` — the **same path in your workspace** — so
+  after `browser_take_screenshot` you can **`Read` the saved PNG** (the path the
+  tool reports) and actually look at it. Tip: set a viewport with `browser_resize`
+  first for a predictable capture.
 
 **Reaching the site:** from inside any container (including the Playwright
 browser) use `http://wordpress/`, e.g. `http://wordpress/wp-login.php`.


### PR DESCRIPTION
## Problem

The Playwright MCP runs in its own container (`mcr.microsoft.com/playwright/mcp`) with **no shared filesystem** with the workspace where the agent runs. So when the agent drove the browser and took a screenshot, the PNG landed only inside the Playwright container — the agent couldn't read it back to actually *look* at the page. It would chase the file across containers and give up (and sometimes didn't realize it should use Playwright at all).

## Fix

Bind-mount `./workspace:/home/node` into the `playwright` service — the **same same-path mount** the `wordpress` and `workspace` services already use — and set `--output-dir /home/node/.playwright-output`.

The MCP server's cwd is `/home/node`, so a screenshot lands in the **shared workspace at the exact path the tool reports**. The agent (same `/home/node` cwd) can `Read` it right back. uid 1000 in the Playwright image matches the workspace owner, so writes succeed.

## Verified end-to-end (live env)

- Recreated a running env's `playwright` with the change.
- `browser_take_screenshot` (no filename) → wrote a **1.19 MB PNG** to `/home/node/.playwright-output/page-<ts>.png`.
- Read it back from the **workspace** container at the **reported path** (1,194,464 bytes) ✓
- The tool also returned the image **inline** (1.59 MB base64), so capable clients (Claude) see it directly too.

## Discoverability

Updated the `wordpress-dev` skill: tells the agent to use the Playwright MCP browser tools for any "how does it look / pixel perfect / does-it-render" task, and that screenshots are saved to `/home/node/.playwright-output` and can be `Read` back.

## Note

Existing envs need their `playwright` container recreated (`docker compose up -d playwright`) to pick up the mount; new envs get it from the template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)