### PR TITLE
fix(server): decouple status probing from requests — paced background prober

### DIFF
--- a/server/src/config.js
+++ b/server/src/config.js
@@ -60,7 +60,11 @@ export function loadConfig(env = process.env) {
     portRange: parseRange(env.WP_PORT_RANGE, '9000-9999'),
     maxEnvironments: parseInt(env.MAX_ENVIRONMENTS || '25', 10),
     buildConcurrency: Math.max(1, parseInt(env.BUILD_CONCURRENCY || '2', 10)),
+    // Status prober: rest between full sweeps, and the delay between probing one
+    // env and the next WITHIN a sweep. The sweep is serial (one env at a time),
+    // so spacing directly bounds how hard it hits docker — never a burst.
     reconcileIntervalMs: parseInt(env.RECONCILE_INTERVAL_MS || '45000', 10),
+    probeSpacingMs: Math.max(0, parseInt(env.PROBE_SPACING_MS || '500', 10)),
     // Warm pool: free env slots reserved for on-demand creates (the pool builder
     // won't fill past maxEnvironments - reserve), and how often it tops up.
     warmPoolReserve: Math.max(0, parseInt(env.WARM_POOL_RESERVE || '5', 10)),

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -93,6 +93,7 @@ async function main() {
     if (shuttingDown) return;
     shuttingDown = true;
     log.info('shutting down — reaping active agent turns (containers stay up)');
+    manager.stopReconcileLoop?.(); // stop the status prober before teardown
     try {
       claudeEngine.interruptAll();
       await Promise.race([

--- a/server/src/manager.js
+++ b/server/src/manager.js
@@ -10,9 +10,11 @@ import { join, dirname } from 'node:path';
 import { allocate } from './allocator.js';
 import * as docker from './docker.js';
 import * as gitauth from './gitauth.js';
-import { computeStatus, coreUp, publicView } from './status.js';
+import { computeStatus, coreUp, publicView, TRANSIENT } from './status.js';
 import { composeProvision } from './provision.js';
 import { log, redact } from './log.js';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // Counting semaphore to bound concurrent (heavy) docker builds.
 class Semaphore {
@@ -41,6 +43,11 @@ export class Manager {
     this.settings = settings;
     this.jobs = new Map(); // id -> transient state string
     this.buildSem = new Semaphore(config.buildConcurrency);
+    // Last `docker compose ps` result per env id ({ ps, at }). The background
+    // prober (reconcile sweep) is the ONLY thing that polls docker on a timer;
+    // the read path (describe/list) serves from this cache so status requests
+    // never fan out docker work — no matter how many clients poll how fast.
+    this.probeCache = new Map(); // id -> { ps, at }
   }
 
   // Write the WP-admin defaults from Settings into a server-scoped
@@ -171,15 +178,31 @@ export class Manager {
 
   // ---- status / describe --------------------------------------------------
 
-  async _gather(record) {
+  // Live single-env probe: hits docker, refreshes the cache, returns the ps.
+  // Used by the background sweep and by user-initiated actions (start/stop,
+  // pre-exec gate) — NOT by the polled read path.
+  async _probe(record) {
     const ps = await docker.ps(record);
+    this.probeCache.set(record.id, { ps, at: Date.now() });
+    return ps;
+  }
+
+  // Read-path status: served from the probe cache, never touches docker. On a
+  // cache miss (env not yet swept, e.g. right after boot or a lifecycle action)
+  // fall back to the persisted record status so the answer is still sane.
+  _gather(record) {
     const jobState = this.jobs.get(record.id) || null;
-    const status = computeStatus({ record, jobState, ps });
-    return { ps, status };
+    const cached = this.probeCache.get(record.id);
+    if (!cached) {
+      const status = jobState && TRANSIENT.has(jobState) ? jobState : record.status;
+      return { ps: null, status };
+    }
+    const status = computeStatus({ record, jobState, ps: cached.ps });
+    return { ps: cached.ps, status };
   }
 
   async describe(record) {
-    const { status } = await this._gather(record);
+    const { status } = this._gather(record);
     return publicView(record, { status });
   }
 
@@ -189,9 +212,11 @@ export class Manager {
     return Promise.all(this.registry.list().filter((r) => !r.pool).map((r) => this.describe(r)));
   }
 
-  // Is the env's core stack up (so we can exec claude/agents in it)? Cheap.
+  // Is the env's core stack up (so we can exec claude/agents in it)? A live,
+  // on-demand single-env probe — this gates a real action, so it must be fresh,
+  // not cached. Refreshes the cache as a side effect.
   async usable(record) {
-    return coreUp(await docker.ps(record));
+    return coreUp(await this._probe(record));
   }
 
   // ---- lifecycle ----------------------------------------------------------
@@ -201,6 +226,9 @@ export class Manager {
   async stop(record) {
     await docker.npmRun(record, 'stop', { timeout: 120_000 });
     await this.registry.update(record.id, { status: 'stopped' });
+    // Drop the (now stale) cached ps so describe reflects the new status
+    // immediately rather than showing "running" until the next sweep.
+    this.probeCache.delete(record.id);
     return this.describe(record);
   }
 
@@ -213,6 +241,7 @@ export class Manager {
     } finally {
       this.jobs.delete(record.id);
     }
+    this.probeCache.delete(record.id); // stale cache → fall back to fresh status
     return this.describe(record);
   }
 
@@ -230,6 +259,7 @@ export class Manager {
       });
     } finally {
       this.jobs.delete(record.id);
+      this.probeCache.delete(record.id); // env gone → drop its cache entry
     }
   }
 
@@ -249,37 +279,70 @@ export class Manager {
 
   // ---- reconcile loop (supervisor) ----------------------------------------
 
+  // One paced sweep: probe every env ONE AT A TIME, waiting for each to finish
+  // before starting the next, with a fixed delay in between. This is the single
+  // background poller — it deliberately trickles docker work so a large fleet
+  // can never pin the host the way a per-request fan-out did. Each probe also
+  // refreshes the read cache that describe()/list() serve from.
   async reconcile() {
-    for (const record of this.registry.list()) {
-      if (this.jobs.has(record.id)) continue; // pipeline owns it
+    const records = this.registry.list();
+    for (let i = 0; i < records.length; i += 1) {
+      const record = records[i];
+      if (this.jobs.has(record.id)) continue; // pipeline owns it (don't probe/clobber)
       try {
-        const ps = await docker.ps(record);
-        if (!coreUp(ps)) {
-          // Containers down: a running/degraded env is now stopped; one left
-          // mid-pipeline by a crash/restart is failed; stopped stays stopped.
-          const s = record.status;
-          if (s === 'running' || s === 'degraded') {
-            await this.registry.update(record.id, { status: 'stopped' });
-          } else if (['setting-up', 'configuring', 'scaffolding'].includes(s)) {
-            await this.registry.update(record.id, { status: 'failed', lastError: record.lastError || 'interrupted (server restart or crash)' });
-          }
-          continue;
-        }
-        // Containers up → running.
-        if (record.status !== 'running' && record.status !== 'stopped') {
-          await this.registry.update(record.id, { status: 'running' });
-        }
+        const ps = await this._probe(record);
+        await this._reconcileStatus(record, ps);
       } catch (err) {
         log.warn(`[${record.name}] reconcile error:`, err.message);
       }
+      // Breathe between envs so the sweep is a trickle, not a burst. (No delay
+      // after the last one.)
+      if (i < records.length - 1) await sleep(this.config.probeSpacingMs);
     }
   }
 
+  // Fold a fresh ps into the persisted status (side of reconcile that writes).
+  async _reconcileStatus(record, ps) {
+    if (!coreUp(ps)) {
+      // Containers down: a running/degraded env is now stopped; one left
+      // mid-pipeline by a crash/restart is failed; stopped stays stopped.
+      const s = record.status;
+      if (s === 'running' || s === 'degraded') {
+        await this.registry.update(record.id, { status: 'stopped' });
+      } else if (['setting-up', 'configuring', 'scaffolding'].includes(s)) {
+        await this.registry.update(record.id, { status: 'failed', lastError: record.lastError || 'interrupted (server restart or crash)' });
+      }
+      return;
+    }
+    // Containers up → running.
+    if (record.status !== 'running' && record.status !== 'stopped') {
+      await this.registry.update(record.id, { status: 'running' });
+    }
+  }
+
+  // Self-rescheduling loop: the next sweep is armed only AFTER the current one
+  // finishes (plus a rest gap), so sweeps can never overlap or stack up even if
+  // one runs long. A plain setInterval could pile sweeps on top of each other
+  // under load — exactly the failure mode this replaces.
   startReconcileLoop() {
-    const tick = () => this.reconcile().catch((e) => log.warn('reconcile loop error:', e.message));
-    tick(); // run once at boot
-    this.reconcileTimer = setInterval(tick, this.config.reconcileIntervalMs);
-    this.reconcileTimer.unref?.();
+    this._reconcileStopped = false;
+    const loop = async () => {
+      if (this._reconcileStopped) return;
+      try {
+        await this.reconcile();
+      } catch (e) {
+        log.warn('reconcile loop error:', e.message);
+      }
+      if (this._reconcileStopped) return;
+      this.reconcileTimer = setTimeout(loop, this.config.reconcileIntervalMs);
+      this.reconcileTimer.unref?.();
+    };
+    loop(); // run one sweep at boot, then rest → sweep → rest → …
+  }
+
+  stopReconcileLoop() {
+    this._reconcileStopped = true;
+    clearTimeout(this.reconcileTimer);
   }
 
   // ---- warm pool ----------------------------------------------------------


### PR DESCRIPTION
## Problem

The `server` was pinning all cores under normal use. Root cause: the env-list read path (`GET /environments`, which the UI polls every ~3s) ran a live `docker compose ps --format json --all` **per environment** on every request. Docker load scaled with **clients × envs** — 20 envs on a single tab ≈ 7 `compose ps`/sec sustained, unbounded with extra tabs and stackable `setInterval` sweeps. Each call is a full Go-binary launch + Docker API round-trip, so it pinned the host.

## Fix — decouple probing from requests

- **Read path serves a cache, zero docker.** `_gather()` (behind `describe`/`list`) is now synchronous: it reads a per-env `probeCache` and composes status in memory. `GET /environments` does no docker work regardless of how many clients poll how fast.
- **One serial, paced background prober** is the only timer that touches docker: probes one env at a time, awaits each, then waits `PROBE_SPACING_MS` (default 500ms) before the next. A trickle, never a burst.
- **No stacking.** The sweep loop self-reschedules with `setTimeout` *after* it finishes (+ `RECONCILE_INTERVAL_MS` rest), so a slow sweep can never pile onto itself — replaces the stackable `setInterval`.
- **Truthful reads after actions.** `start`/`stop`/`destroy` invalidate the cache; `usable()` still does a live single-env probe (it gates a real exec action); `stopAll()` keeps its fast parallel path for explicit shutdown only.
- `stopReconcileLoop()` halts the prober on SIGINT/SIGTERM.

## Load profile

Before: ~7 `compose ps`/sec sustained per tab, unbounded. After: ~2/sec only during a ~10s sweep, then idle for the rest gap; independent of client/tab count. Cannot pin cores.

Tunable via `PROBE_SPACING_MS` and `RECONCILE_INTERVAL_MS`.

## Tradeoff

External container changes (e.g. a container stopped by hand) surface within a sweep cycle (tens of seconds) rather than ~3s; dashboard reads stay instant, just backed by slightly older truth.

## Testing

- Syntax-checked all changed files.
- Runtime smoke test (docker stubbed): cold cache falls back to persisted status with zero probes; sweep runs strictly serially with ~500ms gaps and none after the last env; warm cache serves computed status. All passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)