### PR TITLE
Fix env provisioning after breakdance plugin merge + warm-claim status flicker

### DIFF
--- a/create-katalystwp/server/src/manager.js
+++ b/create-katalystwp/server/src/manager.js
@@ -213,6 +213,10 @@ export class Manager {
       await registry.update(record.id, { status: 'failed', lastError: truncate(redactErr(err)) });
     } finally {
       this.jobs.delete(record.id);
+      // Drop any probe cache so describe() reflects the freshly persisted status
+      // right away (consistent with start()/_claimPipeline); avoids a stale ps
+      // briefly overriding the real state on the read path.
+      this.probeCache.delete(record.id);
     }
   }
 
@@ -459,6 +463,12 @@ export class Manager {
       await registry.update(record.id, { status: 'failed', lastError: truncate(redactErr(err)) });
     } finally {
       this.jobs.delete(record.id);
+      // A claimed warm member carries a stale probe cache (it showed the env
+      // stopped while it waited in the pool). Drop it — like start() does — so
+      // describe() serves the fresh persisted status ('running') immediately
+      // instead of computing 'stopped' from the stale ps until the next sweep
+      // (which made the new env flicker into the Stopped tab and back).
+      this.probeCache.delete(record.id);
     }
   }
 

--- a/create-katalystwp/server/src/presets.js
+++ b/create-katalystwp/server/src/presets.js
@@ -148,7 +148,11 @@ const SEED_PRESETS = [
     description: 'Oxygen builder, built from soflyy/breakdance (BREAKDANCE_MODE=oxygen).',
     setupScript: BREAKDANCE_SETUP_SCRIPT,
     defines: { BREAKDANCE_MODE: 'oxygen', ...BREAKDANCE_BASE_DEFINES },
-    activate: ['oxygen-elements', 'breakdance-elements', 'breakdance-main'],
+    // breakdance PR #9585 merged the standalone breakdance-elements and
+    // breakdance-woocommerce plugins INTO breakdance-main (plugin/elements/,
+    // plugin/woocommerce/); they no longer exist as separate slugs. Activating
+    // breakdance-main now carries their functionality.
+    activate: ['oxygen-elements', 'breakdance-main'],
     devScript: BREAKDANCE_DEV_SCRIPT,
   },
   {
@@ -156,8 +160,8 @@ const SEED_PRESETS = [
     description: 'Breakdance builder, built from soflyy/breakdance (BREAKDANCE_MODE=breakdance).',
     setupScript: BREAKDANCE_SETUP_SCRIPT,
     defines: { BREAKDANCE_MODE: 'breakdance', ...BREAKDANCE_BASE_DEFINES },
-    // Order matters: elements → main → woocommerce.
-    activate: ['breakdance-elements', 'breakdance-main', 'breakdance-woocommerce'],
+    // elements + woocommerce were folded into breakdance-main (breakdance #9585).
+    activate: ['breakdance-main'],
     devScript: BREAKDANCE_DEV_SCRIPT,
   },
   {
@@ -165,8 +169,9 @@ const SEED_PRESETS = [
     description: 'Breakdance + the FutureLayer plugin and app-dot-futurelayer (Next.js, published on an app port), built from soflyy/breakdance.',
     setupScript: FUTURELAYER_SETUP_SCRIPT,
     defines: { BREAKDANCE_MODE: 'breakdance', ...BREAKDANCE_BASE_DEFINES },
-    // Breakdance order, then breakdance-ai, then futurelayer-plugin.
-    activate: ['breakdance-elements', 'breakdance-main', 'breakdance-woocommerce', 'breakdance-ai', 'futurelayer-plugin'],
+    // breakdance-main (now includes elements + woocommerce, breakdance #9585),
+    // then breakdance-ai, then futurelayer-plugin.
+    activate: ['breakdance-main', 'breakdance-ai', 'futurelayer-plugin'],
     devScript: BREAKDANCE_DEV_SCRIPT,
     appPorts: [3000],
   },

--- a/create-katalystwp/templates/scripts/install-plugins.sh
+++ b/create-katalystwp/templates/scripts/install-plugins.sh
@@ -79,7 +79,12 @@ if [ -n "$activate_rows" ]; then
     [ -n "$slug" ] || continue
     echo "→ Activate: $slug"
     # </dev/null so `docker compose exec` doesn't swallow the loop's remaining rows.
-    docker compose exec -T workspace wp plugin activate "$slug" </dev/null
+    # Non-fatal: a single stale/missing slug (e.g. an upstream plugin renamed or
+    # merged away) must NOT abort the whole setup and take down the steps that
+    # run after this one (agent connector, etc.). Warn and keep going.
+    if ! docker compose exec -T workspace wp plugin activate "$slug" </dev/null; then
+      echo "  ⚠ Could not activate '$slug' — skipping (plugin missing or errored). Continuing."
+    fi
   done
 fi
 


### PR DESCRIPTION
## What & why

Three independent bugs that surfaced when creating environments on the live devbox host. All three are fixed here; the running box was already patched at runtime, so this makes the fixes durable in the repo and for fresh deploys.

### 1. Presets pointed at plugins that no longer exist
breakdance **PR #9585** merged the standalone `breakdance-elements` and `breakdance-woocommerce` plugins **into `breakdance-main`** (`breakdance-main/plugin/elements/`, `…/woocommerce/`) and deleted the old plugin dirs. The seed presets still listed the removed slugs, so `wp plugin activate breakdance-elements` errored. Under `set -euo pipefail` that **aborted the whole `npm run setup`**, which meant the *next* step — `install-agent-connector.sh` — never ran:

- "successful" envs had only the first plugin active, **no agent connector**, and couldn't mint a wp-admin login link;
- Oxygen / Breakdance / FutureLayer **warm-pool builds all failed**.

Fix: the three affected seed presets now activate `breakdance-main` (which carries elements + woocommerce), dropping the merged-away slugs.

| Preset | before | after |
| --- | --- | --- |
| Oxygen | `oxygen-elements, breakdance-elements, breakdance-main` | `oxygen-elements, breakdance-main` |
| Breakdance | `breakdance-elements, breakdance-main, breakdance-woocommerce` | `breakdance-main` |
| FutureLayer | `breakdance-elements, breakdance-main, breakdance-woocommerce, breakdance-ai, futurelayer-plugin` | `breakdance-main, breakdance-ai, futurelayer-plugin` |

### 2. One bad slug shouldn't nuke the whole setup
`install-plugins.sh` made a single `wp plugin activate` failure fatal (it's in a `set -e` script), which is what let bug #1 take down the agent-connector step too. It now **warns and continues** on a missing/errored slug, so a future upstream plugin rename/merge can't wholesale-break provisioning.

### 3. Warm-claim status flicker
Creating an env from a warmed preset showed it in **Active ("configuring…") → Stopped → back to Active** on its own. A pooled member carries a stale "down" probe cache (it's stopped while it waits); `_claimPipeline` set `status=running` but — unlike `start()` — never invalidated that cache, so the read path (`computeStatus`) derived `stopped` from the stale `ps` until the next reconcile sweep. Both `_claimPipeline` and `_pipeline` now drop the probe cache in `finally`.

## Verification (on the host)
- `node --check` on `manager.js`/`presets.js`, `bash -n` on `install-plugins.sh`.
- Corrected presets → **Oxygen 2/2, Breakdance 2/2, FutureLayer 1/1** warm pools rebuilt green; a fresh Oxygen member has `agent-connector-for-wp` installed and `✓ Initial setup complete.`
- Claim + 0.5s status poll after the fix: **`configuring → running`**, held at running for 12s, never `stopped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
