### PR TITLE
feat(server): per-env SSH helper modal (reach interactive Claude)

### DIFF
--- a/server/src/status.js
+++ b/server/src/status.js
@@ -49,6 +49,9 @@ export function publicView(record, { status }) {
     // Optional user-set list label; the canonical `name` (dir + compose project)
     // never changes. UI shows displayName when present, else name.
     displayName: record.displayName || null,
+    // Host path of the scaffolded stack — used by the UI to build an SSH command
+    // (cd into it, then `npm run claude` for the interactive TUI).
+    dir: record.dir,
     port: record.port,
     wpUrl: record.wpUrl,
     status,

--- a/server/ui/app.js
+++ b/server/ui/app.js
@@ -324,7 +324,7 @@ function SessionView({ session, now, onChanged, onBack, onDelete }) {
             : html`last active ${fmtAgo(session.lastActivityAt, true)}`}
         </div>
       </header>
-      ${session.sshResumeHint && html`<div class="ssh muted" onClick=${() => navigator.clipboard?.writeText(session.sshResumeHint)} title="click to copy">SSH resume: <code>${session.sshResumeHint}</code></div>`}
+      ${session.sshResumeHint && html`<div class="ssh muted" onClick=${() => copyText(session.sshResumeHint)} title="click to copy">SSH resume: <code>${session.sshResumeHint}</code></div>`}
       <div class="transcript" ref=${scroller} onScroll=${onTranscriptScroll}>
         ${items.map((it, i) => html`<${Bubble} it=${it} key=${i} />`)}
         ${partial && html`<div class="bubble assistant live"><pre>${partial}</pre><span class="cursor">▍</span></div>`}
@@ -940,11 +940,31 @@ function RenameEnvModal({ env, onClose, onSave }) {
     </div>`;
 }
 
+// Copy text to the clipboard. navigator.clipboard only exists on https/localhost,
+// so fall back to a hidden-textarea + execCommand('copy') for plain-http origins
+// (the common case here: hitting the box by IP). Returns true on success.
+async function copyText(text) {
+  try {
+    if (navigator.clipboard && window.isSecureContext) { await navigator.clipboard.writeText(text); return true; }
+  } catch { /* fall through to the execCommand path */ }
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'fixed';
+    ta.style.top = '-1000px';
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    return ok;
+  } catch { return false; }
+}
+
 function CopyLine({ cmd }) {
   const [copied, setCopied] = useState(false);
   const copy = async () => {
-    try { await navigator.clipboard.writeText(cmd); setCopied(true); setTimeout(() => setCopied(false), 1500); }
-    catch { /* clipboard needs https or localhost; the text is selectable regardless */ }
+    if (await copyText(cmd)) { setCopied(true); setTimeout(() => setCopied(false), 1500); }
   };
   return html`
     <div class="copyline">

--- a/server/ui/app.js
+++ b/server/ui/app.js
@@ -107,6 +107,7 @@ function EnvRow({ env, onAction }) {
             ${env.status === 'stopped' && html`<button class="lnk" onClick=${() => onAction('start', env)}>start</button>`}
             ${env.status === 'failed' && html`<button class="lnk" onClick=${() => onAction('start', env)}>retry</button>`}
             <button class="lnk" onClick=${() => onAction('rename', env)}>rename</button>
+            <button class="lnk" onClick=${() => onAction('ssh', env)} title="Copy a command to open a shell / interactive Claude on the box">ssh</button>
             <button class="lnk" onClick=${() => onAction('logs', env)}>logs</button>
             <button class="lnk danger" onClick=${() => onAction('delete', env)}>delete</button>`}
       </div>
@@ -939,6 +940,44 @@ function RenameEnvModal({ env, onClose, onSave }) {
     </div>`;
 }
 
+function CopyLine({ cmd }) {
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    try { await navigator.clipboard.writeText(cmd); setCopied(true); setTimeout(() => setCopied(false), 1500); }
+    catch { /* clipboard needs https or localhost; the text is selectable regardless */ }
+  };
+  return html`
+    <div class="copyline">
+      <code>${cmd}</code>
+      <button class="btn small ghost" onClick=${copy}>${copied ? 'copied ✓' : 'copy'}</button>
+    </div>`;
+}
+
+// Per-env SSH helper: the UI can't run the interactive Claude TUI (/plugin,
+// /mcp, …) over its headless pipe, so hand the user a paste-ready command to
+// reach it on the box. Host = the address they loaded the UI from; dir is the
+// env's host path. Both editable by the user (it's just text).
+function SshModal({ env, onClose }) {
+  const host = location.hostname || 'YOUR_BOX';
+  const label = env.displayName || env.name;
+  const shellCmd = `ssh root@${host} -t 'cd ${env.dir} && exec bash -l'`;
+  const claudeCmd = `ssh root@${host} -t 'cd ${env.dir} && npm run claude'`;
+  const loopback = ['localhost', '127.0.0.1', '::1'].includes(host);
+  return html`
+    <div class="modal-bg" onClick=${onClose}>
+      <div class="modal" onClick=${(e) => e.stopPropagation()}>
+        <h3>SSH into ${label}</h3>
+        <p class="muted small">Open a shell on the box, in this environment's directory. From there <code>npm run claude</code> gives you the full interactive Claude — <code>/plugin</code>, <code>/mcp</code>, <code>/agents</code>, etc. Anything you set up there persists in the workspace and your UI sessions use it too.</p>
+        <label class="muted small">Shell in this environment</label>
+        <${CopyLine} cmd=${shellCmd} />
+        <label class="muted small">…or jump straight into interactive Claude</label>
+        <${CopyLine} cmd=${claudeCmd} />
+        ${loopback && html`<p class="muted small">You loaded this UI over <code>${host}</code> — if you SSH from another machine, swap that for the box's hostname/IP.</p>`}
+        <div class="modal-foot"><button class="btn" onClick=${onClose}>Close</button></div>
+      </div>
+    </div>`;
+}
+
 function App() {
   const [sessions, setSessions] = useState([]);
   const [envs, setEnvs] = useState([]);
@@ -948,6 +987,7 @@ function App() {
   const [showNewEnv, setShowNewEnv] = useState(false);
   const [logEnvId, setLogEnvId] = useState(null);
   const [renameEnv, setRenameEnv] = useState(null);
+  const [sshEnv, setSshEnv] = useState(null);
   const [needToken, setNeedToken] = useState(false);
   const [authed, setAuthed] = useState(!!token.get());
   const [showSettings, setShowSettings] = useState(false);
@@ -1029,6 +1069,7 @@ function App() {
     try {
       if (action === 'logs') return setLogEnvId(env.id);
       if (action === 'rename') return setRenameEnv(env);
+      if (action === 'ssh') return setSshEnv(env);
       if (action === 'session') return setNewSession({ preselect: env.id });
       if (action === 'start') await api(`/environments/${env.id}/start`, { method: 'POST' });
       if (action === 'stop') await api(`/environments/${env.id}/stop`, { method: 'POST' });
@@ -1056,6 +1097,7 @@ function App() {
       ${showNewEnv && html`<${NewEnvModal} presets=${presets} onClose=${() => setShowNewEnv(false)} onCreate=${createEnv} onSavePreset=${savePreset} onDeletePreset=${deletePreset} />`}
       ${logEnvId && logEnv && html`<${LogViewer} env=${logEnv} onClose=${() => setLogEnvId(null)} />`}
       ${renameEnv && html`<${RenameEnvModal} env=${renameEnv} onClose=${() => setRenameEnv(null)} onSave=${renameEnvironment} />`}
+      ${sshEnv && html`<${SshModal} env=${sshEnv} onClose=${() => setSshEnv(null)} />`}
       ${showSettings && html`<${SettingsModal} onClose=${() => setShowSettings(false)}
         onLogout=${() => { token.set(''); setShowSettings(false); setAuthed(false); setNeedToken(true); }} />`}
       ${showHealth && html`<${HealthModal} onClose=${() => setShowHealth(false)} />`}

--- a/server/ui/style.css
+++ b/server/ui/style.css
@@ -151,6 +151,13 @@ pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12.5px/1.5
 .modal .save-preset .btn { white-space: nowrap; }
 .modal.settings { max-height: 90vh; overflow-y: auto; }
 
+/* SSH command copy lines */
+.copyline { display: flex; align-items: center; gap: 8px; margin: 4px 0 10px; }
+.copyline code { flex: 1; min-width: 0; background: var(--bg); border: 1px solid var(--line); border-radius: 8px;
+  padding: 8px 10px; font: 12.5px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--text);
+  overflow-x: auto; white-space: pre; }
+.copyline .btn { flex: none; }
+
 /* warm pool (Settings) */
 .warmpool { margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--line); }
 .warmpool h4 { margin: 0 0 4px; font-size: 13px; }


### PR DESCRIPTION
## What & why

The UI drives Claude **headlessly**, so the interactive TUI commands — `/plugin`, `/mcp`, `/agents`, `/config` — and plugin install can't run from the browser. This adds an **ssh** link on each env that opens a modal with paste-ready commands to reach them on the box.

Two copyable commands:
- `ssh root@<host> -t 'cd <dir> && exec bash -l'` — a shell in the env's directory.
- `ssh root@<host> -t 'cd <dir> && npm run claude'` — straight into the **interactive Claude TUI**.

Anything you set up there (install a plugin, `claude mcp add …`, add a skill) persists in the bind-mounted workspace, so your headless UI sessions pick it up too.

## Details
- **Host** = `location.hostname` (the address you loaded the UI from — usually the box). The modal shows a hint to swap it if you SSH from another machine. The command is plain text, so it's editable.
- **dir** = the env's host path, newly surfaced in the env public view (`status.js` `publicView`).
- Copy buttons use `navigator.clipboard` with graceful fallback (it needs https/localhost; the command text stays selectable either way — same pattern as the existing session SSH-resume hint).

## Verification
- `publicView` unit-check confirms `dir` is included and the command string renders correctly.
- `node --check` clean on changed files.

This is the "just document/expose the SSH path" option — the lightweight way to reach the full interactive Claude without building a web terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)