### PR TITLE
feat(ui): add Grok 4.5 (OpenCode) and GPT-5.6 (Codex) to the model chooser

### DIFF
--- a/server/ui/app.js
+++ b/server/ui/app.js
@@ -420,6 +420,9 @@ const MODELS = {
   ],
   codex: [
     { id: '', label: 'Default' },
+    { id: 'gpt-5.6-sol', label: 'gpt-5.6-sol (flagship)' },
+    { id: 'gpt-5.6-terra', label: 'gpt-5.6-terra (balanced)' },
+    { id: 'gpt-5.6-luna', label: 'gpt-5.6-luna (fast/cheap)' },
     { id: 'gpt-5.5', label: 'gpt-5.5' },
     { id: 'gpt-5.4', label: 'gpt-5.4' },
     { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini' },
@@ -458,6 +461,7 @@ const MODELS = {
     { id: 'opencode/gpt-5', label: 'gpt-5' },
     { id: 'opencode/gpt-5-codex', label: 'gpt-5-codex' },
     { id: 'opencode/gpt-5-nano', label: 'gpt-5-nano' },
+    { id: 'opencode/grok-4.5', label: 'grok-4.5' },
     { id: 'opencode/grok-build-0.1', label: 'grok-build-0.1' },
     { id: 'opencode/deepseek-v4-pro', label: 'deepseek-v4-pro' },
     { id: 'opencode/deepseek-v4-flash', label: 'deepseek-v4-flash' },


### PR DESCRIPTION
## What

Adds the newest models to the per-session model chooser, routed exactly as expected:

- **Codex → GPT-5.6** (`gpt-5.6-sol` flagship · `gpt-5.6-terra` balanced · `gpt-5.6-luna` fast/cheap). The Codex CLI receives these via `codex exec -m <id>`.
- **OpenCode (Zen) → Grok 4.5** (`opencode/grok-4.5`). Grok 4.5 is now in the OpenCode Zen catalog.

IDs taken from the [xAI Grok 4.5 docs](https://docs.x.ai/developers/grok-4-5), the [Codex model docs](https://learn.chatgpt.com/docs/models), and the [OpenCode Zen catalog](https://opencode.ai/docs/zen/). OpenCode keeps its `Custom…` escape hatch; Codex's list is authoritative (`NO_CUSTOM_MODEL`), so listing them is what makes them selectable.

## Note on verification
This is a curated-list change only. The IDs match the official docs, but they haven't been exercised end-to-end against our live Codex/Zen keys in this PR (a turn costs credits + a running env). If any errors on first use, it's a catalog/entitlement issue on the gateway side, not a wiring problem — `Custom…` (OpenCode) or a list tweak (Codex) covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)