### PR TITLE
feat(ui): archive/restore sessions — declutter busy envs without deleting

### DIFF
--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -55,6 +55,7 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
     lastResult: s.lastResult,
     costUsd: s.costUsd,
     lastError: s.lastError,
+    archived: !!s.archived,
     createdAt: s.createdAt,
     lastActivityAt: s.lastActivityAt,
     sshResumeHint: sshHint(s),
@@ -239,8 +240,13 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
       let list = sessions.store.list();
       const envId = ctx.query.get('envId');
       const status = ctx.query.get('status');
+      // archived filter: "only" (archived), "exclude" (active). Default returns
+      // both (with the `archived` flag) so the UI can group them in one fetch.
+      const archived = ctx.query.get('archived');
       if (envId) list = list.filter((s) => s.envId === envId);
       if (status) list = list.filter((s) => publicSession(s).status === status);
+      if (archived === 'only') list = list.filter((s) => s.archived);
+      else if (archived === 'exclude') list = list.filter((s) => !s.archived);
       ctx.send(200, { sessions: list.map(publicSession) });
     }),
 
@@ -251,6 +257,22 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
       const title = String(ctx.body.title || '').replace(/\s+/g, ' ').trim();
       if (!title) throw httpErr(400, 'title is required');
       const updated = await sessions.store.update(s.id, { title: title.slice(0, 200) });
+      ctx.send(200, publicSession(updated));
+    }),
+
+    // Archive: hide a session from the sidebar without deleting it — the record,
+    // transcript, and claude/codex resume id all persist, so it can be restored
+    // and resumed later. Any in-flight turn is interrupted first (an archived
+    // session shouldn't keep working invisibly). Restore just clears the flag.
+    route('POST', '/sessions/:id/archive', async (ctx) => {
+      const s = sessionOr404(ctx);
+      sessions.engine.interrupt(s.id);
+      const updated = await sessions.store.update(s.id, { archived: true });
+      ctx.send(200, publicSession(updated));
+    }),
+    route('POST', '/sessions/:id/restore', async (ctx) => {
+      const s = sessionOr404(ctx);
+      const updated = await sessions.store.update(s.id, { archived: false });
       ctx.send(200, publicSession(updated));
     }),
 

--- a/server/ui/app.js
+++ b/server/ui/app.js
@@ -120,24 +120,29 @@ function WorkingTag({ since, now }) {
   return html`<span class="sess-time working" title="Claude is working right now">working ${fmtDur(ms)}</span>`;
 }
 
-function SessionItem({ s, selectedId, onSelect, onDelete, now }) {
+function SessionItem({ s, selectedId, onSelect, onDelete, onArchive, onRestore, now }) {
   const running = s.status === 'running';
   return html`
-    <div class=${`sess ${s.id === selectedId ? 'active' : ''}`} onClick=${() => onSelect(s.id)}>
+    <div class=${`sess ${s.id === selectedId ? 'active' : ''} ${s.archived ? 'archived' : ''}`} onClick=${() => onSelect(s.id)}>
       <div class="sess-top">
         <${StatusDot} status=${s.status} />
         <span class="sess-title">${s.title || s.id}</span>
         ${running
           ? html`<${WorkingTag} since=${s.lastActivityAt} now=${now} />`
           : html`<span class="sess-time" title=${`last active ${fullTime(s.lastActivityAt)}`}>${fmtAgo(s.lastActivityAt)}</span>`}
+        ${s.archived
+          ? html`<button class="sess-arch lnk" title="Restore session" onClick=${(e) => { e.stopPropagation(); onRestore(s); }}>↩</button>`
+          : html`<button class="sess-arch lnk" title="Archive session (hide, keep transcript)" onClick=${(e) => { e.stopPropagation(); onArchive(s); }}>🗄</button>`}
         <button class="sess-del lnk" title="Delete session" onClick=${(e) => { e.stopPropagation(); onDelete(s); }}>🗑</button>
       </div>
       <div class="sess-sub muted"><span class="agent-tag">${agentLabel(s.agent)}</span> · started ${fmtAgo(s.createdAt, true)} · ${s.turnCount} turn${s.turnCount === 1 ? '' : 's'} · $${(s.costUsd || 0).toFixed(3)}</div>
     </div>`;
 }
 
-function Sidebar({ sessions, envs, selectedId, now, onSelect, onNewEnv, onEnvAction, onSettings, onHealth, onDeleteSession }) {
+function Sidebar({ sessions, envs, selectedId, now, onSelect, onNewEnv, onEnvAction, onSettings, onHealth, onDeleteSession, onArchiveSession, onRestoreSession }) {
   const [expanded, setExpanded] = useState(() => new Set());
+  // Which envs currently have their "Archived (N)" reveal expanded.
+  const [archOpen, setArchOpen] = useState(() => new Set());
   // Declutter long lists: stopped envs (data intact, just parked) are hidden by
   // default. "Active" = anything not stopped (running/degraded/building/failed).
   const [filter, setFilter] = useState('active');
@@ -146,6 +151,11 @@ function Sidebar({ sessions, envs, selectedId, now, onSelect, onNewEnv, onEnvAct
   const shown = envs.filter((e) =>
     filter === 'all' ? true : filter === 'stopped' ? e.status === 'stopped' : e.status !== 'stopped');
   const toggle = (id) => setExpanded((prev) => {
+    const next = new Set(prev);
+    next.has(id) ? next.delete(id) : next.add(id);
+    return next;
+  });
+  const toggleArch = (id) => setArchOpen((prev) => {
     const next = new Set(prev);
     next.has(id) ? next.delete(id) : next.add(id);
     return next;
@@ -177,18 +187,32 @@ function Sidebar({ sessions, envs, selectedId, now, onSelect, onNewEnv, onEnvAct
             const envSessions = sessions
               .filter((s) => s.envId === e.id)
               .sort((a, b) => String(b.lastActivityAt || '').localeCompare(String(a.lastActivityAt || '')));
+            // Archived sessions are kept but hidden behind a reveal, so a busy env
+            // (20 sessions) can show just the two you're working on.
+            const active = envSessions.filter((s) => !s.archived);
+            const archived = envSessions.filter((s) => s.archived);
             const open = expanded.has(e.id) || e.id === selEnvId;
+            const showArch = archOpen.has(e.id);
+            const itemProps = { selectedId, now, onSelect, onDelete: onDeleteSession, onArchive: onArchiveSession, onRestore: onRestoreSession };
             return html`
               <div class="env-group" key=${e.id}>
                 <${EnvRow} env=${e} onAction=${onEnvAction} />
                 <button class="sess-toggle" onClick=${() => toggle(e.id)}>
                   <span class="chev">${open ? '▾' : '▸'}</span>
-                  ${envSessions.length} session${envSessions.length === 1 ? '' : 's'}
+                  ${active.length} session${active.length === 1 ? '' : 's'}
+                  ${archived.length > 0 && html`<span class="muted small"> · ${archived.length} archived</span>`}
                 </button>
                 ${open && html`
                   <div class="env-sessions">
-                    ${envSessions.length === 0 && html`<div class="muted pad small no-sess">No sessions yet.</div>`}
-                    ${envSessions.map((s) => html`<${SessionItem} s=${s} key=${s.id} selectedId=${selectedId} now=${now} onSelect=${onSelect} onDelete=${onDeleteSession} />`)}
+                    ${active.length === 0 && archived.length === 0 && html`<div class="muted pad small no-sess">No sessions yet.</div>`}
+                    ${active.length === 0 && archived.length > 0 && html`<div class="muted pad small no-sess">No active sessions.</div>`}
+                    ${active.map((s) => html`<${SessionItem} ...${itemProps} s=${s} key=${s.id} />`)}
+                    ${archived.length > 0 && html`
+                      <button class="arch-toggle" onClick=${() => toggleArch(e.id)}>
+                        <span class="chev">${showArch ? '▾' : '▸'}</span>
+                        Archived (${archived.length})
+                      </button>`}
+                    ${showArch && archived.map((s) => html`<${SessionItem} ...${itemProps} s=${s} key=${s.id} />`)}
                   </div>`}
               </div>`;
           })}
@@ -214,7 +238,7 @@ function Bubble({ it }) {
   return html`<div class="raw"><pre>${it.text}</pre></div>`;
 }
 
-function SessionView({ session, now, onChanged, onBack, onDelete }) {
+function SessionView({ session, now, onChanged, onBack, onDelete, onArchive, onRestore }) {
   const [items, setItems] = useState([]);
   const [partial, setPartial] = useState('');
   const [busy, setBusy] = useState(false);
@@ -311,6 +335,9 @@ function SessionView({ session, now, onChanged, onBack, onDelete }) {
                 onBlur=${saveTitle} />`
             : html`<strong title="Double-click to rename" onDblClick=${startEdit}>${session.title || id}</strong>
                 <button class="lnk small" onClick=${startEdit} title="Rename">✎</button>
+                ${session.archived
+                  ? html`<button class="lnk small" onClick=${onRestore} title="Restore session">↩</button>`
+                  : html`<button class="lnk small" onClick=${onArchive} title="Archive session (hide, keep transcript)">🗄</button>`}
                 <button class="lnk small danger" onClick=${onDelete} title="Delete session">🗑</button>`}
         </div>
         <div class="bar-meta muted">
@@ -1068,6 +1095,16 @@ function App() {
       await refresh();
     } catch (e) { alert(`Delete failed: ${e.message}`); }
   };
+  // Archive/restore are reversible — no confirm. Archiving interrupts any live
+  // turn server-side; the transcript and resume id are kept either way.
+  const archiveSession = async (s) => {
+    try { await api(`/sessions/${s.id}/archive`, { method: 'POST' }); await refresh(); }
+    catch (e) { alert(`Archive failed: ${e.message}`); }
+  };
+  const restoreSession = async (s) => {
+    try { await api(`/sessions/${s.id}/restore`, { method: 'POST' }); await refresh(); }
+    catch (e) { alert(`Restore failed: ${e.message}`); }
+  };
   const envAction = async (action, env) => {
     if (action === 'admin-login') {
       // Open the tab synchronously (in the click gesture) so popup blockers allow
@@ -1106,9 +1143,10 @@ function App() {
     <div class=${`layout ${selected ? 'has-selection' : ''}`}>
       <${Sidebar} sessions=${sessions} envs=${envs} selectedId=${selectedId} now=${now}
         onSelect=${setSelectedId} onNewEnv=${() => setShowNewEnv(true)}
-        onEnvAction=${envAction} onSettings=${() => setShowSettings(true)} onHealth=${() => setShowHealth(true)} onDeleteSession=${deleteSession} />
+        onEnvAction=${envAction} onSettings=${() => setShowSettings(true)} onHealth=${() => setShowHealth(true)}
+        onDeleteSession=${deleteSession} onArchiveSession=${archiveSession} onRestoreSession=${restoreSession} />
       ${selected
-        ? html`<${SessionView} session=${selected} key=${selected.id} now=${now} onChanged=${refresh} onBack=${() => setSelectedId(null)} onDelete=${() => deleteSession(selected)} />`
+        ? html`<${SessionView} session=${selected} key=${selected.id} now=${now} onChanged=${refresh} onBack=${() => setSelectedId(null)} onDelete=${() => deleteSession(selected)} onArchive=${() => archiveSession(selected)} onRestore=${() => restoreSession(selected)} />`
         : html`<section class="main empty"><div class="muted">
             ${envs.length === 0
               ? html`No environments yet. <button class="btn" onClick=${() => setShowNewEnv(true)}>Create an environment</button> to begin.`

--- a/server/ui/style.css
+++ b/server/ui/style.css
@@ -50,9 +50,17 @@ pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12.5px/1.5
 .env-sessions { padding-left: 12px; border-left: 2px solid var(--line); margin: 0 0 6px 16px; }
 .env-sessions .no-sess { padding: 4px 8px; }
 .env-sessions .sess { border-bottom: 0; border-radius: 6px; padding: 6px 8px; }
-.sess-del { flex: none; opacity: 0; font-size: 12px; }
-.sess:hover .sess-del, .sess.active .sess-del { opacity: 0.7; }
-.sess-del:hover { opacity: 1; }
+.sess-del, .sess-arch { flex: none; opacity: 0; font-size: 12px; }
+.sess:hover .sess-del, .sess.active .sess-del,
+.sess:hover .sess-arch, .sess.active .sess-arch { opacity: 0.7; }
+.sess-del:hover, .sess-arch:hover { opacity: 1; }
+/* Archived sessions read as parked: dimmed until hovered/selected. */
+.sess.archived { opacity: 0.6; }
+.sess.archived:hover, .sess.archived.active { opacity: 1; }
+.arch-toggle { display: flex; align-items: center; gap: 6px; width: 100%; background: none; border: 0;
+  color: var(--muted); cursor: pointer; font-size: 11px; text-align: left; padding: 4px 8px; }
+.arch-toggle:hover { color: var(--text); }
+.arch-toggle .chev { width: 9px; display: inline-block; }
 .rename { font: inherit; font-weight: 600; background: var(--bg); color: var(--text);
   border: 1px solid var(--accent); border-radius: 6px; padding: 2px 6px; min-width: 200px; }
 .sess { padding: 10px 12px; border-bottom: 1px solid var(--line); cursor: pointer; }


### PR DESCRIPTION
## Why
An environment can rack up 20+ sessions, but you usually only care about a couple. Deleting loses the transcript and the agent's resume id. **Archive** hides a session from the sidebar while keeping *everything* — record, transcript, cost, and the claude/codex resume id — so it can be restored and resumed later. Fully reversible; distinct from delete.

## Server
- `publicSession` exposes `archived`.
- `POST /sessions/:id/archive` — interrupts any in-flight turn (an archived session shouldn't keep working invisibly), then sets the flag.
- `POST /sessions/:id/restore` — clears the flag.
- `GET /sessions` gains `?archived=only|exclude`; the default still returns **both** (each carrying the flag) so the sidebar can group active/archived in a single fetch.

## UI
- Sidebar splits each env's sessions into **active** (shown) and **archived** (tucked behind an `Archived (N)` reveal). The env's session count now reflects active sessions, with a subtle `· N archived` hint.
- Archive (🗄) / restore (↩) controls on each session row and in the open-session header, beside delete. Archived rows render dimmed.

## Verification
Exercised end-to-end against a throwaway server instance (separate port + temp data, prod untouched):
- archive → `archived:true`, restore → `archived:false`
- `?archived=exclude` and `?archived=only` partition correctly
- archiving a missing id → 404

Server routes verified live; the UI change is a straightforward Preact/htm render (syntax-checked). Not yet exercised in a browser on prod — see deploy note in the PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)