### PR TITLE
feat(server): warm pool — pre-built environments waiting per preset

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -11,6 +11,7 @@ The server is a **thin orchestrator over the scaffolded project's own scripts**:
 - **Create**: runs the standard scaffolder once — `node ../index.js <dir> --port=N` — which scaffolds **and** `npm run setup` (build + boot + provision). Default compose project = the env name. Bounded by a build semaphore.
 - **Git auth**: configures `gh` + git identity inside the workspace from the shared `GITHUB_TOKEN` (non-fatal).
 - **Provisioning via presets**: an environment is provisioned by the **presets** chosen at create time (composable — pick several, applied in order). A preset carries a setup script, a long-running dev script, wp-config defines, and an ordered plugin-activation list. Built-ins include **Oxygen** (build Breakdance/Oxygen from source) and **Agent Connector (dev)** (replace the release-zip gateway with a live git checkout — clone → `composer install --no-dev` → symlink into `wp-content/plugins` → activate). Presets live in `data/presets.json`, managed in the UI / via `/presets`.
+- **Warm pool**: provisioning a fresh env takes minutes (build + WP setup). To make creation instant, the server keeps a configurable number of **pre-built, then stopped** envs waiting per preset (set per preset in Settings, or via `PUT /pool/:presetId`). A create that matches a single warmed preset (no custom overrides) **claims** a ready env and just `start`s it (cached, seconds) instead of building; the pool refills in the background, bounded by the build semaphore and leaving `WARM_POOL_RESERVE` free slots for on-demand creates. Pushed new code and the pool is stale? `POST /pool/:presetId/rebuild` (or the Settings button) nukes and rebuilds it. Warm members are tagged in the registry and hidden from the env list.
 - **Claude sessions**: each user message spawns `claude -p [--resume <id>] --output-format stream-json …` via the env's own `scripts/in-workspace.sh` (so auth = the proven token path; the server holds no Claude token). stdout is streamed to the browser over **SSE**; the session id + result + cost are persisted (`data/sessions.json`, raw events in `data/sessions/<id>.ndjson`). Resumable from the UI **and** by SSH (`bash scripts/in-workspace.sh claude --resume <id>`).
 - **Turn lifecycle / reaping**: a `claude -p` turn runs *inside* the workspace container, so it survives a server restart. The server reaps in-container turns on **interrupt**, on **shutdown**, and on **startup** (any `claude -p` still running when the server boots is an orphan from a previous run) — so a resume never spawns a duplicate that races the orphan. A plain restart (Ctrl+C) reaps turns but leaves the env containers up, so sessions resume cleanly.
 - **Control / shutdown**: `POST /control/interrupt-all` (stop all turns), `/control/stop-all` (stop every env's containers), `/control/shutdown` (stop everything + exit the process) — surfaced as buttons on the Health screen.
@@ -35,6 +36,8 @@ The server is a **thin orchestrator over the scaffolded project's own scripts**:
 | `SCAFFOLDER_DIR` | repo root | path to the scaffolder (`index.js`) |
 | `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL` | `devbox` / `devbox@localhost` | commit identity |
 | `RECONCILE_INTERVAL_MS` | `45000` | status reconcile loop interval |
+| `WARM_POOL_RESERVE` | `5` | free env slots the warm pool leaves for on-demand creates (it won't fill past `MAX_ENVIRONMENTS − reserve`) |
+| `WARM_POOL_INTERVAL_MS` | `20000` | warm-pool top-up loop interval |
 
 ## Run
 
@@ -84,6 +87,9 @@ DEVBOX_API_TOKEN=secret GITHUB_TOKEN=… npm start
 | `DELETE` | `/sessions/:id` | forget the session |
 | `GET` | `/host` | system health: memory/CPU/disk, docker df, per-env container memory, RAM-headroom estimate |
 | `GET` / `PUT` | `/settings` | tokens + WP-admin defaults (secrets masked on read) |
+| `GET` | `/pool` | warm-pool status per preset `{presetId,name,desired,ready,building,failed}` |
+| `PUT` | `/pool/:presetId` | `{count}` → set how many pre-built envs to keep ready (0 = off) |
+| `POST` | `/pool/:presetId/rebuild` | destroy that preset's warm envs (stale code) → the loop refills |
 | `POST` | `/control/interrupt-all` | interrupt every running Claude turn (containers stay up) |
 | `POST` | `/control/stop-all` | stop every env's containers (and interrupt their turns) |
 | `POST` | `/control/shutdown` | full teardown: stop everything + exit the server process |

--- a/server/src/allocator.js
+++ b/server/src/allocator.js
@@ -41,12 +41,17 @@ export class AllocationError extends Error {
 
 // Returns the reservation record (already persisted into the registry with
 // status "scaffolding").
-export async function allocate(registry, config, { nameHint } = {}) {
+export async function allocate(registry, config, { nameHint, pool = null } = {}) {
   return registry.mutate(async (data) => {
     const envs = Object.values(data.environments);
-    if (envs.length >= config.maxEnvironments) {
+    // Warm-pool builds must leave a reserve of free slots for on-demand creates,
+    // so they stop short of the hard cap; user creates may use the full cap.
+    const cap = pool ? Math.max(0, config.maxEnvironments - config.warmPoolReserve) : config.maxEnvironments;
+    if (envs.length >= cap) {
       throw new AllocationError(
-        `at capacity: ${envs.length}/${config.maxEnvironments} environments (raise MAX_ENVIRONMENTS)`,
+        pool
+          ? `warm pool deferred: ${envs.length}/${config.maxEnvironments} env(s), reserving ${config.warmPoolReserve} free slot(s)`
+          : `at capacity: ${envs.length}/${config.maxEnvironments} environments (raise MAX_ENVIRONMENTS)`,
         503,
       );
     }
@@ -106,6 +111,10 @@ export async function allocate(registry, config, { nameHint } = {}) {
       // Setup log lives OUTSIDE the env dir (the scaffolder requires an empty
       // target dir).
       setupLogPath: join(config.dataDir, 'logs', `${name}.log`),
+      // Warm-pool members carry the preset id they were built for; poolReady is
+      // set once built + stopped. Both null/false for normal envs.
+      pool: pool || null,
+      poolReady: false,
     };
     data.environments[id] = record;
     return record;

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -61,6 +61,10 @@ export function loadConfig(env = process.env) {
     maxEnvironments: parseInt(env.MAX_ENVIRONMENTS || '25', 10),
     buildConcurrency: Math.max(1, parseInt(env.BUILD_CONCURRENCY || '2', 10)),
     reconcileIntervalMs: parseInt(env.RECONCILE_INTERVAL_MS || '45000', 10),
+    // Warm pool: free env slots reserved for on-demand creates (the pool builder
+    // won't fill past maxEnvironments - reserve), and how often it tops up.
+    warmPoolReserve: Math.max(0, parseInt(env.WARM_POOL_RESERVE || '5', 10)),
+    warmPoolIntervalMs: parseInt(env.WARM_POOL_INTERVAL_MS || '20000', 10),
 
     // GitHub + Claude tokens are managed in Settings — these env values only
     // seed the settings file on first run.

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -48,6 +48,7 @@ async function main() {
   }).load();
   addSecrets(settings.secrets()); // redact the stored tokens from logs too
   const manager = new Manager(config, registry, settings);
+  manager.presets = presets; // warm-pool builder reads preset definitions
 
   // Claude session subsystem.
   const sessionStore = await new SessionStore(config.sessionsPath).load();
@@ -80,6 +81,7 @@ async function main() {
         `max: ${config.maxEnvironments} | auth: ${config.apiToken ? 'bearer' : 'none'} | UI: http://${config.bind}:${config.port}/`,
     );
     manager.startReconcileLoop();
+    manager.startPoolLoop();
   });
 
   // On a plain restart (Ctrl+C / SIGTERM) we reap the in-container agent turns

--- a/server/src/manager.js
+++ b/server/src/manager.js
@@ -11,6 +11,7 @@ import { allocate } from './allocator.js';
 import * as docker from './docker.js';
 import * as gitauth from './gitauth.js';
 import { computeStatus, coreUp, publicView } from './status.js';
+import { composeProvision } from './provision.js';
 import { log, redact } from './log.js';
 
 // Counting semaphore to bound concurrent (heavy) docker builds.
@@ -72,7 +73,7 @@ export class Manager {
     // (carried in-memory through the pipeline; see onEnvReady).
     const initial = prompt ? { prompt, model, agent } : null;
     // Fire-and-forget pipeline; status is observable via GET.
-    this._pipeline(record, provisionPlan, initial).catch((err) => log.error(`[${record.name}] pipeline crashed:`, err));
+    this._pipeline(record, { provisionPlan, initial }).catch((err) => log.error(`[${record.name}] pipeline crashed:`, err));
     return record;
   }
 
@@ -105,7 +106,7 @@ export class Manager {
     return { args, scratchDir };
   }
 
-  async _pipeline(record, provisionPlan = null, initial = null) {
+  async _pipeline(record, { provisionPlan = null, initial = null, pool = false } = {}) {
     const { config, registry } = this;
     try {
       await mkdir(config.envsDir, { recursive: true });
@@ -148,9 +149,15 @@ export class Manager {
 
       // 3. Up and provisioned.
       await registry.update(record.id, { status: 'running', lastError: null });
-      // Env is up — fire the optional initial session. Best-effort: its failure
-      // must not fail the environment (the env itself is fine).
-      if (initial?.prompt) {
+      if (pool) {
+        // Warm-pool build: it's built and healthy — stop it so it waits cheaply,
+        // and mark it claimable. (start is the fast cached `up -d --build`.)
+        await this.stop(record);
+        await registry.update(record.id, { poolReady: true });
+        log.info(`[pool] ${record.name} ready (preset ${record.pool})`);
+      } else if (initial?.prompt) {
+        // Env is up — fire the optional initial session. Best-effort: its failure
+        // must not fail the environment (the env itself is fine).
         try { await this.onEnvReady?.(record, initial); }
         catch (err) { log.warn(`[${record.name}] initial session failed:`, err.message); }
       }
@@ -177,7 +184,9 @@ export class Manager {
   }
 
   async list() {
-    return Promise.all(this.registry.list().map((r) => this.describe(r)));
+    // Warm-pool members are infrastructure, not user envs — hide them from the
+    // list (they surface via the pool status API instead).
+    return Promise.all(this.registry.list().filter((r) => !r.pool).map((r) => this.describe(r)));
   }
 
   // Is the env's core stack up (so we can exec claude/agents in it)? Cheap.
@@ -271,6 +280,172 @@ export class Manager {
     tick(); // run once at boot
     this.reconcileTimer = setInterval(tick, this.config.reconcileIntervalMs);
     this.reconcileTimer.unref?.();
+  }
+
+  // ---- warm pool ----------------------------------------------------------
+  //
+  // Keep N pre-built-then-stopped envs per preset waiting, so creating from a
+  // warmed preset is a fast cached `start` (claimAndStart) instead of a ~10-min
+  // build. Desired counts live in settings.warmPool ({ [presetId]: n }); warm
+  // members are tagged `pool: presetId` (+ `poolReady` once built). The preset
+  // store is wired in as `this.presets` at boot (index.js).
+
+  poolEntries() {
+    return Object.entries(this.settings.get().warmPool || {});
+  }
+
+  // Live per-preset status for the settings UI.
+  poolStatus() {
+    const byPreset = new Map();
+    const ensure = (pid) => {
+      if (!byPreset.has(pid)) byPreset.set(pid, { presetId: pid, desired: 0, ready: 0, building: 0, failed: 0 });
+      return byPreset.get(pid);
+    };
+    for (const [pid, n] of this.poolEntries()) ensure(pid).desired = Math.max(0, parseInt(n, 10) || 0);
+    for (const e of this.registry.list()) {
+      if (!e.pool) continue;
+      const row = ensure(e.pool);
+      if (e.status === 'failed') row.failed += 1;
+      else if (e.poolReady) row.ready += 1;
+      else row.building += 1;
+    }
+    return [...byPreset.values()].map((r) => ({ ...r, name: this.presets?.get(r.presetId)?.name || null }));
+  }
+
+  // Atomically claim a ready warm env for a preset, converting it to a normal
+  // env (drops the pool tag; the typed name becomes its display label).
+  async claimPoolEnv(presetId, { name } = {}) {
+    return this.registry.mutate((data) => {
+      const cand = Object.values(data.environments).find(
+        (e) => e.pool === presetId && e.poolReady === true && !this.jobs.has(e.id),
+      );
+      if (!cand) return null;
+      cand.pool = null;
+      cand.poolReady = false;
+      if (name && name.trim()) cand.displayName = name.trim().slice(0, 80);
+      return cand;
+    });
+  }
+
+  // Create-from-warmed-preset fast path: claim + cached start + optional initial
+  // session, refilling the pool. Returns the claimed record, or null if none
+  // was ready (caller falls back to a normal build).
+  async claimAndStart(presetId, { name, prompt, model, agent } = {}) {
+    const record = await this.claimPoolEnv(presetId, { name });
+    if (!record) return null;
+    this.jobs.set(record.id, 'configuring');
+    this._claimPipeline(record, { prompt, model, agent }).catch((err) => log.error(`[${record.name}] claim crashed:`, err));
+    this.maintainPoolSoon(); // top the pool back up
+    return record;
+  }
+
+  async _claimPipeline(record, initial = {}) {
+    const { registry, config } = this;
+    try {
+      await docker.npmRun(record, 'start', { timeout: 600_000 }); // up -d --build (cached)
+      await gitauth.configure(record, config, this.settings.get().githubToken);
+      await registry.update(record.id, { status: 'running', lastError: null });
+      if (initial.prompt) {
+        try { await this.onEnvReady?.(registry.get(record.id), initial); }
+        catch (err) { log.warn(`[${record.name}] initial session failed:`, err.message); }
+      }
+    } catch (err) {
+      log.error(`[${record.name}] claim-start failed:`, err.message);
+      await registry.update(record.id, { status: 'failed', lastError: truncate(redactErr(err)) });
+    } finally {
+      this.jobs.delete(record.id);
+    }
+  }
+
+  // Build one warm env for a preset (allocate with reserve-aware cap → pipeline →
+  // stop → poolReady). May throw AllocationError when capacity/reserve is hit.
+  async _buildPoolEnv(presetId) {
+    const preset = this.presets?.get(presetId);
+    if (!preset) return;
+    const provision = composeProvision([preset], null);
+    const record = await allocate(this.registry, this.config, { pool: presetId });
+    this.jobs.set(record.id, 'scaffolding');
+    await this.registry.update(record.id, { preset: preset.name });
+    const provisionPlan = provision ? await this._materializeProvision(record, provision) : null;
+    this._pipeline(record, { provisionPlan, pool: true }).catch((err) => log.error(`[pool ${preset.name}] pipeline crashed:`, err));
+  }
+
+  // Top up / clean up the pool to match desired counts. Idempotent and mutually
+  // exclusive (timer + on-demand callers can't double-build).
+  async maintainPool() {
+    if (!this.presets || this._poolBusy) return;
+    this._poolBusy = true;
+    try {
+      for (const [presetId, desiredRaw] of this.poolEntries()) {
+        const desired = Math.max(0, parseInt(desiredRaw, 10) || 0);
+        const preset = this.presets.get(presetId);
+        let mine = this.registry.list().filter((e) => e.pool === presetId);
+
+        // Stale config (preset deleted): tear down its warm envs.
+        if (!preset) {
+          for (const e of mine) if (!this.jobs.has(e.id)) await this.destroy(e).catch(() => {});
+          continue;
+        }
+
+        // Discard failed warm envs; finalize crash-orphaned ones (built but never
+        // stopped/marked — e.g. server died between 'running' and stop()).
+        for (const e of mine) {
+          if (this.jobs.has(e.id)) continue;
+          if (e.status === 'failed') {
+            log.warn(`[pool ${preset.name}] discarding failed warm env ${e.name}`);
+            await this.destroy(e).catch(() => {});
+          } else if (!e.poolReady && e.setupFinishedAt) {
+            if (e.status === 'running' || e.status === 'degraded') await this.stop(e).catch(() => {});
+            await this.registry.update(e.id, { poolReady: true });
+          }
+        }
+
+        mine = this.registry.list().filter((e) => e.pool === presetId && e.status !== 'failed');
+        const ready = mine.filter((e) => e.poolReady).length;
+        const building = mine.length - ready;
+        // Cap concurrent warm builds so on-demand creates always keep a build
+        // slot (a single broken preset also can't pile up — at most one build is
+        // in flight, re-checked each tick). Each build is fire-and-forget.
+        const inFlightCap = Math.max(1, this.config.buildConcurrency - 1);
+        let slots = Math.min(inFlightCap - building, desired - mine.length);
+        while (slots > 0) {
+          try {
+            await this._buildPoolEnv(presetId);
+          } catch (err) {
+            log.info(`[pool ${preset.name}] hold: ${err.message}`); // at capacity/reserve — retry next tick
+            break;
+          }
+          slots -= 1;
+        }
+      }
+    } finally {
+      this._poolBusy = false;
+    }
+  }
+
+  // Debounced background top-up (after a claim or a config change).
+  maintainPoolSoon() {
+    if (this._poolSoon) return;
+    this._poolSoon = setTimeout(() => {
+      this._poolSoon = null;
+      this.maintainPool().catch((e) => log.warn('pool maintain error:', e.message));
+    }, 1500);
+    this._poolSoon.unref?.();
+  }
+
+  // Nuke a preset's warm envs (e.g. stale after a git push); the loop refills.
+  async rebuildPool(presetId) {
+    const mine = this.registry.list().filter((e) => e.pool === presetId);
+    await Promise.allSettled(mine.map((e) => this.destroy(e)));
+    this.maintainPoolSoon();
+    return mine.length;
+  }
+
+  startPoolLoop() {
+    const tick = () => this.maintainPool().catch((e) => log.warn('pool loop error:', e.message));
+    tick();
+    this.poolTimer = setInterval(tick, this.config.warmPoolIntervalMs);
+    this.poolTimer.unref?.();
   }
 
   // ---- helpers ------------------------------------------------------------

--- a/server/src/provision.js
+++ b/server/src/provision.js
@@ -1,0 +1,37 @@
+// Compose selected presets (in order) + optional custom fields into one
+// provision object the scaffolder understands. Pure (no I/O), so it's shared by
+// the route layer (on-demand creates) and the manager (warm-pool builds).
+//
+// setup scripts run sequentially, dev scripts run concurrently in the single dev
+// container, defines merge (later wins), activate lists concatenate (deduped).
+// Returns null when there's nothing to provision.
+export function composeProvision(presets, custom) {
+  const parts = presets.map((p) => ({
+    label: p.name, setupScript: p.setupScript, devScript: p.devScript, defines: p.defines, activate: p.activate,
+  }));
+  if (custom) parts.push({ label: 'Custom', ...custom });
+  if (!parts.length) return null;
+
+  const setupChunks = parts
+    .filter((p) => p.setupScript && p.setupScript.trim())
+    .map((p) => `# ===== ${p.label} =====\n${p.setupScript.trim()}\n`);
+  const setupScript = setupChunks.length
+    ? `#!/usr/bin/env bash\nset -euo pipefail\n\n${setupChunks.join('\n')}`
+    : '';
+
+  const devs = parts.filter((p) => p.devScript && p.devScript.trim());
+  let devScript = '';
+  if (devs.length === 1) devScript = devs[0].devScript;
+  else if (devs.length > 1) {
+    devScript = '#!/usr/bin/env bash\n# composed dev scripts — run concurrently in one dev container\n'
+      + devs.map((d) => `# --- ${d.label} ---\n(\n${d.devScript.trim()}\n) &`).join('\n')
+      + '\nwait\n';
+  }
+
+  const defines = Object.assign({}, ...parts.map((p) => p.defines || {}));
+  const activate = [];
+  for (const p of parts) for (const s of p.activate || []) if (!activate.includes(s)) activate.push(s);
+
+  if (!setupScript && !devScript && !activate.length && !Object.keys(defines).length) return null;
+  return { setupScript, devScript, defines, activate, presetName: presets.map((p) => p.name).join(' + ') || null };
+}

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -8,6 +8,7 @@ import { exec } from './docker.js';
 import { systemHealth } from './health.js';
 import { AGENTS } from './claude.js';
 import { AllocationError } from './allocator.js';
+import { composeProvision } from './provision.js';
 import { openSse } from './sse.js';
 import { makeStaticHandler } from './static.js';
 
@@ -105,6 +106,17 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
         const prompt = typeof ctx.body.prompt === 'string' ? ctx.body.prompt.trim() : '';
         const model = typeof ctx.body.model === 'string' && ctx.body.model.trim() ? ctx.body.model.trim() : undefined;
         const agent = AGENTS[ctx.body.agent] ? ctx.body.agent : undefined; // first-prompt session agent; else default
+
+        // Warm-pool fast path: a single preset with no custom overrides can claim
+        // a pre-built env and just start it (seconds) instead of building (~10m).
+        if (presetIds.length === 1 && !custom) {
+          const claimed = await manager.claimAndStart(presetIds[0], { name: ctx.body.name, prompt: prompt || undefined, model, agent });
+          if (claimed) {
+            ctx.send(202, { id: claimed.id, name: claimed.name, port: claimed.port, wpUrl: claimed.wpUrl, status: 'configuring', warm: true });
+            return;
+          }
+        }
+
         const record = await manager.createEnvironment({ name: ctx.body.name, provision, prompt: prompt || undefined, model, agent });
         ctx.send(202, { id: record.id, name: record.name, port: record.port, wpUrl: record.wpUrl, status: record.status });
       } catch (err) {
@@ -180,6 +192,24 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
     route('DELETE', '/presets/:id', async (ctx) => {
       if (!(await presets.remove(ctx.params.id))) throw httpErr(404, `preset "${ctx.params.id}" not found`);
       ctx.send(200, { deleted: true });
+    }),
+
+    // ---- warm pool (pre-built envs waiting per preset) --------------------
+    // Live status (desired/ready/building/failed per preset) for the UI.
+    route('GET', '/pool', async (ctx) => ctx.send(200, { pool: manager.poolStatus() })),
+    // Set the desired ready count for a preset (0 turns its pool off).
+    route('PUT', '/pool/:id', async (ctx) => {
+      if (!presets.get(ctx.params.id)) throw httpErr(404, `preset "${ctx.params.id}" not found`);
+      const count = Math.max(0, Math.min(50, parseInt(ctx.body.count, 10) || 0));
+      await settings.setWarmPool(ctx.params.id, count);
+      manager.maintainPoolSoon();
+      ctx.send(200, { pool: manager.poolStatus() });
+    }),
+    // Nuke a preset's warm envs (rebuild after stale code); the loop refills.
+    route('POST', '/pool/:id/rebuild', async (ctx) => {
+      if (!presets.get(ctx.params.id)) throw httpErr(404, `preset "${ctx.params.id}" not found`);
+      const removed = await manager.rebuildPool(ctx.params.id);
+      ctx.send(200, { rebuilt: removed, pool: manager.poolStatus() });
     }),
 
     // ---- agent sessions (claude | codex) ----------------------------------
@@ -327,37 +357,6 @@ function normalizeProvision(body) {
   return { setupScript, devScript, activate, defines };
 }
 
-// Compose selected presets (in order) + optional custom fields into one provision:
-// setup scripts run sequentially, dev scripts run concurrently in the single dev
-// container, defines merge (later wins), activate lists concatenate (deduped).
-// Returns null when there's nothing to provision. Exported for testing.
-export function composeProvision(presets, custom) {
-  const parts = presets.map((p) => ({
-    label: p.name, setupScript: p.setupScript, devScript: p.devScript, defines: p.defines, activate: p.activate,
-  }));
-  if (custom) parts.push({ label: 'Custom', ...custom });
-  if (!parts.length) return null;
-
-  const setupChunks = parts
-    .filter((p) => p.setupScript && p.setupScript.trim())
-    .map((p) => `# ===== ${p.label} =====\n${p.setupScript.trim()}\n`);
-  const setupScript = setupChunks.length
-    ? `#!/usr/bin/env bash\nset -euo pipefail\n\n${setupChunks.join('\n')}`
-    : '';
-
-  const devs = parts.filter((p) => p.devScript && p.devScript.trim());
-  let devScript = '';
-  if (devs.length === 1) devScript = devs[0].devScript;
-  else if (devs.length > 1) {
-    devScript = '#!/usr/bin/env bash\n# composed dev scripts — run concurrently in one dev container\n'
-      + devs.map((d) => `# --- ${d.label} ---\n(\n${d.devScript.trim()}\n) &`).join('\n')
-      + '\nwait\n';
-  }
-
-  const defines = Object.assign({}, ...parts.map((p) => p.defines || {}));
-  const activate = [];
-  for (const p of parts) for (const s of p.activate || []) if (!activate.includes(s)) activate.push(s);
-
-  if (!setupScript && !devScript && !activate.length && !Object.keys(defines).length) return null;
-  return { setupScript, devScript, defines, activate, presetName: presets.map((p) => p.name).join(' + ') || null };
-}
+// composeProvision lives in provision.js (shared with the warm-pool builder in
+// manager.js); re-exported here for any existing importers/tests.
+export { composeProvision };

--- a/server/src/settings.js
+++ b/server/src/settings.js
@@ -29,6 +29,9 @@ function defaults() {
     wpAdminUser: 'admin',
     wpAdminPassword: 'password',
     wpAdminEmail: 'admin@example.com',
+    // Warm pool: { [presetId]: desiredReadyCount }. How many pre-built (then
+    // stopped) environments to keep waiting per preset. Empty = pooling off.
+    warmPool: {},
   };
 }
 
@@ -78,7 +81,22 @@ export class SettingsStore {
       wpAdminUser: s.wpAdminUser,
       wpAdminEmail: s.wpAdminEmail,
       wpAdminPassword: mask(s.wpAdminPassword),
+      warmPool: { ...(s.warmPool || {}) },
     };
+  }
+
+  // Set the desired warm-pool count for one preset (0 removes it). Kept separate
+  // from update() because it's config, not a masked-secret form field.
+  setWarmPool(presetId, count) {
+    return this.mutex(async () => {
+      const n = Math.max(0, Math.min(50, parseInt(count, 10) || 0));
+      const warmPool = { ...(this.data.settings.warmPool || {}) };
+      if (n === 0) delete warmPool[presetId];
+      else warmPool[presetId] = n;
+      this.data.settings = { ...this.data.settings, warmPool };
+      await this._persist();
+      return warmPool;
+    });
   }
 
   // Apply a patch from the Settings form. Non-secret fields are set when a

--- a/server/ui/app.js
+++ b/server/ui/app.js
@@ -673,6 +673,61 @@ function NewEnvModal({ presets, onClose, onCreate, onSavePreset, onDeletePreset 
     </div>`;
 }
 
+// Warm-pool config: per-preset desired ready count + live status + rebuild.
+// Polls /pool so "building → ready" transitions show without a manual refresh.
+function WarmPoolSection() {
+  const [presets, setPresets] = useState([]);
+  const [pool, setPool] = useState([]);
+  const [err, setErr] = useState('');
+
+  const load = useCallback(async () => {
+    try {
+      const [p, pl] = await Promise.all([api('/presets'), api('/pool')]);
+      setPresets(p.presets); setPool(pl.pool);
+    } catch (e) { setErr(e.message); }
+  }, []);
+  useEffect(() => { load(); const t = setInterval(load, 4000); return () => clearInterval(t); }, [load]);
+
+  const byId = Object.fromEntries(pool.map((r) => [r.presetId, r]));
+  const setCount = async (presetId, count) => {
+    setErr('');
+    try { const d = await api(`/pool/${presetId}`, { method: 'PUT', body: JSON.stringify({ count: parseInt(count, 10) || 0 }) }); setPool(d.pool); }
+    catch (e) { setErr(e.message); }
+  };
+  const rebuild = async (presetId, name) => {
+    if (!confirm(`Rebuild the warm pool for "${name}"? This destroys its pre-built environments and rebuilds them from scratch (each rebuild takes the full ~10-min setup).`)) return;
+    setErr('');
+    try { const d = await api(`/pool/${presetId}/rebuild`, { method: 'POST' }); setPool(d.pool); }
+    catch (e) { setErr(e.message); }
+  };
+
+  return html`
+    <div class="warmpool">
+      <h4>Warm pool</h4>
+      <p class="muted small">Keep pre-built (then stopped) environments waiting per preset, so creating one is an instant start instead of a ~10-minute build. Rebuild to refresh a pool after pushing new code that would make it stale.</p>
+      ${presets.length === 0 && html`<div class="muted small">No presets yet — create one to warm a pool.</div>`}
+      ${presets.map((p) => {
+        const st = byId[p.id] || { desired: 0, ready: 0, building: 0, failed: 0 };
+        const live = st.ready + st.building + st.failed;
+        return html`
+          <div class="wp-row" key=${p.id}>
+            <span class="wp-name" title=${p.name}>${p.name}</span>
+            <span class="wp-status muted small">
+              ${st.ready} ready${st.building ? ` · ${st.building} building` : ''}${st.failed ? ` · ${st.failed} failed` : ''}
+            </span>
+            <label class="wp-keep muted small">keep
+              <input class="wp-count" type="number" min="0" max="50" value=${st.desired}
+                onChange=${(e) => setCount(p.id, e.target.value)} title="Desired ready count" />
+            </label>
+            ${live > 0
+              ? html`<button class="lnk" onClick=${() => rebuild(p.id, p.name)}>rebuild</button>`
+              : html`<span class="wp-spacer"></span>`}
+          </div>`;
+      })}
+      ${err && html`<div class="err-msg">${err}</div>`}
+    </div>`;
+}
+
 function SettingsModal({ onClose, onLogout }) {
   const [s, setS] = useState(null);
   const [ghToken, setGh] = useState('');
@@ -710,7 +765,7 @@ function SettingsModal({ onClose, onLogout }) {
 
   return html`
     <div class="modal-bg" onClick=${onClose}>
-      <div class="modal" onClick=${(e) => e.stopPropagation()}>
+      <div class="modal settings" onClick=${(e) => e.stopPropagation()}>
         <h3>Settings</h3>
         ${!s && !err && html`<div class="muted">Loading…</div>`}
         ${s && html`
@@ -737,6 +792,7 @@ function SettingsModal({ onClose, onLogout }) {
             <input value=${wpEmail} onInput=${(e) => setWpEmail(e.target.value)} />
           </label>
           <p class="muted small">Token changes apply to newly-created environments and new Claude turns. WP-admin defaults seed new sites.</p>`}
+        <${WarmPoolSection} />
         ${err && html`<div class="err-msg">${err}</div>`}
         ${saved && html`<div class="ok-msg">Saved.</div>`}
         <div class="modal-foot">

--- a/server/ui/style.css
+++ b/server/ui/style.css
@@ -149,6 +149,18 @@ pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12.5px/1.5
 .custom-prov summary { cursor: pointer; color: var(--muted); font-size: 13px; }
 .modal .save-preset { margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--line); }
 .modal .save-preset .btn { white-space: nowrap; }
+.modal.settings { max-height: 90vh; overflow-y: auto; }
+
+/* warm pool (Settings) */
+.warmpool { margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--line); }
+.warmpool h4 { margin: 0 0 4px; font-size: 13px; }
+.wp-row { display: flex; align-items: center; gap: 10px; padding: 6px 0; border-top: 1px solid var(--line); }
+.wp-name { font-weight: 600; max-width: 36%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.wp-status { flex: 1; }
+.wp-keep { display: flex; align-items: center; gap: 6px; margin: 0; }
+.wp-count { width: 56px; }
+.warmpool .wp-keep input { width: 56px; }
+.wp-spacer { width: 44px; }
 .modal.logs { width: 820px; }
 .logbox { margin-top: 8px; max-height: 62vh; overflow: auto; background: var(--bg);
   border: 1px solid var(--line); border-radius: 8px; padding: 10px; color: var(--text); }


### PR DESCRIPTION
## What & why

Provisioning a fresh env takes minutes (docker build + WordPress setup). This keeps a configurable number of **pre-built, then stopped** environments waiting per preset, so creating one becomes an **instant start** instead of a ~10-minute build.

## How it works

- **Pool members** are normal registry records tagged `pool: <presetId>` + `poolReady`, built via the existing `_pipeline` (no initial prompt) and then **stopped**. They're excluded from `GET /environments`, so they never clutter the env list.
- **Background loop** (alongside reconcile, every `WARM_POOL_INTERVAL_MS`) keeps `ready + building == desired` per preset, discards failed members, finalizes crash-orphaned ones, and **caps in-flight warm builds at `BUILD_CONCURRENCY − 1`** so an on-demand create always keeps a build-semaphore slot. Reserve-aware cap: the pool won't fill past `MAX_ENVIRONMENTS − WARM_POOL_RESERVE` (default reserve 5).
- **Claim:** `POST /environments` with exactly one preset and no custom overrides atomically claims a ready env and just `start`s it (cached `up -d --build`, seconds). The typed name becomes its **display label** (reusing the rename feature); the canonical name/dir/Docker project stay the pre-built one. Unwarmed presets, multi-preset combos, and custom provision still build fresh.
- **Settings → Warm pool:** per-preset desired count, live "N ready · M building · K failed" status (polled), and a **rebuild** button that nukes + refills a pool when a git push makes it stale.

## API

| Method | Path | Body | Notes |
|---|---|---|---|
| `GET` | `/pool` | — | per-preset `{presetId,name,desired,ready,building,failed}` |
| `PUT` | `/pool/:presetId` | `{count}` | desired ready count (0 = off); persists to `settings.warmPool` |
| `POST` | `/pool/:presetId/rebuild` | — | destroy that preset's warm envs → loop refills |

## Config (env)

| Var | Default | Meaning |
|---|---|---|
| `WARM_POOL_RESERVE` | `5` | free slots left for on-demand creates (pool stops at `MAX_ENVIRONMENTS − reserve`) |
| `WARM_POOL_INTERVAL_MS` | `20000` | top-up loop interval |

## Verification

- **Docker-free logic harness** (12 assertions): `setWarmPool` persistence + `publicView`, `poolStatus` ready/building/failed buckets, `list()` hides pool envs, atomic `claimPoolEnv` (drops pool tag, sets displayName, persists), "no ready env → null".
- **Live HTTP test** on a temp data dir: `GET /pool`, `PUT` set/disarm, `rebuild` on empty (`rebuilt:0`), unknown-preset `404`, `settings.json` round-trip — **zero builds fired**.
- All changed files pass `node --check`.

Notes: extracted `composeProvision` into `provision.js` (shared by routes + the pool builder, avoids a routes→manager import). Token/secret handling unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)