### PR TITLE
feat(server): split env caps into running vs stored + disk guard

### DIFF
--- a/server/src/allocator.js
+++ b/server/src/allocator.js
@@ -5,6 +5,7 @@
 import net from 'node:net';
 import { randomBytes } from 'node:crypto';
 import { join } from 'node:path';
+import { statfs } from 'node:fs/promises';
 import { listProjects } from './docker.js';
 
 const NAME_RE = /^[a-z0-9][a-z0-9-]{1,38}$/;
@@ -39,6 +40,17 @@ export class AllocationError extends Error {
   }
 }
 
+// Free gibibytes on the filesystem holding `path`, or null if it can't be read
+// (never block an allocation on a stat failure — treat unknown as "room").
+async function freeDiskGb(path) {
+  try {
+    const s = await statfs(path);
+    return (s.bavail * s.bsize) / 1024 ** 3;
+  } catch {
+    return null;
+  }
+}
+
 // Returns the reservation record (already persisted into the registry with
 // status "scaffolding").
 export async function allocate(registry, config, { nameHint, pool = null } = {}) {
@@ -54,6 +66,19 @@ export async function allocate(registry, config, { nameHint, pool = null } = {})
           : `at capacity: ${envs.length}/${config.maxEnvironments} environments (raise MAX_ENVIRONMENTS)`,
         503,
       );
+    }
+
+    // Disk guard: the real limit on stored envs is disk, not a count. Stat the
+    // data filesystem (envsDir may not exist yet; dataDir shares its filesystem).
+    if (config.minFreeDiskGb > 0) {
+      const freeGb = await freeDiskGb(config.dataDir);
+      if (freeGb !== null && freeGb < config.minFreeDiskGb) {
+        throw new AllocationError(
+          `low disk: ${freeGb.toFixed(1)}GB free < ${config.minFreeDiskGb}GB floor` +
+            (pool ? ' (warm build deferred)' : ' — free space or add disk (raise/lower MIN_FREE_DISK_GB)'),
+          507,
+        );
+      }
     }
 
     const usedNames = new Set(envs.map((e) => e.name));

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -58,7 +58,17 @@ export function loadConfig(env = process.env) {
 
     // Allocation / limits
     portRange: parseRange(env.WP_PORT_RANGE, '9000-9999'),
-    maxEnvironments: parseInt(env.MAX_ENVIRONMENTS || '25', 10),
+    // Two independent caps, because stored and running envs cost different
+    // resources. maxEnvironments bounds TOTAL stored records (running + stopped +
+    // warm pool) — a high safety backstop; the real limit on stored envs is disk
+    // (see minFreeDiskGb), since a stopped env idles at ~0 CPU/RAM. maxRunning
+    // bounds envs whose containers are up (or coming up) — the CPU/RAM guardrail.
+    maxEnvironments: parseInt(env.MAX_ENVIRONMENTS || '200', 10),
+    maxRunning: Math.max(1, parseInt(env.MAX_RUNNING || '10', 10)),
+    // Refuse new allocations (user create or warm build) when free disk on the
+    // data filesystem drops below this — stops a runaway pool from filling the
+    // disk. 0 disables the guard.
+    minFreeDiskGb: Math.max(0, parseFloat(env.MIN_FREE_DISK_GB || '10')),
     buildConcurrency: Math.max(1, parseInt(env.BUILD_CONCURRENCY || '2', 10)),
     // Status prober: rest between full sweeps, and the delay between probing one
     // env and the next WITHIN a sweep. The sweep is serial (one env at a time),

--- a/server/src/health.js
+++ b/server/src/health.js
@@ -108,7 +108,7 @@ export async function systemHealth(config, registry) {
     cpu,
     disk,
     docker: { df, containersRunning: running, containersTotal: total },
-    environments: { count: envs.length, max: config.maxEnvironments, running: liveEnvs.length },
+    environments: { count: envs.length, max: config.maxEnvironments, running: liveEnvs.length, maxRunning: config.maxRunning },
     perEnv,
     estimate: { avgEnvMemBytes, ramHeadroomEnvs },
   };

--- a/server/src/manager.js
+++ b/server/src/manager.js
@@ -7,7 +7,7 @@ import { createWriteStream, mkdirSync } from 'node:fs';
 import { readFile, writeFile, rm, mkdir } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 
-import { allocate } from './allocator.js';
+import { allocate, AllocationError } from './allocator.js';
 import * as docker from './docker.js';
 import * as gitauth from './gitauth.js';
 import { computeStatus, coreUp, publicView, TRANSIENT } from './status.js';
@@ -15,6 +15,11 @@ import { composeProvision } from './provision.js';
 import { log, redact } from './log.js';
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Statuses where an env is consuming compute — its containers are up, or a
+// pipeline is bringing them up. These count against maxRunning (the CPU/RAM
+// cap). Stopped/failed/destroying envs cost disk, not compute, so they don't.
+const COMPUTE_STATUSES = new Set(['running', 'degraded', 'scaffolding', 'setting-up', 'configuring']);
 
 // Counting semaphore to bound concurrent (heavy) docker builds.
 class Semaphore {
@@ -50,6 +55,32 @@ export class Manager {
     this.probeCache = new Map(); // id -> { ps, at }
   }
 
+  // ---- running cap --------------------------------------------------------
+  //
+  // Envs whose containers are up (or being brought up) cost CPU/RAM; stopped
+  // ones (incl. the warm pool) cost only disk. maxRunning bounds the former so
+  // a large stored fleet can't peg the host. Enforced at every boot point:
+  // create, restart (start), warm claim, and warm build.
+
+  _runningCount() {
+    return this.registry.list().filter((e) => COMPUTE_STATUSES.has(e.status)).length;
+  }
+
+  // Throw (AllocationError, so routes map it to a 503) if booting one more env
+  // would exceed maxRunning. Warm builds phrase it as a deferral — maintainPool
+  // catches and retries next tick.
+  _assertRunRoom({ pool = false } = {}) {
+    const n = this._runningCount();
+    if (n >= this.config.maxRunning) {
+      throw new AllocationError(
+        pool
+          ? `warm build deferred: ${n}/${this.config.maxRunning} running`
+          : `at running capacity: ${n}/${this.config.maxRunning} running — stop an env or raise MAX_RUNNING`,
+        503,
+      );
+    }
+  }
+
   // Write the WP-admin defaults from Settings into a server-scoped
   // XDG_CONFIG_HOME config.json that the scaffolder reads (seeds each new site's
   // admin account). Kept out of the operator's real ~/.config.
@@ -66,6 +97,7 @@ export class Manager {
   // ---- create -------------------------------------------------------------
 
   async createEnvironment({ name, provision, prompt, model, agent } = {}) {
+    this._assertRunRoom(); // a create boots immediately — count it against maxRunning
     const record = await allocate(this.registry, this.config, { nameHint: name });
     this.jobs.set(record.id, 'scaffolding');
     // Materialize the provisioning inputs to files the scaffolder can read, and
@@ -233,6 +265,7 @@ export class Manager {
   }
 
   async start(record) {
+    this._assertRunRoom(); // restarting a stopped env brings its containers back up
     this.jobs.set(record.id, 'configuring');
     try {
       await docker.npmRun(record, 'start', { timeout: 600_000 }); // up -d --build (cached)
@@ -394,6 +427,7 @@ export class Manager {
   // session, refilling the pool. Returns the claimed record, or null if none
   // was ready (caller falls back to a normal build).
   async claimAndStart(presetId, { name, prompt, model, agent } = {}) {
+    this._assertRunRoom(); // claiming + starting a warm env boots it (before touching the pool)
     const record = await this.claimPoolEnv(presetId, { name });
     if (!record) return null;
     this.jobs.set(record.id, 'configuring');
@@ -425,6 +459,7 @@ export class Manager {
   async _buildPoolEnv(presetId) {
     const preset = this.presets?.get(presetId);
     if (!preset) return;
+    this._assertRunRoom({ pool: true }); // a build boots the stack before stopping it
     const provision = composeProvision([preset], null);
     const record = await allocate(this.registry, this.config, { pool: presetId });
     this.jobs.set(record.id, 'scaffolding');

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -151,7 +151,14 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
       ctx.send(200, { loginUrl: url });
     }),
     route('POST', '/environments/:id/stop', async (ctx) => ctx.send(200, await manager.stop(envOr404(ctx)))),
-    route('POST', '/environments/:id/start', async (ctx) => ctx.send(200, await manager.start(envOr404(ctx)))),
+    route('POST', '/environments/:id/start', async (ctx) => {
+      try {
+        ctx.send(200, await manager.start(envOr404(ctx)));
+      } catch (err) {
+        if (err instanceof AllocationError) throw httpErr(err.status, err.message);
+        throw err;
+      }
+    }),
 
     // Rename the list label only — canonical name/dir/compose project are untouched.
     // Blank resets to the canonical name (displayName -> null).

--- a/server/ui/app.js
+++ b/server/ui/app.js
@@ -881,7 +881,7 @@ function HealthModal({ onClose }) {
               ? html`Room for ≈ <b>${est.ramHeadroomEnvs}</b> more environment${est.ramHeadroomEnvs === 1 ? '' : 's'} in RAM — avg <b>${gb(est.avgEnvMemBytes)}</b>/env, ${h.environments.running} running.${m.swapTotalBytes ? '' : ' No swap: when free RAM hits zero the box starts OOM-killing processes, so keep headroom.'}`
               : html`${h.environments.running} environments running.`}
           </div>
-          <div class="muted small">Environments: ${h.environments.running} running · ${h.environments.count} total · cap ${h.environments.max}</div>
+          <div class="muted small">Environments: ${h.environments.running}${h.environments.maxRunning ? `/${h.environments.maxRunning}` : ''} running · ${h.environments.count} stored · stored cap ${h.environments.max}</div>
           ${h.perEnv.length > 0 && html`
             <table class="health-table">
               <thead><tr><th>Environment</th><th>Status</th><th>Containers</th><th>Memory</th></tr></thead>


### PR DESCRIPTION
## What

The warm pool was capped by a single `maxEnvironments=25` limit that conflated two very different resources: environments whose containers are **up** (cost CPU/RAM) and environments merely **stored** on disk (a stopped env idles at ~0 CPU/RAM). That capped the pool far below what the box can hold.

Splits it into two independent caps plus a disk floor:

- **`maxRunning`** (default `10`) — bounds envs in a *compute* status (`running`/`degraded`/`scaffolding`/`setting-up`/`configuring`). Enforced at every boot point — create, start, warm claim, warm build — via `Manager._assertRunRoom`, which throws an `AllocationError` mapped to **503**. Warm builds phrase it as a *deferral* so `maintainPool` just retries next tick.
- **`maxEnvironments`** (default `25` → `200`) — a high backstop on total *stored* records.
- **`minFreeDiskGb`** (default `10`) — `allocate()` refuses new user creates and warm builds when free disk on the data filesystem drops below the floor (**507**). A stat failure is treated as "room", so it never blocks on an unreadable mount.

Health snapshot + UI now show `running/maxRunning` and `stored/cap` separately.

## Config
All overridable: `MAX_RUNNING`, `MAX_ENVIRONMENTS`, `MIN_FREE_DISK_GB`.

## Test
- Verified config loads: `maxEnvironments=200`, `maxRunning=10`, `minFreeDiskGb=10`.
- Running count excludes stopped/failed envs; disk guard reads real free space via `statfs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)