### PR TITLE
feat(ui): add Fable 5 to the Claude model chooser

### DIFF
--- a/server/ui/app.js
+++ b/server/ui/app.js
@@ -413,6 +413,7 @@ const AGENTS_ORDER = ['claude', 'codex', 'opencode'];
 const MODELS = {
   claude: [
     { id: '', label: 'Default' },
+    { id: 'fable', label: 'Fable 5' },
     { id: 'opus', label: 'Opus 4.8' },
     { id: 'sonnet', label: 'Sonnet 4.6' },
     { id: 'haiku', label: 'Haiku 4.5' },


### PR DESCRIPTION
Adds Fable 5 as a selectable model when driving Claude through the server.

## Change

One entry in the Claude model dropdown (`server/ui/app.js`), placed above Opus as the most-capable tier:

```js
{ id: 'fable', label: 'Fable 5' },
```

## Why one line is enough

- The selected `id` flows UI → `POST /environments/:id/sessions` → `newSession` → `session.model` → `claude --model <id>`, passed **verbatim** with no server-side allowlist. Adding the dropdown entry is the whole change.
- `fable` is the correct value: confirmed against the model reference (Fable 5 = `claude-fable-5`) and against the installed CLI — `claude --help` (v2.1.202) documents `fable` as a first-class `--model` alias next to `opus`/`sonnet`, so it resolves like the others.
- `NO_CUSTOM_MODEL` is `codex`-only, so Claude already accepted custom ids; this promotes Fable to a first-class option.

## Not changed

Server default `CLAUDE_DEFAULT_MODEL` stays `opus`. Fable is premium-priced ($10/$50 per MTok), so it remains opt-in via the picker rather than the default.

## Testing

`node --check server/ui/app.js` passes; the mechanism is identical to the existing opus/sonnet/haiku entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)