### PR TITLE
katalystwp name-reservation stub

### DIFF
--- a/katalystwp/README.md
+++ b/katalystwp/README.md
@@ -1,0 +1,15 @@
+# katalystwp
+
+The KatalystWP environment manager — an interactive dashboard over all your
+local WordPress + AI-agent sites. **Coming soon** (design:
+[`docs/katalyst-manager-plan.md`](../docs/katalyst-manager-plan.md)).
+
+Until then:
+
+```bash
+npm create katalystwp@latest   # create a site
+npx create-katalystwp list     # list your sites
+npm run katalyst               # (inside a site) the Katalyst menu
+```
+
+Part of [soflyy/katalystwp](https://github.com/soflyy/katalystwp).

--- a/katalystwp/index.js
+++ b/katalystwp/index.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+/**
+ * katalystwp — the KatalystWP environment manager.
+ *
+ * This is a name-reserving stub: the manager (an arrow-key dashboard over all
+ * your Katalyst sites) is designed but not built yet — see
+ * docs/katalyst-manager-plan.md in the repo.
+ */
+
+console.log(`
+KatalystWP — the environment manager CLI is coming soon.
+
+Until then:
+
+  npm create katalystwp@latest        create a WordPress + AI-agent site
+  npx create-katalystwp list          list your existing sites
+  npm run katalyst                    (inside a site) the Katalyst menu
+
+https://github.com/soflyy/katalystwp
+`);

--- a/katalystwp/package.json
+++ b/katalystwp/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "katalystwp",
+  "version": "0.0.1",
+  "description": "KatalystWP — manage your local WordPress + AI-agent environments. Manager CLI coming soon; create sites today with `npm create katalystwp`.",
+  "type": "module",
+  "bin": {
+    "katalystwp": "index.js"
+  },
+  "files": [
+    "index.js"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "wordpress",
+    "docker",
+    "ai",
+    "agents",
+    "katalyst",
+    "katalystwp"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/soflyy/katalystwp.git",
+    "directory": "katalystwp"
+  },
+  "author": "Soflyy",
+  "license": "GPL-2.0-or-later"
+}


### PR DESCRIPTION
Minimal placeholder package for the katalystwp npm name (v0.0.1): a bin that points at the create flow and the manager plan doc. Reserves the name for the future multi-site manager per docs/katalyst-manager-plan.md. Published manually (npm 2FA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)