### PR TITLE
feat(server): MCP endpoint — drive the devbox server from any MCP client

### DIFF
--- a/create-katalystwp/server/AGENT_USAGE.md
+++ b/create-katalystwp/server/AGENT_USAGE.md
@@ -78,7 +78,7 @@ running. If you pass `presetIds`, fetch the available ones from `GET /presets`.
 | `POST /sessions/:id/messages` | `{prompt}` → continue (`--resume`); `409` if a turn is active. |
 | `GET /sessions` · `GET /sessions/:id` | list / one session. |
 | `GET /sessions/:id/stream` | **SSE** live `stream-json` (auth: bearer or `?access_token=`). |
-| `GET /sessions/:id/transcript?tail=N` | full event history. |
+| `GET /sessions/:id/transcript?tail=N` | full event history. Add `&partials=none` to drop token deltas and `&clip=16384` to truncate giant strings (screenshots, whole-file tool results) — recommended before reading a long session. |
 | `PATCH /sessions/:id` | `{title}` → rename. |
 | `POST /sessions/:id/interrupt` · `DELETE /sessions/:id` | interrupt the turn / delete the session. |
 | `GET /presets` · `POST/PUT/DELETE /presets[/:id]` | manage provisioning presets. |

--- a/create-katalystwp/server/AGENT_USAGE.md
+++ b/create-katalystwp/server/AGENT_USAGE.md
@@ -19,6 +19,13 @@ Connector (dev)** (check out `agent-connector-for-wp` for the agent to work on).
 You do **not** need a special client — every action is an HTTP request you can
 make with `curl` (or any HTTP library).
 
+> **Using MCP instead?** The same surface is available as an MCP server at
+> `POST /mcp` (Streamable HTTP, same bearer token):
+> `claude mcp add --transport http katalyst http://<host>:4000/mcp --header "Authorization: Bearer <token>"`.
+> Once connected, call the `get_instructions` tool for the MCP-flavored version
+> of this guide (generated from the live tool table, always in sync). The rest
+> of this document describes the raw HTTP API.
+
 ## Connection
 
 Two values the operator gives you (fill these in):

--- a/create-katalystwp/server/AGENT_USAGE.md
+++ b/create-katalystwp/server/AGENT_USAGE.md
@@ -52,7 +52,8 @@ preset). **Poll `GET /environments/<name>` until `status` is `running`.**
 #    name, presetIds (array), provision (custom setup), prompt (first Claude message), model
 curl -s -H "Authorization: Bearer $TOK" -X POST "$BASE/environments" \
   -d '{"name":"my-devbox"}'
-# → {"id":"env_…","name":"my-devbox","port":9000,"wpUrl":"http://localhost:9000","status":"scaffolding"}
+# → {"id":"env_…","name":"my-devbox","port":9000,"wpUrl":"http://<host>:9000","status":"scaffolding"}
+#   (wpUrl and admin-login URLs use the server's DEVBOX_PUBLIC_HOST — directly openable)
 
 # 2. Poll until running (or failed). Repeat every ~10s.
 curl -s -H "Authorization: Bearer $TOK" "$BASE/environments/my-devbox"

--- a/create-katalystwp/server/README.md
+++ b/create-katalystwp/server/README.md
@@ -31,7 +31,7 @@ The server is a **thin orchestrator over the scaffolded project's own scripts**:
 | `DEVBOX_BIND` | `127.0.0.1` | bind address. `0.0.0.0` (or a specific IP) to reach it over the network — **requires `DEVBOX_API_TOKEN`** (the server refuses to start network-exposed without one) and a firewall/VPN |
 | `DEVBOX_API_TOKEN` | — | if set, all routes require `Authorization: Bearer <token>` |
 | `WP_PORT_RANGE` | `9000-9999` | host ports to allocate from (the env's WP port **and** its app ports) |
-| `DEVBOX_PUBLIC_HOST` | `localhost` | hostname/IP browsers use to reach this Docker host (your server's public IP / DNS name) — passed to the scaffolder as `--public-host` so setup scripts can build browser-valid URLs |
+| `DEVBOX_PUBLIC_HOST` | `localhost` | hostname/IP browsers use to reach this Docker host (your server's public IP / DNS name) — used in every returned URL (`wpUrl`, admin-login `loginUrl`) and passed to the scaffolder as `--public-host` so setup scripts can build browser-valid URLs |
 | `SANDBOX_SETUP_ENV_*` | — | setup secrets forwarded to every env's setup script with the prefix stripped (see above) |
 | `MAX_ENVIRONMENTS` | `25` | hard cap on environments |
 | `BUILD_CONCURRENCY` | `2` | simultaneous `docker build`/setup runs |

--- a/create-katalystwp/server/README.md
+++ b/create-katalystwp/server/README.md
@@ -85,7 +85,7 @@ DEVBOX_API_TOKEN=secret GITHUB_TOKEN=… npm start
 | `POST` | `/sessions/:id/messages` | `{prompt}` → 202; continue the session (`--resume`); 409 if a turn is active |
 | `GET` | `/sessions` / `/sessions/:id` | list / one session (id, claudeSessionId, status, cost, `sshResumeHint`) |
 | `GET` | `/sessions/:id/stream` | **SSE** live stream-json (auth: bearer or `?access_token=`) |
-| `GET` | `/sessions/:id/transcript?tail=N` | full event history (ndjson) |
+| `GET` | `/sessions/:id/transcript?tail=N` | full event history; `&partials=live\|none` drops token deltas, `&clip=N` truncates giant strings (screenshots, file blobs) |
 | `POST` | `/sessions/:id/interrupt` | SIGINT the active turn |
 | `DELETE` | `/sessions/:id` | forget the session |
 | `GET` | `/host` | system health: memory/CPU/disk, docker df, per-env container memory, RAM-headroom estimate |

--- a/create-katalystwp/server/README.md
+++ b/create-katalystwp/server/README.md
@@ -118,6 +118,8 @@ claude mcp add --transport http katalyst http://<host>:4000/mcp \
   --header "Authorization: Bearer $DEVBOX_API_TOKEN"
 ```
 
+(Use `https://` if the server sits behind TLS — see **HTTPS on a bare IP** below.)
+
 Same bearer auth as the JSON API. ~30 tools mirroring everything above —
 environments (create / wait / logs / start / stop / destroy / admin-login),
 presets, warm pool, host health, and full agent-session driving
@@ -127,6 +129,22 @@ which returns a complete usage guide. The tool list, that guide, and the MCP
 `src/mcp.js`, so docs can't drift from the callable surface. Both endpoints
 share one ops layer (`src/ops.js`); deliberately **not** exposed over MCP:
 settings writes (credential rotation) and `/control/shutdown`.
+
+## HTTPS on a bare IP
+
+Running network-exposed, the bearer token otherwise crosses the wire in
+cleartext. You don't need a domain to fix that: Let's Encrypt issues
+publicly-trusted certificates **for IP addresses** (GA since 2026-01, ~6-day
+lifetime via the `shortlived` ACME profile), and Caddy ≥ 2.10 auto-obtains and
+renews them. Bind the server to loopback (`DEVBOX_BIND=127.0.0.1`,
+`DEVBOX_PORT=4001`) and put Caddy on the public port — see
+[`deploy/Caddyfile.example`](deploy/Caddyfile.example). Ports 80/443 must stay
+reachable for ACME validation. SSE session streams work through the proxy
+unchanged.
+
+This covers the control plane (API/MCP/UI/token). The per-env WordPress sites
+on their own ports remain plain HTTP until they're proxied too (requires
+compose port rebinding + WP siteurl scheme changes — tracked separately).
 
 ## Web UI
 

--- a/create-katalystwp/server/README.md
+++ b/create-katalystwp/server/README.md
@@ -106,6 +106,28 @@ curl -N $H localhost:4000/sessions/<id>/stream         # live stream-json
 curl -s $H -XPOST localhost:4000/sessions/<id>/messages -d '{"prompt":"now add a CHANGELOG entry"}'
 ```
 
+## MCP
+
+The same surface is exposed as an **MCP server** at `POST /mcp` (Streamable
+HTTP transport, stateless, hand-rolled — still zero dependencies), so any MCP
+client (Claude Code, Cursor, claude.ai, …) can drive the server with typed
+tools instead of raw curl. From a machine that can reach the server:
+
+```bash
+claude mcp add --transport http katalyst http://<host>:4000/mcp \
+  --header "Authorization: Bearer $DEVBOX_API_TOKEN"
+```
+
+Same bearer auth as the JSON API. ~30 tools mirroring everything above —
+environments (create / wait / logs / start / stop / destroy / admin-login),
+presets, warm pool, host health, and full agent-session driving
+(`start_session` → `wait_for_turn` → `send_message`), plus `get_instructions`,
+which returns a complete usage guide. The tool list, that guide, and the MCP
+`initialize.instructions` field are all generated from the single tool table in
+`src/mcp.js`, so docs can't drift from the callable surface. Both endpoints
+share one ops layer (`src/ops.js`); deliberately **not** exposed over MCP:
+settings writes (credential rotation) and `/control/shutdown`.
+
 ## Web UI
 
 Open `http://<host>:<port>/` and enter the `DEVBOX_API_TOKEN`. List sessions across all devboxes, watch a session stream live (token-by-token, with tool calls), send messages, interrupt, start a new session (pick a devbox + model), and copy the SSH-resume command. Buildless (Preact + htm from a CDN) — to run fully offline, vendor those into `ui/vendor/`.

--- a/create-katalystwp/server/deploy/Caddyfile.example
+++ b/create-katalystwp/server/deploy/Caddyfile.example
@@ -1,0 +1,35 @@
+# HTTPS for the devbox control plane on a BARE IP — no domain needed.
+#
+# Let's Encrypt issues publicly-trusted certificates for IP addresses (GA since
+# 2026-01) via the "shortlived" ACME profile: ~6-day lifetime, auto-renewed by
+# Caddy (needs Caddy >= 2.10). ACME validation (http-01 / tls-alpn-01) always
+# happens on ports 80/443, so both must be reachable from the internet even
+# though the site itself serves on :4000.
+#
+# Pair this with devbox-server bound to loopback so raw HTTP is unreachable
+# from outside — in the server's env (e.g. /etc/devbox/devbox.env):
+#
+#   DEVBOX_BIND=127.0.0.1
+#   DEVBOX_PORT=4001
+#
+# Then clients keep using the familiar port, now with TLS:
+#
+#   claude mcp add --transport http katalyst https://<your-ip>:4000/mcp \
+#     --header "Authorization: Bearer $DEVBOX_API_TOKEN"
+#
+# Note: this secures the CONTROL PLANE (API token, MCP, session streams, UI).
+# The per-env WordPress sites on their own ports remain plain HTTP until they
+# are proxied too (bigger change: compose port rebinding + WP siteurl scheme).
+
+{
+	email you@example.com
+}
+
+<your-ip>:4000 {
+	tls {
+		issuer acme {
+			profile shortlived
+		}
+	}
+	reverse_proxy 127.0.0.1:4001
+}

--- a/create-katalystwp/server/deploy/Caddyfile.example
+++ b/create-katalystwp/server/deploy/Caddyfile.example
@@ -31,5 +31,8 @@
 			profile shortlived
 		}
 	}
+	# JSON payloads (session transcripts, env lists) compress ~10x; Caddy
+	# skips compression for SSE streams automatically.
+	encode zstd gzip
 	reverse_proxy 127.0.0.1:4001
 }

--- a/create-katalystwp/server/src/allocator.js
+++ b/create-katalystwp/server/src/allocator.js
@@ -141,7 +141,9 @@ export async function allocate(registry, config, { nameHint, pool = null, appPor
       // Host-published dev-server ports ({ host, container }), allocated from
       // the same range as `port`. Empty for envs that don't publish any.
       appPorts: allocatedAppPorts,
-      wpUrl: `http://localhost:${port}`,
+      // No wpUrl stored: public URLs are built from DEVBOX_PUBLIC_HOST + port
+      // at view time (status.js publicView / ops.js), so a host config change
+      // never leaves stale URLs behind (issue #74).
       status: 'scaffolding',
       createdAt: new Date().toISOString(),
       setupStartedAt: null,

--- a/create-katalystwp/server/src/index.js
+++ b/create-katalystwp/server/src/index.js
@@ -15,7 +15,9 @@ import { Manager } from './manager.js';
 import { SessionStore } from './sessions.js';
 import { SessionBus } from './sessionbus.js';
 import { ClaudeEngine, reapAgents } from './claude.js';
+import { buildOps } from './ops.js';
 import { buildRoutes } from './routes.js';
+import { buildMcpRoutes } from './mcp.js';
 import { createServer } from './http.js';
 
 // Load server/.env (or $DEVBOX_ENV_FILE) into process.env if present, using
@@ -71,7 +73,12 @@ async function main() {
     log.info(`[${env.name}] started initial session ${s.id}`);
   };
 
-  const routes = buildRoutes(config, registry, manager, sessions, presets, settings);
+  // Shared ops layer feeds both API surfaces: JSON HTTP routes and MCP (/mcp).
+  const ops = buildOps(config, registry, manager, sessions, presets);
+  const routes = [
+    ...buildRoutes(config, registry, manager, sessions, presets, settings, ops),
+    ...buildMcpRoutes(config, registry, manager, sessions, presets, settings, ops),
+  ];
   const server = createServer(config, routes);
 
   server.listen(config.port, config.bind, () => {

--- a/create-katalystwp/server/src/manager.js
+++ b/create-katalystwp/server/src/manager.js
@@ -247,7 +247,7 @@ export class Manager {
 
   async describe(record) {
     const { status } = this._gather(record);
-    return publicView(record, { status });
+    return publicView(record, { status, publicHost: this.config.publicHost });
   }
 
   async list() {

--- a/create-katalystwp/server/src/mcp.js
+++ b/create-katalystwp/server/src/mcp.js
@@ -13,7 +13,6 @@
 // `get_instructions` tool, so the docs an agent sees can never drift from the
 // tools it can call.
 
-import { readFile } from 'node:fs/promises';
 import { route } from './http.js';
 import { systemHealth } from './health.js';
 import { AGENTS } from './claude.js';
@@ -55,20 +54,6 @@ export function buildMcpRoutes(config, registry, manager, sessions, presets, set
       }
       await sleep(2000);
     }
-  };
-
-  const readTranscript = async (s, tail, includePartial) => {
-    let events = [];
-    try {
-      const text = await readFile(s.eventLogPath, 'utf8');
-      events = text.split('\n').filter(Boolean).map((l) => {
-        try { return JSON.parse(l); } catch { return { type: 'raw', text: l }; }
-      });
-    } catch { /* no log yet */ }
-    // Token-delta stream_events triple the size and add nothing once the turn
-    // is over; drop them unless explicitly asked for.
-    if (!includePartial) events = events.filter((e) => e.type !== 'stream_event');
-    return { events: events.slice(-tail), totalEvents: events.length };
   };
 
   const TOOLS = [
@@ -348,14 +333,19 @@ export function buildMcpRoutes(config, registry, manager, sessions, presets, set
     {
       name: 'get_transcript',
       category: 'Agent sessions',
-      description: 'The session\'s event history (assistant/user messages incl. tool use, and per-turn results). Token-by-token partials are excluded unless includePartial.',
+      description: 'The session\'s event history (assistant/user messages incl. tool use, and per-turn results). Token-by-token partials are excluded unless includePartial, and giant strings inside events (screenshots, whole-file tool results) are truncated to clipChars.',
       inputSchema: args({
         sessionId: SESSION_ARG,
         tail: int('Events to return from the end, max 5000 (default 200).'),
         includePartial: { type: 'boolean', description: 'Include raw stream_event token deltas (verbose; default false).' },
+        clipChars: int('Max chars per string inside an event before truncation, 0 = unlimited (default 16384).'),
       }, ['sessionId']),
-      handler: ({ sessionId, tail, includePartial }) =>
-        readTranscript(ops.sessionByRef(sessionId), Math.min(parseInt(tail, 10) || 200, 5000), !!includePartial),
+      handler: ({ sessionId, tail, includePartial, clipChars }) =>
+        ops.readTranscript(ops.sessionByRef(sessionId), {
+          tail: Math.min(parseInt(tail, 10) || 200, 5000),
+          partials: includePartial ? 'all' : 'none',
+          clip: clipChars === 0 ? 0 : Math.max(0, parseInt(clipChars, 10) || 16384),
+        }),
     },
     {
       name: 'interrupt_session',

--- a/create-katalystwp/server/src/mcp.js
+++ b/create-katalystwp/server/src/mcp.js
@@ -1,0 +1,553 @@
+// MCP endpoint — Model Context Protocol over the Streamable HTTP transport,
+// stateless, zero dependencies. `POST /mcp` accepts JSON-RPC 2.0 messages and
+// answers with plain JSON (no SSE; every tool call is a single response, which
+// the spec allows). Auth is the same bearer token as the JSON API — from a
+// local Claude Code:
+//
+//   claude mcp add --transport http katalyst http://<host>:4000/mcp \
+//     --header "Authorization: Bearer $DEVBOX_API_TOKEN"
+//
+// Tools are thin wrappers over the SAME ops/manager/session layer routes.js
+// uses (see ops.js) — no business logic lives here. The single TOOLS table
+// below generates `tools/list`, the `initialize.instructions` guide, and the
+// `get_instructions` tool, so the docs an agent sees can never drift from the
+// tools it can call.
+
+import { readFile } from 'node:fs/promises';
+import { route } from './http.js';
+import { systemHealth } from './health.js';
+import { AGENTS } from './claude.js';
+import { httpErr, validatePreset } from './ops.js';
+
+const LATEST_PROTOCOL = '2025-06-18';
+const KNOWN_PROTOCOLS = new Set(['2025-06-18', '2025-03-26', '2024-11-05']);
+const SERVER_INFO = { name: 'katalyst-devbox', title: 'Katalyst Devbox Server', version: '0.1.0' };
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+export function buildMcpRoutes(config, registry, manager, sessions, presets, settings, ops) {
+  // ---- tool table ---------------------------------------------------------
+  // { name, category, description, inputSchema, handler }. Keep descriptions
+  // agent-facing: what it does, when to use it, what comes back.
+  const str = (description) => ({ type: 'string', description });
+  const int = (description) => ({ type: 'integer', description });
+  const ENV_ARG = str('Environment name or id (both accepted everywhere).');
+  const SESSION_ARG = str('Session id (from start_session / list_sessions).');
+  const PRESET_ARG = str('Preset id (from list_presets).');
+  const args = (properties = {}, required = []) => ({ type: 'object', properties, required });
+
+  // Poll an env by id until its status settles (running/failed), it disappears,
+  // or the timeout elapses. Used by wait_for_environment.
+  const pollEnv = async (id, timeoutMs) => {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const rec = registry.get(id);
+      if (!rec) throw httpErr(410, 'environment was destroyed while waiting');
+      const view = await manager.describe(rec);
+      if (view.status === 'running' || view.status === 'failed' || Date.now() >= deadline) {
+        return {
+          ...view,
+          done: view.status === 'running' || view.status === 'failed',
+          hint: view.status === 'running' ? undefined
+            : view.status === 'failed' ? 'setup failed — read get_setup_logs, then destroy_environment and recreate'
+            : 'still provisioning — call wait_for_environment again (cold builds take ~10 min)',
+        };
+      }
+      await sleep(2000);
+    }
+  };
+
+  const readTranscript = async (s, tail, includePartial) => {
+    let events = [];
+    try {
+      const text = await readFile(s.eventLogPath, 'utf8');
+      events = text.split('\n').filter(Boolean).map((l) => {
+        try { return JSON.parse(l); } catch { return { type: 'raw', text: l }; }
+      });
+    } catch { /* no log yet */ }
+    // Token-delta stream_events triple the size and add nothing once the turn
+    // is over; drop them unless explicitly asked for.
+    if (!includePartial) events = events.filter((e) => e.type !== 'stream_event');
+    return { events: events.slice(-tail), totalEvents: events.length };
+  };
+
+  const TOOLS = [
+    // ---- meta -------------------------------------------------------------
+    {
+      name: 'get_instructions',
+      category: 'Meta',
+      description: 'Full usage guide for this server: concepts, workflows, status lifecycle, gotchas, and the complete tool reference. Call this first if you have not read the instructions yet.',
+      inputSchema: args(),
+      handler: async () => instructions, // same text initialize returns
+    },
+    {
+      name: 'host_health',
+      category: 'Meta',
+      description: 'Host capacity and health: memory/CPU/disk, docker usage, per-environment memory, and an estimate of how many more environments fit. Check before creating several environments.',
+      inputSchema: args(),
+      handler: async () => ({ ...(await systemHealth(config, registry)), sessions: sessions.store.list().length }),
+    },
+
+    // ---- environments -----------------------------------------------------
+    {
+      name: 'list_environments',
+      category: 'Environments',
+      description: 'List all environments with live status, WordPress URL, and ports.',
+      inputSchema: args(),
+      handler: async () => ({ environments: await manager.list() }),
+    },
+    {
+      name: 'get_environment',
+      category: 'Environments',
+      description: 'Describe one environment: status, wpUrl, ports, preset provenance, lastError.',
+      inputSchema: args({ env: ENV_ARG }, ['env']),
+      handler: async ({ env }) => manager.describe(ops.envByRef(env)),
+    },
+    {
+      name: 'create_environment',
+      category: 'Environments',
+      description: 'Create a WordPress environment (async — returns immediately; follow with wait_for_environment). Compose presets via presetIds (see list_presets); a single preset with no custom provision claims a pre-built warm env in seconds, otherwise a cold build takes ~10 min. Optional prompt starts an agent session automatically once the env is ready.',
+      inputSchema: args({
+        name: str('Environment name, ^[a-z0-9][a-z0-9-]{1,38}$, unique. Omit for an auto-generated one.'),
+        presetIds: { type: 'array', items: { type: 'string' }, description: 'Preset ids to compose, in order (from list_presets).' },
+        prompt: str('Optional first agent prompt — starts a session automatically when the env becomes ready.'),
+        model: str('Model for that first session (optional).'),
+        agent: str(`Agent for that first session: ${Object.keys(AGENTS).join(' | ')} (default claude).`),
+        provision: {
+          type: 'object',
+          description: 'Custom provisioning on top of (or instead of) presets. Note: any custom provision disables the warm-pool fast path.',
+          properties: {
+            setupScript: str('Bash run once in the workspace after WordPress is up.'),
+            devScript: str('Long-running dev/watch script.'),
+            activate: { type: 'array', items: { type: 'string' }, description: 'Plugin slugs to activate, in order.' },
+            defines: { type: 'object', description: 'wp-config PHP defines, { "WP_CONST": value }.' },
+            appPorts: { type: 'array', items: { type: 'integer' }, description: 'Extra container ports to publish (e.g. [3000]).' },
+          },
+        },
+      }),
+      handler: (body) => ops.createEnvironment(body),
+    },
+    {
+      name: 'wait_for_environment',
+      category: 'Environments',
+      description: 'Block until an environment reaches running or failed (or the timeout passes — then call again; cold builds take ~10 min). Returns the environment description plus done:true/false.',
+      inputSchema: args({ env: ENV_ARG, timeoutSeconds: int('Max seconds to wait, 5-600 (default 120).') }, ['env']),
+      handler: async ({ env, timeoutSeconds }) => {
+        const t = Math.min(Math.max(parseInt(timeoutSeconds, 10) || 120, 5), 600);
+        return pollEnv(ops.envByRef(env).id, t * 1000);
+      },
+    },
+    {
+      name: 'get_setup_logs',
+      category: 'Environments',
+      description: 'Tail an environment\'s logs. which: "setup" (provisioning log — read this when a create fails), "dev" (dev/watch script), or "all".',
+      inputSchema: args({ env: ENV_ARG, which: str('setup | dev | all (default setup).'), tail: int('Lines to tail, max 5000 (default 200).') }, ['env']),
+      handler: async ({ env, which, tail }) =>
+        manager.logs(ops.envByRef(env), which || 'setup', Math.min(parseInt(tail, 10) || 200, 5000)),
+    },
+    {
+      name: 'start_environment',
+      category: 'Environments',
+      description: 'Start a stopped environment\'s containers (data was preserved).',
+      inputSchema: args({ env: ENV_ARG }, ['env']),
+      handler: ({ env }) => manager.start(ops.envByRef(env)),
+    },
+    {
+      name: 'stop_environment',
+      category: 'Environments',
+      description: 'Stop an environment\'s containers. Data is preserved; start_environment resumes it.',
+      inputSchema: args({ env: ENV_ARG }, ['env']),
+      handler: ({ env }) => manager.stop(ops.envByRef(env)),
+    },
+    {
+      name: 'destroy_environment',
+      category: 'Environments',
+      description: 'Destroy an environment permanently: stop and remove its containers, delete its directory, and delete all its agent sessions. Irreversible.',
+      inputSchema: args({ env: ENV_ARG }, ['env']),
+      handler: async ({ env }) => { await ops.destroyEnvironment(ops.envByRef(env)); return { deleted: true }; },
+    },
+    {
+      name: 'set_environment_label',
+      category: 'Environments',
+      description: 'Set the display label shown in lists (canonical name/URL unchanged). Empty label resets to the canonical name.',
+      inputSchema: args({ env: ENV_ARG, label: str('New display label (empty to reset).') }, ['env']),
+      handler: async ({ env, label }) => {
+        const rec = ops.envByRef(env);
+        const clean = String(label ?? '').replace(/\s+/g, ' ').trim();
+        return manager.describe(await registry.update(rec.id, { displayName: clean ? clean.slice(0, 80) : null }));
+      },
+    },
+    {
+      name: 'mint_admin_login',
+      category: 'Environments',
+      description: 'Mint a one-time, 5-minute, passwordless wp-admin login URL for a running environment. No password needed — just open the returned loginUrl.',
+      inputSchema: args({ env: ENV_ARG }, ['env']),
+      handler: ({ env }) => ops.mintAdminLogin(ops.envByRef(env)),
+    },
+
+    // ---- presets ----------------------------------------------------------
+    {
+      name: 'list_presets',
+      category: 'Presets',
+      description: 'List provisioning presets (saved blueprints: setup script, plugins to activate, defines, app ports). Use their ids in create_environment.',
+      inputSchema: args(),
+      handler: async () => ({ presets: presets.list() }),
+    },
+    {
+      name: 'create_preset',
+      category: 'Presets',
+      description: 'Create a provisioning preset.',
+      inputSchema: args({
+        name: str('Preset name (required).'),
+        description: str('What this preset sets up.'),
+        setupScript: str('Bash run once in the workspace after WordPress is up.'),
+        devScript: str('Long-running dev/watch script.'),
+        activate: { type: 'array', items: { type: 'string' }, description: 'Plugin slugs to activate, in order.' },
+        defines: { type: 'object', description: 'wp-config PHP defines.' },
+        appPorts: { type: 'array', items: { type: 'integer' }, description: 'Extra container ports to publish.' },
+      }, ['name']),
+      handler: (body) => presets.create(validatePreset(body)),
+    },
+    {
+      name: 'update_preset',
+      category: 'Presets',
+      description: 'REPLACE a preset\'s definition (PUT semantics — send the FULL object; omitted provision fields are cleared, so read it from list_presets first and modify).',
+      inputSchema: args({
+        presetId: PRESET_ARG,
+        name: str('Preset name (required).'),
+        description: str('What this preset sets up.'),
+        setupScript: str('Bash run once in the workspace after WordPress is up.'),
+        devScript: str('Long-running dev/watch script.'),
+        activate: { type: 'array', items: { type: 'string' }, description: 'Plugin slugs to activate, in order.' },
+        defines: { type: 'object', description: 'wp-config PHP defines.' },
+        appPorts: { type: 'array', items: { type: 'integer' }, description: 'Extra container ports to publish.' },
+      }, ['presetId', 'name']),
+      handler: async ({ presetId, ...body }) => {
+        const rec = await presets.update(presetId, validatePreset(body));
+        if (!rec) throw httpErr(404, `preset "${presetId}" not found`);
+        return rec;
+      },
+    },
+    {
+      name: 'delete_preset',
+      category: 'Presets',
+      description: 'Delete a preset (existing environments built from it are unaffected).',
+      inputSchema: args({ presetId: PRESET_ARG }, ['presetId']),
+      handler: async ({ presetId }) => {
+        if (!(await presets.remove(presetId))) throw httpErr(404, `preset "${presetId}" not found`);
+        return { deleted: true };
+      },
+    },
+
+    // ---- warm pool --------------------------------------------------------
+    {
+      name: 'pool_status',
+      category: 'Warm pool',
+      description: 'Warm-pool status per preset: desired/ready/building/failed counts. Ready members make create_environment near-instant for that preset.',
+      inputSchema: args(),
+      handler: async () => ({ pool: manager.poolStatus() }),
+    },
+    {
+      name: 'set_pool_size',
+      category: 'Warm pool',
+      description: 'Set the desired number of pre-built warm environments kept ready for a preset (0 turns its pool off). The pool refills in the background.',
+      inputSchema: args({ presetId: PRESET_ARG, count: int('Desired ready count, 0-50.') }, ['presetId', 'count']),
+      handler: async ({ presetId, count }) => {
+        if (!presets.get(presetId)) throw httpErr(404, `preset "${presetId}" not found`);
+        await settings.setWarmPool(presetId, Math.max(0, Math.min(50, parseInt(count, 10) || 0)));
+        manager.maintainPoolSoon();
+        return { pool: manager.poolStatus() };
+      },
+    },
+    {
+      name: 'rebuild_pool',
+      category: 'Warm pool',
+      description: 'Discard a preset\'s warm environments so they rebuild from current code (use after changing the preset). The pool refills in the background.',
+      inputSchema: args({ presetId: PRESET_ARG }, ['presetId']),
+      handler: async ({ presetId }) => {
+        if (!presets.get(presetId)) throw httpErr(404, `preset "${presetId}" not found`);
+        return { rebuilt: await manager.rebuildPool(presetId), pool: manager.poolStatus() };
+      },
+    },
+
+    // ---- agent sessions ---------------------------------------------------
+    {
+      name: 'start_session',
+      category: 'Agent sessions',
+      description: 'Start a headless agent session (claude | codex | opencode) inside a RUNNING environment with a first prompt. Async — returns the session immediately; follow with wait_for_turn to get the answer.',
+      inputSchema: args({
+        env: ENV_ARG,
+        prompt: str('The first prompt/task for the agent.'),
+        model: str('Model override (optional).'),
+        agent: str(`Agent CLI to use: ${Object.keys(AGENTS).join(' | ')} (default claude).`),
+      }, ['env', 'prompt']),
+      handler: async ({ env, prompt, model, agent }) => {
+        const rec = ops.envByRef(env);
+        await ops.assertUsable(rec);
+        const p = String(prompt || '').trim();
+        if (!p) throw httpErr(400, 'prompt is required');
+        return ops.publicSession(await sessions.engine.newSession(rec, { prompt: p, model, agent: AGENTS[agent] ? agent : 'claude' }));
+      },
+    },
+    {
+      name: 'send_message',
+      category: 'Agent sessions',
+      description: 'Send the next prompt to an existing session (resumes the same conversation). One turn at a time — errors if a turn is in progress. Async — follow with wait_for_turn.',
+      inputSchema: args({ sessionId: SESSION_ARG, prompt: str('The next prompt.') }, ['sessionId', 'prompt']),
+      handler: async ({ sessionId, prompt }) => {
+        const s = ops.sessionByRef(sessionId);
+        if (sessions.engine.isActive(s.id)) throw httpErr(409, 'a turn is already in progress for this session');
+        const env = registry.get(s.envId);
+        if (!env) throw httpErr(410, 'the environment for this session no longer exists');
+        await ops.assertUsable(env);
+        const p = String(prompt || '').trim();
+        if (!p) throw httpErr(400, 'prompt is required');
+        await sessions.engine.sendMessage(env, s, { prompt: p });
+        return ops.publicSession(sessions.store.get(s.id));
+      },
+    },
+    {
+      name: 'wait_for_turn',
+      category: 'Agent sessions',
+      description: 'Block until the session\'s current turn finishes (or the timeout passes — then call again). Returns the session with lastResult = the agent\'s final answer (truncated; use get_transcript for the full trail) and done:true/false.',
+      inputSchema: args({ sessionId: SESSION_ARG, timeoutSeconds: int('Max seconds to wait, 5-600 (default 60).') }, ['sessionId']),
+      handler: async ({ sessionId, timeoutSeconds }) => {
+        const t = Math.min(Math.max(parseInt(timeoutSeconds, 10) || 60, 5), 600);
+        const deadline = Date.now() + t * 1000;
+        for (;;) {
+          const s = ops.sessionByRef(sessionId); // throws 404 if deleted mid-wait
+          if (!sessions.engine.isActive(s.id)) return { ...ops.publicSession(s), done: true };
+          if (Date.now() >= deadline) {
+            return { ...ops.publicSession(s), done: false, hint: 'turn still running — call wait_for_turn again' };
+          }
+          await sleep(1000);
+        }
+      },
+    },
+    {
+      name: 'list_sessions',
+      category: 'Agent sessions',
+      description: 'List agent sessions, optionally filtered by environment, status, or archived ("only" | "exclude"; default both, flagged).',
+      inputSchema: args({ env: ENV_ARG, status: str('Filter: running | completed | interrupted | failed.'), archived: str('"only" | "exclude" (default: include both).') }),
+      handler: async ({ env, status, archived }) => {
+        let list = sessions.store.list();
+        if (env) { const rec = ops.envByRef(env); list = list.filter((s) => s.envId === rec.id); }
+        if (status) list = list.filter((s) => ops.publicSession(s).status === status);
+        if (archived === 'only') list = list.filter((s) => s.archived);
+        else if (archived === 'exclude') list = list.filter((s) => !s.archived);
+        return { sessions: list.map(ops.publicSession) };
+      },
+    },
+    {
+      name: 'get_session',
+      category: 'Agent sessions',
+      description: 'One session: status, turnCount, lastResult, cost, timestamps.',
+      inputSchema: args({ sessionId: SESSION_ARG }, ['sessionId']),
+      handler: async ({ sessionId }) => ops.publicSession(ops.sessionByRef(sessionId)),
+    },
+    {
+      name: 'get_transcript',
+      category: 'Agent sessions',
+      description: 'The session\'s event history (assistant/user messages incl. tool use, and per-turn results). Token-by-token partials are excluded unless includePartial.',
+      inputSchema: args({
+        sessionId: SESSION_ARG,
+        tail: int('Events to return from the end, max 5000 (default 200).'),
+        includePartial: { type: 'boolean', description: 'Include raw stream_event token deltas (verbose; default false).' },
+      }, ['sessionId']),
+      handler: ({ sessionId, tail, includePartial }) =>
+        readTranscript(ops.sessionByRef(sessionId), Math.min(parseInt(tail, 10) || 200, 5000), !!includePartial),
+    },
+    {
+      name: 'interrupt_session',
+      category: 'Agent sessions',
+      description: 'Interrupt the session\'s in-flight turn (like pressing Esc). The session survives and can be resumed with send_message.',
+      inputSchema: args({ sessionId: SESSION_ARG }, ['sessionId']),
+      handler: async ({ sessionId }) => {
+        const s = ops.sessionByRef(sessionId);
+        if (!sessions.engine.interrupt(s.id)) throw httpErr(409, 'no active turn to interrupt');
+        return ops.publicSession(sessions.store.get(s.id));
+      },
+    },
+    {
+      name: 'rename_session',
+      category: 'Agent sessions',
+      description: 'Set a session\'s title.',
+      inputSchema: args({ sessionId: SESSION_ARG, title: str('New title.') }, ['sessionId', 'title']),
+      handler: async ({ sessionId, title }) => {
+        const s = ops.sessionByRef(sessionId);
+        const clean = String(title || '').replace(/\s+/g, ' ').trim();
+        if (!clean) throw httpErr(400, 'title is required');
+        return ops.publicSession(await sessions.store.update(s.id, { title: clean.slice(0, 200) }));
+      },
+    },
+    {
+      name: 'archive_session',
+      category: 'Agent sessions',
+      description: 'Archive a session (hidden from default lists; transcript and resume id persist). Interrupts any in-flight turn first.',
+      inputSchema: args({ sessionId: SESSION_ARG }, ['sessionId']),
+      handler: async ({ sessionId }) => {
+        const s = ops.sessionByRef(sessionId);
+        sessions.engine.interrupt(s.id);
+        return ops.publicSession(await sessions.store.update(s.id, { archived: true }));
+      },
+    },
+    {
+      name: 'restore_session',
+      category: 'Agent sessions',
+      description: 'Un-archive a session.',
+      inputSchema: args({ sessionId: SESSION_ARG }, ['sessionId']),
+      handler: async ({ sessionId }) =>
+        ops.publicSession(await sessions.store.update(ops.sessionByRef(sessionId).id, { archived: false })),
+    },
+    {
+      name: 'delete_session',
+      category: 'Agent sessions',
+      description: 'Delete a session permanently (record, transcript, resume id). Irreversible — archive_session if you might want it back.',
+      inputSchema: args({ sessionId: SESSION_ARG }, ['sessionId']),
+      handler: async ({ sessionId }) => { await ops.deleteSession(ops.sessionByRef(sessionId)); return { deleted: true }; },
+    },
+
+    // ---- control ----------------------------------------------------------
+    {
+      name: 'interrupt_all_sessions',
+      category: 'Control',
+      description: 'Interrupt every running agent turn across all sessions. Environments keep running.',
+      inputSchema: args(),
+      handler: async () => ({ interrupted: sessions.engine.interruptAll() }),
+    },
+    {
+      name: 'stop_all_environments',
+      category: 'Control',
+      description: 'Stop ALL environments\' containers (interrupts their agent turns too). Data preserved; start each again individually.',
+      inputSchema: args(),
+      handler: async () => { sessions.engine.interruptAll(); return { stopped: await manager.stopAll() }; },
+    },
+  ];
+  // Deliberately NOT exposed over MCP: settings writes (credential rotation)
+  // and /control/shutdown (kills the control server) — those stay browser-only.
+
+  const byName = new Map(TOOLS.map((t) => [t.name, t]));
+  const instructions = buildInstructions(TOOLS);
+
+  // ---- JSON-RPC dispatch --------------------------------------------------
+  const rpcResult = (id, result) => ({ jsonrpc: '2.0', id, result });
+  const rpcError = (id, code, message) => ({ jsonrpc: '2.0', id, error: { code, message } });
+
+  const dispatch = async (msg) => {
+    switch (msg.method) {
+      case 'initialize': {
+        const asked = msg.params?.protocolVersion;
+        return rpcResult(msg.id, {
+          protocolVersion: KNOWN_PROTOCOLS.has(asked) ? asked : LATEST_PROTOCOL,
+          capabilities: { tools: { listChanged: false } },
+          serverInfo: SERVER_INFO,
+          instructions,
+        });
+      }
+      case 'ping':
+        return rpcResult(msg.id, {});
+      case 'tools/list':
+        return rpcResult(msg.id, {
+          tools: TOOLS.map(({ name, description, inputSchema }) => ({ name, description, inputSchema })),
+        });
+      case 'tools/call': {
+        const { name, arguments: toolArgs } = msg.params || {};
+        const tool = byName.get(name);
+        if (!tool) return rpcError(msg.id, -32602, `unknown tool "${name}"`);
+        try {
+          const data = await tool.handler(toolArgs || {});
+          const result = { content: [{ type: 'text', text: typeof data === 'string' ? data : JSON.stringify(data, null, 2) }] };
+          if (data && typeof data === 'object' && !Array.isArray(data)) result.structuredContent = data;
+          return rpcResult(msg.id, result);
+        } catch (err) {
+          // Tool failures are results (isError), not protocol errors, per spec.
+          return rpcResult(msg.id, { content: [{ type: 'text', text: `Error: ${err.message}` }], isError: true });
+        }
+      }
+      default:
+        return rpcError(msg.id, -32601, `method "${msg.method}" not supported`);
+    }
+  };
+
+  return [
+    route('POST', '/mcp', async (ctx) => {
+      const msg = ctx.body;
+      if (Array.isArray(msg)) return ctx.send(400, rpcError(null, -32600, 'JSON-RPC batching is not supported'));
+      if (!msg || msg.jsonrpc !== '2.0') return ctx.send(400, rpcError(msg?.id ?? null, -32600, 'expected a JSON-RPC 2.0 message'));
+      // Notifications (and client responses) get 202 + no body.
+      if (msg.id === undefined || msg.id === null || !msg.method) {
+        ctx.res.writeHead(202).end();
+        return;
+      }
+      ctx.send(200, await dispatch(msg));
+    }),
+    // Stateless server: no server-initiated SSE stream, no session to delete.
+    route('GET', '/mcp', async (ctx) => ctx.send(405, { error: 'no server stream — POST JSON-RPC messages to /mcp' })),
+    route('DELETE', '/mcp', async (ctx) => ctx.send(405, { error: 'stateless server — no session to delete' })),
+  ];
+}
+
+// ---- generated instructions ----------------------------------------------
+// Built from the same TOOLS table that serves tools/list, so the guide always
+// matches the callable surface. Served as initialize.instructions AND via the
+// get_instructions tool.
+function buildInstructions(tools) {
+  const sig = (t) => {
+    const req = new Set(t.inputSchema.required || []);
+    const names = Object.keys(t.inputSchema.properties || {});
+    return `${t.name}(${names.map((n) => (req.has(n) ? n : `${n}?`)).join(', ')})`;
+  };
+  const categories = [...new Set(tools.map((t) => t.category))];
+  const reference = categories
+    .map((c) => `### ${c}\n${tools.filter((t) => t.category === c).map((t) => `- **${sig(t)}** — ${t.description}`).join('\n')}`)
+    .join('\n\n');
+
+  return `# Katalyst Devbox Server
+
+You are connected to a devbox control server that manages many self-contained
+**WordPress dev environments** on one Docker host and can drive coding agents
+(claude | codex | opencode) **headlessly inside each one**. Each environment is
+a live WordPress site (wpUrl) plus a workspace container with WP-CLI, Node,
+git, gh, and the agent CLIs. Environments are provisioned by composable
+**presets** (setup script, plugins, wp-config defines, extra ports).
+
+## Core workflows
+
+**Create an environment and open its site:**
+1. \`list_presets\` → pick preset id(s). \`host_health\` first if creating several.
+2. \`create_environment({ presetIds: [id] })\` — returns immediately (async).
+3. \`wait_for_environment({ env })\` until \`done: true\` and status \`running\`
+   (warm claims take seconds; cold builds ~10 min — just call it again on timeout).
+4. \`mint_admin_login({ env })\` → one-time passwordless wp-admin URL; the site
+   itself is at the environment's \`wpUrl\`.
+
+**Drive an agent inside an environment (the main loop):**
+1. \`start_session({ env, prompt })\` — async, returns the session id.
+2. \`wait_for_turn({ sessionId })\` until \`done: true\` — \`lastResult\` is the
+   agent's final answer (truncated to ~4000 chars).
+3. \`get_transcript({ sessionId })\` when you need the full tool-use trail.
+4. \`send_message({ sessionId, prompt })\` to continue the same conversation,
+   then \`wait_for_turn\` again. One turn at a time per session.
+
+Passing \`prompt\` to \`create_environment\` fuses the two flows: the session
+starts automatically the moment the env is ready.
+
+## Environment status lifecycle
+\`scaffolding\` → \`setting-up\` → \`configuring\` → **\`running\`** (create pipeline; wait it out)
+· \`degraded\` (some containers down) · \`stopped\` (resume with start_environment)
+· \`failed\` (read get_setup_logs, then usually destroy and recreate).
+
+## Rules and gotchas
+- Environment names: \`^[a-z0-9][a-z0-9-]{1,38}$\`, unique. Omit to auto-generate.
+- Everything async returns BEFORE the work finishes — use the wait_* tools.
+- Each environment costs a few GB of RAM: check \`host_health\` before mass-creating; creation errors "at capacity" when full.
+- \`update_preset\` REPLACES the whole preset — read it first, send the full object.
+- After editing a preset, \`rebuild_pool\` so its warm environments rebuild from the new definition.
+- Credentials (GitHub/Claude tokens) are managed server-side by the operator — never send or request them.
+- \`destroy_environment\` and \`delete_session\` are irreversible; prefer stop/archive when unsure.
+
+## Tool reference
+
+${reference}
+`;
+}

--- a/create-katalystwp/server/src/ops.js
+++ b/create-katalystwp/server/src/ops.js
@@ -159,9 +159,11 @@ export function buildOps(config, registry, manager, sessions, presets) {
   });
 
   // One-click passwordless wp-admin login: mint a one-time, 5-min link via the
-  // agent-connector ability already installed in every env. Returns a localhost
-  // URL with the token; callers rebase the host:port (redemption uses the
-  // request host, so the token is host-agnostic).
+  // agent-connector ability already installed in every env. WP emits the URL on
+  // its own (in-container) home host, so rebase it to the public host + the
+  // env's published port to make it directly openable (issue #74) — redemption
+  // uses the request host, so the token is host-agnostic. Plain http until env
+  // sites are proxied too (TLS phase 2, issue #73).
   const mintAdminLogin = async (env) => {
     await assertUsable(env);
     let res;
@@ -174,7 +176,8 @@ export function buildOps(config, registry, manager, sessions, presets) {
     if (!/^https?:\/\/\S*acfw_login=/.test(url)) {
       throw httpErr(502, `admin login link unavailable: ${String(res.stderr || url || '').trim().slice(0, 200)}`);
     }
-    return { loginUrl: url };
+    const u = new URL(url);
+    return { loginUrl: `http://${config.publicHost}:${env.port}${u.pathname}${u.search}` };
   };
 
   // Read a session's event log.
@@ -223,15 +226,19 @@ export function buildOps(config, registry, manager, sessions, presets) {
     const model = typeof body.model === 'string' && body.model.trim() ? body.model.trim() : undefined;
     const agent = AGENTS[body.agent] ? body.agent : undefined; // first-prompt session agent; else default
 
+    // wpUrl from the public host, not the stored record (issue #74) — same as
+    // publicView in status.js.
+    const wpUrl = (rec) => `http://${config.publicHost}:${rec.port}`;
+
     if (presetIds.length === 1 && !custom) {
       const claimed = await manager.claimAndStart(presetIds[0], { name: body.name, prompt: prompt || undefined, model, agent });
       if (claimed) {
-        return { id: claimed.id, name: claimed.name, port: claimed.port, appPorts: claimed.appPorts ?? [], wpUrl: claimed.wpUrl, status: 'configuring', warm: true };
+        return { id: claimed.id, name: claimed.name, port: claimed.port, appPorts: claimed.appPorts ?? [], wpUrl: wpUrl(claimed), status: 'configuring', warm: true };
       }
     }
 
     const record = await manager.createEnvironment({ name: body.name, provision, prompt: prompt || undefined, model, agent });
-    return { id: record.id, name: record.name, port: record.port, appPorts: record.appPorts ?? [], wpUrl: record.wpUrl, status: record.status, warm: false };
+    return { id: record.id, name: record.name, port: record.port, appPorts: record.appPorts ?? [], wpUrl: wpUrl(record), status: record.status, warm: false };
   };
 
   return {

--- a/create-katalystwp/server/src/ops.js
+++ b/create-katalystwp/server/src/ops.js
@@ -4,7 +4,7 @@
 // warm-pool fast path), admin-login minting, session shaping, and input
 // validation. Endpoint files stay thin: parse transport, call ops, shape reply.
 
-import { rm } from 'node:fs/promises';
+import { readFile, rm } from 'node:fs/promises';
 import { exec } from './docker.js';
 import { AGENTS } from './claude.js';
 import { composeProvision } from './provision.js';
@@ -13,6 +13,19 @@ export function httpErr(status, message) {
   const e = new Error(message);
   e.status = status;
   return e;
+}
+
+// Deep-copy a JSON value, truncating any string longer than `max` chars with
+// an explicit marker. Keys are untouched; short strings pass through as-is.
+function clipStrings(v, max) {
+  if (typeof v === 'string') return v.length > max ? `${v.slice(0, max)}…[+${v.length - max} chars truncated]` : v;
+  if (Array.isArray(v)) return v.map((x) => clipStrings(x, max));
+  if (v && typeof v === 'object') {
+    const o = {};
+    for (const k of Object.keys(v)) o[k] = clipStrings(v[k], max);
+    return o;
+  }
+  return v;
 }
 
 // Run inside the workspace via `wp eval`: mint a one-time admin login URL for the
@@ -164,6 +177,35 @@ export function buildOps(config, registry, manager, sessions, presets) {
     return { loginUrl: url };
   };
 
+  // Read a session's event log.
+  //
+  // `partials` controls stream_event token deltas (numerous but only needed to
+  // rebuild the in-progress line): 'all' (raw log), 'live' (only the deltas
+  // after the last assistant message — exactly what reconstructs the current
+  // partial), 'none' (drop them all). Deltas of completed messages are
+  // superseded by their assistant event either way.
+  //
+  // `clip` (chars, 0 = off) truncates any single string inside an event —
+  // giant tool_results (base64 screenshots, whole files) can be 1MB+ each and
+  // dominate a long turn's payload far beyond what any viewer needs.
+  const readTranscript = async (s, { tail = 2000, partials = 'all', clip = 0 } = {}) => {
+    let events = [];
+    try {
+      const text = await readFile(s.eventLogPath, 'utf8');
+      events = text.split('\n').filter(Boolean).map((l) => {
+        try { return JSON.parse(l); } catch { return { type: 'raw', text: l }; }
+      });
+    } catch { /* no log yet */ }
+    if (partials !== 'all') {
+      const lastAssistant = events.findLastIndex((e) => e.type === 'assistant');
+      events = events.filter((e, i) => e.type !== 'stream_event' || (partials === 'live' && i > lastAssistant));
+    }
+    const totalEvents = events.length;
+    events = events.slice(-tail);
+    if (clip > 0) events = events.map((e) => clipStrings(e, clip));
+    return { events, totalEvents };
+  };
+
   // Create an environment: compose any selected presets (in order) with optional
   // custom fields; a single preset with no custom overrides can claim a warm
   // pre-built env (seconds) instead of building (~10m). Async either way — the
@@ -200,6 +242,7 @@ export function buildOps(config, registry, manager, sessions, presets) {
     destroyEnvironment,
     publicSession,
     mintAdminLogin,
+    readTranscript,
     createEnvironment,
   };
 }

--- a/create-katalystwp/server/src/ops.js
+++ b/create-katalystwp/server/src/ops.js
@@ -1,0 +1,205 @@
+// Shared operations used by BOTH API surfaces: the JSON HTTP routes
+// (routes.js) and the MCP endpoint (mcp.js). Extracted so the two cannot
+// drift — one implementation of env lookup, env-create composition (incl. the
+// warm-pool fast path), admin-login minting, session shaping, and input
+// validation. Endpoint files stay thin: parse transport, call ops, shape reply.
+
+import { rm } from 'node:fs/promises';
+import { exec } from './docker.js';
+import { AGENTS } from './claude.js';
+import { composeProvision } from './provision.js';
+
+export function httpErr(status, message) {
+  const e = new Error(message);
+  e.status = status;
+  return e;
+}
+
+// Run inside the workspace via `wp eval`: mint a one-time admin login URL for the
+// site's first administrator through the agent-connector ability's service. The
+// FQCN is the same whether the companion ships as default- or universal-abilities.
+const ADMIN_LOGIN_PHP = `
+$admins = get_users(array('role' => 'administrator', 'number' => 1, 'orderby' => 'ID'));
+$u = $admins ? $admins[0] : null;
+if (!$u) { fwrite(STDERR, 'no administrator user'); exit(1); }
+$cls = 'AgentConnectorForWp\\DefaultAbilities\\Services\\AdminLoginLink';
+if (!class_exists($cls)) { fwrite(STDERR, 'abilities plugin (admin login) not active'); exit(1); }
+$r = $cls::create($u->ID, 'index.php', 300);
+if (is_wp_error($r)) { fwrite(STDERR, $r->get_error_message()); exit(1); }
+echo $r['login_url'];
+`;
+
+const SLUG_RE = /^[a-z0-9][a-z0-9._-]*$/i; // plugin slug
+const CONST_RE = /^[A-Za-z_][A-Za-z0-9_]*$/; // PHP constant name
+
+// Validate the activate list + defines map shared by provision and presets.
+// Throws 400 on a bad slug / constant name / defines shape.
+export function validateProvisionFields(body = {}) {
+  const setupScript = typeof body.setupScript === 'string' ? body.setupScript : '';
+  const devScript = typeof body.devScript === 'string' ? body.devScript : '';
+
+  let activate = [];
+  if (body.activate != null) {
+    if (!Array.isArray(body.activate)) throw httpErr(400, 'activate must be an array of plugin slugs');
+    activate = body.activate.filter((s) => typeof s === 'string' && s.trim()).map((s) => s.trim());
+    for (const s of activate) if (!SLUG_RE.test(s)) throw httpErr(400, `invalid plugin slug "${s}"`);
+  }
+
+  let defines = {};
+  if (body.defines != null) {
+    if (typeof body.defines !== 'object' || Array.isArray(body.defines)) {
+      throw httpErr(400, 'defines must be a JSON object of { "WP_CONST": value } pairs');
+    }
+    defines = body.defines;
+    for (const k of Object.keys(defines)) if (!CONST_RE.test(k)) throw httpErr(400, `invalid define name "${k}"`);
+  }
+
+  // Container ports to publish per env (each gets a unique host port from the
+  // allocator), e.g. [3000] for a Next.js dev server.
+  let appPorts = [];
+  if (body.appPorts != null) {
+    if (!Array.isArray(body.appPorts)) throw httpErr(400, 'appPorts must be an array of container ports, e.g. [3000]');
+    appPorts = body.appPorts.map((p) => parseInt(p, 10));
+    for (const p of appPorts) {
+      if (!Number.isInteger(p) || p < 1 || p > 65535) throw httpErr(400, `invalid app port "${p}" — expected an integer 1-65535`);
+    }
+    appPorts = [...new Set(appPorts)];
+  }
+
+  return { setupScript, devScript, activate, defines, appPorts };
+}
+
+// A preset additionally carries name/description.
+export function validatePreset(body = {}) {
+  const name = String((body && body.name) || '').trim();
+  if (!name) throw httpErr(400, 'preset name is required');
+  return { name, description: typeof body.description === 'string' ? body.description : '', ...validateProvisionFields(body) };
+}
+
+// Custom (ad-hoc) provision fields for a create. Returns null when nothing was
+// specified (a blank WordPress env, or presets-only).
+export function normalizeProvision(body) {
+  if (!body || typeof body !== 'object') return null;
+  const { setupScript, devScript, activate, defines, appPorts } = validateProvisionFields(body);
+  if (!setupScript && !devScript && !activate.length && !Object.keys(defines).length && !appPorts.length) return null;
+  return { setupScript, devScript, activate, defines, appPorts };
+}
+
+// Build the shared ops bundle. `sessions` bundles { store, engine, bus }.
+export function buildOps(config, registry, manager, sessions, presets) {
+  const envByRef = (ref) => {
+    const rec = registry.get(ref) || registry.getByName(ref);
+    if (!rec) throw httpErr(404, `environment "${ref}" not found`);
+    return rec;
+  };
+
+  const sessionByRef = (ref) => {
+    const s = sessions.store.get(ref);
+    if (!s) throw httpErr(404, `session "${ref}" not found`);
+    return s;
+  };
+
+  const assertUsable = async (env) => {
+    if (!(await manager.usable(env))) throw httpErr(409, `environment "${env.name}" is not running`);
+  };
+
+  // Fully remove a session: stop any active turn, drop its event stream + log
+  // file, and delete the record. Used by session delete and env destroy.
+  const deleteSession = async (s) => {
+    sessions.engine.interrupt(s.id);
+    sessions.bus.clear(s.id);
+    await sessions.store.remove(s.id);
+    if (s.eventLogPath) await rm(s.eventLogPath, { force: true }).catch(() => {});
+  };
+
+  // Destroy an env and everything tied to it (sessions cascade).
+  const destroyEnvironment = async (env) => {
+    sessions.engine.killEnvSessions(env.id);
+    for (const s of sessions.store.listByEnv(env.id)) await deleteSession(s);
+    await manager.destroy(env);
+  };
+
+  const sshHint = (s) => {
+    const env = registry.get(s.envId);
+    if (!env || !s.claudeSessionId) return null;
+    return (AGENTS[s.agent] || AGENTS.claude).resumeHint(env.dir, s.claudeSessionId);
+  };
+
+  const publicSession = (s) => ({
+    id: s.id,
+    envId: s.envId,
+    envName: s.envName,
+    agent: s.agent || 'claude',
+    claudeSessionId: s.claudeSessionId,
+    cwd: s.cwd,
+    model: s.model,
+    title: s.title,
+    status: sessions.engine.isActive(s.id) ? 'running' : s.status,
+    turnCount: s.turnCount,
+    lastResult: s.lastResult,
+    costUsd: s.costUsd,
+    lastError: s.lastError,
+    archived: !!s.archived,
+    createdAt: s.createdAt,
+    lastActivityAt: s.lastActivityAt,
+    sshResumeHint: sshHint(s),
+  });
+
+  // One-click passwordless wp-admin login: mint a one-time, 5-min link via the
+  // agent-connector ability already installed in every env. Returns a localhost
+  // URL with the token; callers rebase the host:port (redemption uses the
+  // request host, so the token is host-agnostic).
+  const mintAdminLogin = async (env) => {
+    await assertUsable(env);
+    let res;
+    try {
+      res = await exec(env, 'workspace', ['wp', 'eval', ADMIN_LOGIN_PHP], { timeout: 30_000 });
+    } catch (err) {
+      throw httpErr(502, `could not mint admin login link: ${String(err.stderr || err.message || '').trim().slice(0, 200)}`);
+    }
+    const url = String(res.stdout || '').trim();
+    if (!/^https?:\/\/\S*acfw_login=/.test(url)) {
+      throw httpErr(502, `admin login link unavailable: ${String(res.stderr || url || '').trim().slice(0, 200)}`);
+    }
+    return { loginUrl: url };
+  };
+
+  // Create an environment: compose any selected presets (in order) with optional
+  // custom fields; a single preset with no custom overrides can claim a warm
+  // pre-built env (seconds) instead of building (~10m). Async either way — the
+  // caller polls until `running`. Throws AllocationError on capacity/name issues.
+  const createEnvironment = async (body = {}) => {
+    const presetIds = Array.isArray(body.presetIds) ? body.presetIds : [];
+    const selected = presetIds.map((pid) => {
+      const p = presets.get(pid);
+      if (!p) throw httpErr(400, `unknown preset "${pid}"`);
+      return p;
+    });
+    const custom = normalizeProvision(body.provision);
+    const provision = composeProvision(selected, custom);
+    const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : '';
+    const model = typeof body.model === 'string' && body.model.trim() ? body.model.trim() : undefined;
+    const agent = AGENTS[body.agent] ? body.agent : undefined; // first-prompt session agent; else default
+
+    if (presetIds.length === 1 && !custom) {
+      const claimed = await manager.claimAndStart(presetIds[0], { name: body.name, prompt: prompt || undefined, model, agent });
+      if (claimed) {
+        return { id: claimed.id, name: claimed.name, port: claimed.port, appPorts: claimed.appPorts ?? [], wpUrl: claimed.wpUrl, status: 'configuring', warm: true };
+      }
+    }
+
+    const record = await manager.createEnvironment({ name: body.name, provision, prompt: prompt || undefined, model, agent });
+    return { id: record.id, name: record.name, port: record.port, appPorts: record.appPorts ?? [], wpUrl: record.wpUrl, status: record.status, warm: false };
+  };
+
+  return {
+    envByRef,
+    sessionByRef,
+    assertUsable,
+    deleteSession,
+    destroyEnvironment,
+    publicSession,
+    mintAdminLogin,
+    createEnvironment,
+  };
+}

--- a/create-katalystwp/server/src/routes.js
+++ b/create-katalystwp/server/src/routes.js
@@ -2,7 +2,6 @@
 // also used by the MCP endpoint) or the manager/session engine directly, shape
 // the response. `sessions` bundles { store, engine, bus }.
 
-import { readFile } from 'node:fs/promises';
 import { route } from './http.js';
 import { addSecrets } from './log.js';
 import { systemHealth } from './health.js';
@@ -202,17 +201,18 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
       ctx.send(200, publicSession(updated));
     }),
 
+    // partials: 'all' (default, raw log) | 'live' (only the token deltas that
+    // rebuild the in-progress line — what the UI uses) | 'none'.
+    // clip: truncate any single string inside an event to N chars (0 = off,
+    // the default) — giant tool_results (screenshots, whole files) can be
+    // 1MB+ each. The UI passes both; defaults keep the raw-log behavior.
     route('GET', '/sessions/:id/transcript', async (ctx) => {
       const s = sessionOr404(ctx);
       const tail = Math.min(parseInt(ctx.query.get('tail') || '2000', 10) || 2000, 20000);
-      let events = [];
-      try {
-        const text = await readFile(s.eventLogPath, 'utf8');
-        events = text.split('\n').filter(Boolean).slice(-tail).map((l) => {
-          try { return JSON.parse(l); } catch { return { type: 'raw', text: l }; }
-        });
-      } catch { /* no log yet */ }
-      ctx.send(200, { events });
+      const p = ctx.query.get('partials');
+      const partials = p === 'live' || p === 'none' ? p : 'all';
+      const clip = Math.max(0, Math.min(parseInt(ctx.query.get('clip') || '0', 10) || 0, 1 << 20));
+      ctx.send(200, await ops.readTranscript(s, { tail, partials, clip }));
     }),
 
     route('GET', '/sessions/:id/stream', async (ctx) => {

--- a/create-katalystwp/server/src/routes.js
+++ b/create-katalystwp/server/src/routes.js
@@ -67,8 +67,9 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
       const tail = Math.min(parseInt(ctx.query.get('tail') || '200', 10) || 200, 5000);
       ctx.send(200, await manager.logs(envOr404(ctx), which, tail));
     }),
-    // One-click passwordless wp-admin login (see ops.mintAdminLogin). The UI
-    // rebases the returned localhost URL's host:port.
+    // One-click passwordless wp-admin login (see ops.mintAdminLogin). Returns
+    // http://<DEVBOX_PUBLIC_HOST>:<envPort>/?acfw_login=… — directly openable;
+    // the UI still rebases host:port onto its own hostname before opening.
     route('POST', '/environments/:id/admin-login', async (ctx) => {
       ctx.send(200, await ops.mintAdminLogin(envOr404(ctx)));
     }),

--- a/create-katalystwp/server/src/routes.js
+++ b/create-katalystwp/server/src/routes.js
@@ -1,65 +1,24 @@
-// Endpoint handlers — thin: validate input, call the manager/session engine,
-// shape the response. `sessions` bundles { store, engine, bus }.
+// Endpoint handlers — thin: validate input, call the shared ops layer (ops.js,
+// also used by the MCP endpoint) or the manager/session engine directly, shape
+// the response. `sessions` bundles { store, engine, bus }.
 
-import { readFile, rm } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { route } from './http.js';
 import { addSecrets } from './log.js';
-import { exec } from './docker.js';
 import { systemHealth } from './health.js';
 import { AGENTS } from './claude.js';
 import { AllocationError } from './allocator.js';
 import { composeProvision } from './provision.js';
+import { httpErr, validatePreset } from './ops.js';
 import { openSse } from './sse.js';
 import { makeStaticHandler } from './static.js';
 
-export function buildRoutes(config, registry, manager, sessions, presets, settings) {
+export function buildRoutes(config, registry, manager, sessions, presets, settings, ops) {
   const staticHandler = makeStaticHandler(config.uiRoot);
 
-  const envOr404 = (ctx) => {
-    const rec = registry.get(ctx.params.id) || registry.getByName(ctx.params.id);
-    if (!rec) throw httpErr(404, `environment "${ctx.params.id}" not found`);
-    return rec;
-  };
-  const sessionOr404 = (ctx) => {
-    const s = sessions.store.get(ctx.params.id);
-    if (!s) throw httpErr(404, `session "${ctx.params.id}" not found`);
-    return s;
-  };
-  const assertUsable = async (env) => {
-    if (!(await manager.usable(env))) throw httpErr(409, `environment "${env.name}" is not running`);
-  };
-  // Fully remove a session: stop any active turn, drop its event stream + log
-  // file, and delete the record. Used by DELETE /sessions/:id and env destroy.
-  const deleteSession = async (s) => {
-    sessions.engine.interrupt(s.id);
-    sessions.bus.clear(s.id);
-    await sessions.store.remove(s.id);
-    if (s.eventLogPath) await rm(s.eventLogPath, { force: true }).catch(() => {});
-  };
-  const sshHint = (s) => {
-    const env = registry.get(s.envId);
-    if (!env || !s.claudeSessionId) return null;
-    return (AGENTS[s.agent] || AGENTS.claude).resumeHint(env.dir, s.claudeSessionId);
-  };
-  const publicSession = (s) => ({
-    id: s.id,
-    envId: s.envId,
-    envName: s.envName,
-    agent: s.agent || 'claude',
-    claudeSessionId: s.claudeSessionId,
-    cwd: s.cwd,
-    model: s.model,
-    title: s.title,
-    status: sessions.engine.isActive(s.id) ? 'running' : s.status,
-    turnCount: s.turnCount,
-    lastResult: s.lastResult,
-    costUsd: s.costUsd,
-    lastError: s.lastError,
-    archived: !!s.archived,
-    createdAt: s.createdAt,
-    lastActivityAt: s.lastActivityAt,
-    sshResumeHint: sshHint(s),
-  });
+  const envOr404 = (ctx) => ops.envByRef(ctx.params.id);
+  const sessionOr404 = (ctx) => ops.sessionByRef(ctx.params.id);
+  const { assertUsable, publicSession } = ops;
 
   return [
     route('GET', '/health', async (ctx) => ctx.send(200, { ok: true, version: 1 })),
@@ -95,31 +54,8 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
     // ---- environments -----------------------------------------------------
     route('POST', '/environments', async (ctx) => {
       try {
-        // Compose any selected presets (in order) with optional custom fields.
-        const presetIds = Array.isArray(ctx.body.presetIds) ? ctx.body.presetIds : [];
-        const selected = presetIds.map((pid) => {
-          const p = presets.get(pid);
-          if (!p) throw httpErr(400, `unknown preset "${pid}"`);
-          return p;
-        });
-        const custom = normalizeProvision(ctx.body.provision);
-        const provision = composeProvision(selected, custom);
-        const prompt = typeof ctx.body.prompt === 'string' ? ctx.body.prompt.trim() : '';
-        const model = typeof ctx.body.model === 'string' && ctx.body.model.trim() ? ctx.body.model.trim() : undefined;
-        const agent = AGENTS[ctx.body.agent] ? ctx.body.agent : undefined; // first-prompt session agent; else default
-
-        // Warm-pool fast path: a single preset with no custom overrides can claim
-        // a pre-built env and just start it (seconds) instead of building (~10m).
-        if (presetIds.length === 1 && !custom) {
-          const claimed = await manager.claimAndStart(presetIds[0], { name: ctx.body.name, prompt: prompt || undefined, model, agent });
-          if (claimed) {
-            ctx.send(202, { id: claimed.id, name: claimed.name, port: claimed.port, appPorts: claimed.appPorts ?? [], wpUrl: claimed.wpUrl, status: 'configuring', warm: true });
-            return;
-          }
-        }
-
-        const record = await manager.createEnvironment({ name: ctx.body.name, provision, prompt: prompt || undefined, model, agent });
-        ctx.send(202, { id: record.id, name: record.name, port: record.port, appPorts: record.appPorts ?? [], wpUrl: record.wpUrl, status: record.status });
+        const { warm, ...created } = await ops.createEnvironment(ctx.body);
+        ctx.send(202, warm ? { ...created, warm } : created);
       } catch (err) {
         if (err instanceof AllocationError) throw httpErr(err.status, err.message);
         throw err;
@@ -132,24 +68,10 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
       const tail = Math.min(parseInt(ctx.query.get('tail') || '200', 10) || 200, 5000);
       ctx.send(200, await manager.logs(envOr404(ctx), which, tail));
     }),
-    // One-click passwordless wp-admin login: mint a one-time, 5-min link via the
-    // agent-connector ability already installed in every env. Returns a localhost
-    // URL with the token; the UI rebases the host:port (redemption uses the
-    // browser's request host, so the token is host-agnostic).
+    // One-click passwordless wp-admin login (see ops.mintAdminLogin). The UI
+    // rebases the returned localhost URL's host:port.
     route('POST', '/environments/:id/admin-login', async (ctx) => {
-      const env = envOr404(ctx);
-      await assertUsable(env);
-      let res;
-      try {
-        res = await exec(env, 'workspace', ['wp', 'eval', ADMIN_LOGIN_PHP], { timeout: 30_000 });
-      } catch (err) {
-        throw httpErr(502, `could not mint admin login link: ${String(err.stderr || err.message || '').trim().slice(0, 200)}`);
-      }
-      const url = String(res.stdout || '').trim();
-      if (!/^https?:\/\/\S*acfw_login=/.test(url)) {
-        throw httpErr(502, `admin login link unavailable: ${String(res.stderr || url || '').trim().slice(0, 200)}`);
-      }
-      ctx.send(200, { loginUrl: url });
+      ctx.send(200, await ops.mintAdminLogin(envOr404(ctx)));
     }),
     route('POST', '/environments/:id/stop', async (ctx) => ctx.send(200, await manager.stop(envOr404(ctx)))),
     route('POST', '/environments/:id/start', async (ctx) => {
@@ -170,11 +92,8 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
       ctx.send(200, await manager.describe(updated));
     }),
     route('DELETE', '/environments/:id', async (ctx) => {
-      const env = envOr404(ctx);
       // Sessions are tied to their environment: destroying it deletes them all.
-      sessions.engine.killEnvSessions(env.id);
-      for (const s of sessions.store.listByEnv(env.id)) await deleteSession(s);
-      await manager.destroy(env);
+      await ops.destroyEnvironment(envOr404(ctx));
       ctx.send(200, { deleted: true });
     }),
 
@@ -312,7 +231,7 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
     }),
 
     route('DELETE', '/sessions/:id', async (ctx) => {
-      await deleteSession(sessionOr404(ctx));
+      await ops.deleteSession(sessionOr404(ctx));
       ctx.send(200, { deleted: true });
     }),
 
@@ -320,82 +239,6 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
     route('GET', '/', staticHandler, { kind: 'static' }),
     route('GET', '/ui/:rest*', staticHandler, { kind: 'static' }),
   ];
-}
-
-function httpErr(status, message) {
-  const e = new Error(message);
-  e.status = status;
-  return e;
-}
-
-// Run inside the workspace via `wp eval`: mint a one-time admin login URL for the
-// site's first administrator through the agent-connector ability's service. The
-// FQCN is the same whether the companion ships as default- or universal-abilities.
-const ADMIN_LOGIN_PHP = `
-$admins = get_users(array('role' => 'administrator', 'number' => 1, 'orderby' => 'ID'));
-$u = $admins ? $admins[0] : null;
-if (!$u) { fwrite(STDERR, 'no administrator user'); exit(1); }
-$cls = 'AgentConnectorForWp\\DefaultAbilities\\Services\\AdminLoginLink';
-if (!class_exists($cls)) { fwrite(STDERR, 'abilities plugin (admin login) not active'); exit(1); }
-$r = $cls::create($u->ID, 'index.php', 300);
-if (is_wp_error($r)) { fwrite(STDERR, $r->get_error_message()); exit(1); }
-echo $r['login_url'];
-`;
-
-const SLUG_RE = /^[a-z0-9][a-z0-9._-]*$/i; // plugin slug
-const CONST_RE = /^[A-Za-z_][A-Za-z0-9_]*$/; // PHP constant name
-
-// Validate the activate list + defines map shared by provision and presets.
-// Throws 400 on a bad slug / constant name / defines shape.
-function validateProvisionFields(body = {}) {
-  const setupScript = typeof body.setupScript === 'string' ? body.setupScript : '';
-  const devScript = typeof body.devScript === 'string' ? body.devScript : '';
-
-  let activate = [];
-  if (body.activate != null) {
-    if (!Array.isArray(body.activate)) throw httpErr(400, 'activate must be an array of plugin slugs');
-    activate = body.activate.filter((s) => typeof s === 'string' && s.trim()).map((s) => s.trim());
-    for (const s of activate) if (!SLUG_RE.test(s)) throw httpErr(400, `invalid plugin slug "${s}"`);
-  }
-
-  let defines = {};
-  if (body.defines != null) {
-    if (typeof body.defines !== 'object' || Array.isArray(body.defines)) {
-      throw httpErr(400, 'defines must be a JSON object of { "WP_CONST": value } pairs');
-    }
-    defines = body.defines;
-    for (const k of Object.keys(defines)) if (!CONST_RE.test(k)) throw httpErr(400, `invalid define name "${k}"`);
-  }
-
-  // Container ports to publish per env (each gets a unique host port from the
-  // allocator), e.g. [3000] for a Next.js dev server.
-  let appPorts = [];
-  if (body.appPorts != null) {
-    if (!Array.isArray(body.appPorts)) throw httpErr(400, 'appPorts must be an array of container ports, e.g. [3000]');
-    appPorts = body.appPorts.map((p) => parseInt(p, 10));
-    for (const p of appPorts) {
-      if (!Number.isInteger(p) || p < 1 || p > 65535) throw httpErr(400, `invalid app port "${p}" — expected an integer 1-65535`);
-    }
-    appPorts = [...new Set(appPorts)];
-  }
-
-  return { setupScript, devScript, activate, defines, appPorts };
-}
-
-// A preset additionally carries name/description.
-function validatePreset(body = {}) {
-  const name = String((body && body.name) || '').trim();
-  if (!name) throw httpErr(400, 'preset name is required');
-  return { name, description: typeof body.description === 'string' ? body.description : '', ...validateProvisionFields(body) };
-}
-
-// Custom (ad-hoc) provision fields for a create. Returns null when nothing was
-// specified (a blank WordPress env, or presets-only).
-function normalizeProvision(body) {
-  if (!body || typeof body !== 'object') return null;
-  const { setupScript, devScript, activate, defines, appPorts } = validateProvisionFields(body);
-  if (!setupScript && !devScript && !activate.length && !Object.keys(defines).length && !appPorts.length) return null;
-  return { setupScript, devScript, activate, defines, appPorts };
 }
 
 // composeProvision lives in provision.js (shared with the warm-pool builder in

--- a/create-katalystwp/server/src/status.js
+++ b/create-katalystwp/server/src/status.js
@@ -42,7 +42,7 @@ export function computeStatus({ record, jobState, ps }) {
 }
 
 // Public-facing view of an environment (no secrets).
-export function publicView(record, { status }) {
+export function publicView(record, { status, publicHost }) {
   return {
     id: record.id,
     name: record.name,
@@ -56,7 +56,11 @@ export function publicView(record, { status }) {
     // Host-published dev-server ports ({ host, container }) — the UI links them
     // like `port`, rebased on the browser's hostname.
     appPorts: record.appPorts ?? [],
-    wpUrl: record.wpUrl,
+    // Built from DEVBOX_PUBLIC_HOST at view time (not the stored record, which
+    // predates any host config change) so remote clients get a directly
+    // openable URL, not http://localhost:<port> (issue #74). Plain http until
+    // env sites are proxied too (TLS phase 2, issue #73).
+    wpUrl: `http://${publicHost || 'localhost'}:${record.port}`,
     status,
     preset: record.preset || null,
     createdAt: record.createdAt,

--- a/create-katalystwp/server/ui/app.js
+++ b/create-katalystwp/server/ui/app.js
@@ -867,6 +867,7 @@ function SettingsModal({ onClose, onLogout }) {
             <input value=${wpEmail} onInput=${(e) => setWpEmail(e.target.value)} />
           </label>
           <p class="muted small">Token changes apply to newly-created environments and new Claude turns. WP-admin defaults seed new sites.</p>`}
+        <${McpConnect} />
         <${WarmPoolSection} />
         ${err && html`<div class="err-msg">${err}</div>`}
         ${saved && html`<div class="ok-msg">Saved.</div>`}
@@ -877,6 +878,24 @@ function SettingsModal({ onClose, onLogout }) {
           <button class="btn" onClick=${save} disabled=${!s || busy}>${busy ? 'Saving…' : 'Save'}</button>
         </div>
       </div>
+    </div>`;
+}
+
+// Copy-paste command to attach a local MCP client (Claude Code) to this
+// server's /mcp endpoint. Assembled entirely client-side: host = the origin
+// this page was loaded from, token = the API token this browser is already
+// authed with (from localStorage — the server never returns it).
+function McpConnect() {
+  const t = token.get();
+  const cmd = `claude mcp add --transport http katalyst ${location.origin}/mcp`
+    + (t ? ` --header "Authorization: Bearer ${t}"` : '');
+  return html`
+    <div class="mcpconnect">
+      <h4>Connect an agent (MCP)</h4>
+      <p class="muted small">Run this on your machine to let Claude Code drive this server — create environments,
+        run agent sessions, mint admin logins. Any MCP client works (Streamable HTTP endpoint at <code>/mcp</code>).
+        The command includes this browser's API token — treat it like a password.</p>
+      <${CopyLine} cmd=${cmd} />
     </div>`;
 }
 

--- a/create-katalystwp/server/ui/app.js
+++ b/create-katalystwp/server/ui/app.js
@@ -27,6 +27,10 @@ const streamUrl = (id) => {
   const t = token.get();
   return `/sessions/${id}/stream${t ? `?access_token=${encodeURIComponent(t)}` : ''}`;
 };
+// Env sites (WP + app ports) are plain HTTP even when the control plane is
+// served over TLS — always link them http:// until they're proxied too
+// (TLS phase 2, issue #73). location.protocol would mint dead https links.
+const envSiteUrl = (port, query = '') => `http://${location.hostname}:${port}/${query}`;
 
 // ---- stream-json → transcript items --------------------------------------
 function reduce(items, partialRef, evt) {
@@ -88,14 +92,14 @@ function EnvRow({ env, onAction }) {
   // Link to the WP site on the SAME host the UI was loaded from (not the
   // server's localhost wpUrl) — so it works from a phone/laptop hitting the
   // server's IP, and still works from inside the devbox via localhost.
-  const wpUrl = `${location.protocol}//${location.hostname}:${env.port}/`;
+  const wpUrl = envSiteUrl(env.port);
   return html`
     <div class="env">
       <div class="env-top">
         <${StatusDot} status=${env.status} /> <span class="env-name" title=${env.displayName ? `${env.displayName} · ${env.name}` : env.name}>${env.displayName || env.name}</span>
         ${env.preset && html`<span class="badge" title="provisioned from preset">${env.preset}</span>`}
         <a class="env-port" href=${wpUrl} target="_blank" rel="noreferrer" title="Open the site front end" onClick=${(e) => e.stopPropagation()}>:${env.port}</a>
-        ${(env.appPorts || []).map((p) => html`<a class="env-port" href=${`${location.protocol}//${location.hostname}:${p.host}/`} target="_blank" rel="noreferrer" title=${`App port → container :${p.container}`} onClick=${(e) => e.stopPropagation()}>:${p.host}<span class="muted small">→${p.container}</span></a>`)}
+        ${(env.appPorts || []).map((p) => html`<a class="env-port" href=${envSiteUrl(p.host)} target="_blank" rel="noreferrer" title=${`App port → container :${p.container}`} onClick=${(e) => e.stopPropagation()}>:${p.host}<span class="muted small">→${p.container}</span></a>`)}
         ${up && html`<button class="env-admin lnk" title="One-click passwordless wp-admin login" onClick=${(e) => { e.stopPropagation(); onAction('admin-login', env); }}>admin ↗</button>`}
       </div>
       <div class="env-actions">
@@ -1208,7 +1212,7 @@ function App() {
       try {
         const { loginUrl } = await api(`/environments/${env.id}/admin-login`, { method: 'POST' });
         const u = new URL(loginUrl);
-        const dest = `${location.protocol}//${location.hostname}:${env.port}/?${u.searchParams.toString()}`;
+        const dest = envSiteUrl(env.port, `?${u.searchParams.toString()}`);
         if (w) w.location = dest; else window.open(dest, '_blank', 'noopener');
       } catch (e) { if (w) w.close(); alert(`Admin login failed: ${e.message}`); }
       return;

--- a/create-katalystwp/server/ui/app.js
+++ b/create-katalystwp/server/ui/app.js
@@ -222,26 +222,36 @@ function Sidebar({ sessions, envs, selectedId, now, onSelect, onNewEnv, onEnvAct
     </aside>`;
 }
 
+// A single runaway blob (base64 screenshot, whole-file tool payload) can be
+// 1MB+ — clip what lands in the DOM so the transcript stays scrollable. The
+// history fetch is clipped server-side too; this also covers live SSE events.
+function clipText(t, max = 20000) {
+  const s = typeof t === 'string' ? t : String(t ?? '');
+  return s.length > max ? `${s.slice(0, max)}\n…[+${(s.length - max).toLocaleString()} chars clipped]` : s;
+}
+
 function Bubble({ it }) {
-  if (it.kind === 'user') return html`<div class="bubble user"><pre>${it.text}</pre></div>`;
-  if (it.kind === 'assistant') return html`<div class="bubble assistant"><pre>${it.text}</pre></div>`;
+  if (it.kind === 'user') return html`<div class="bubble user"><pre>${clipText(it.text)}</pre></div>`;
+  if (it.kind === 'assistant') return html`<div class="bubble assistant"><pre>${clipText(it.text)}</pre></div>`;
   if (it.kind === 'system') return html`<div class="chip">${it.text}</div>`;
   if (it.kind === 'control') return html`<div class="divider">${it.text}</div>`;
   if (it.kind === 'tool_use')
-    return html`<details class="tool"><summary>🔧 ${it.name}</summary><pre>${JSON.stringify(it.input, null, 2)}</pre></details>`;
+    return html`<details class="tool"><summary>🔧 ${it.name}</summary><pre>${clipText(JSON.stringify(it.input, null, 2))}</pre></details>`;
   if (it.kind === 'tool_result') {
     const text = typeof it.content === 'string' ? it.content : JSON.stringify(it.content, null, 2);
-    return html`<details class="tool result"><summary>↳ result</summary><pre>${text}</pre></details>`;
+    return html`<details class="tool result"><summary>↳ result</summary><pre>${clipText(text)}</pre></details>`;
   }
   if (it.kind === 'result')
     return html`<div class="result-foot ${it.isError ? 'err' : ''}">✓ done · $${(it.cost || 0).toFixed(4)} · ${Math.round((it.ms || 0))}ms</div>`;
-  if (it.kind === 'stderr') return html`<div class="stderr"><pre>${it.text}</pre></div>`;
-  return html`<div class="raw"><pre>${it.text}</pre></div>`;
+  if (it.kind === 'stderr') return html`<div class="stderr"><pre>${clipText(it.text)}</pre></div>`;
+  return html`<div class="raw"><pre>${clipText(it.text)}</pre></div>`;
 }
 
 function SessionView({ session, now, onChanged, onBack, onDelete, onArchive, onRestore }) {
   const [items, setItems] = useState([]);
   const [partial, setPartial] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [loadErr, setLoadErr] = useState('');
   const [busy, setBusy] = useState(false);
   const [input, setInput] = useState('');
   const [editing, setEditing] = useState(false);
@@ -255,18 +265,25 @@ function SessionView({ session, now, onChanged, onBack, onDelete, onArchive, onR
 
   useEffect(() => {
     // Reset for the newly-selected session, load history, then go live.
-    setItems([]); setPartial(''); partialRef.current = { text: '' }; seen.current = new Set();
+    setItems([]); setPartial(''); setLoading(true); setLoadErr('');
+    partialRef.current = { text: '' }; seen.current = new Set();
     stick.current = true; setHasNew(false);
     let es;
     let cancelled = false;
     (async () => {
       try {
-        const { events } = await api(`/sessions/${id}/transcript?tail=5000`);
+        // partials=live: skip token deltas of completed messages (they're
+        // superseded by their assistant events and dominate a long turn's
+        // payload) — the server keeps just the tail that rebuilds the
+        // in-progress line. A missing log is a 200 with events:[] — a catch
+        // here is a real failure, so show it instead of a blank transcript.
+        const { events } = await api(`/sessions/${id}/transcript?tail=5000&partials=live&clip=16384`);
         const arr = [];
         for (const e of events) { if (e.uuid) seen.current.add(e.uuid); reduce(arr, partialRef.current, e); }
         if (!cancelled) { setItems(arr.slice()); setPartial(partialRef.current.text); }
-      } catch { /* fresh session, no transcript */ }
+      } catch (e) { if (!cancelled) setLoadErr(e.message || 'failed to load history'); }
       if (cancelled) return;
+      setLoading(false);
       es = new EventSource(streamUrl(id));
       es.onmessage = (m) => {
         let evt; try { evt = JSON.parse(m.data); } catch { return; }
@@ -354,9 +371,11 @@ function SessionView({ session, now, onChanged, onBack, onDelete, onArchive, onR
       </header>
       ${session.sshResumeHint && html`<div class="ssh muted" onClick=${() => copyText(session.sshResumeHint)} title="click to copy">SSH resume: <code>${session.sshResumeHint}</code></div>`}
       <div class="transcript" ref=${scroller} onScroll=${onTranscriptScroll}>
+        ${loading && !loadErr && html`<div class="muted pad">loading history…</div>`}
+        ${loadErr && html`<div class="err-msg">could not load history: ${loadErr}</div>`}
         ${items.map((it, i) => html`<${Bubble} it=${it} key=${i} />`)}
         ${partial && html`<div class="bubble assistant live"><pre>${partial}</pre><span class="cursor">▍</span></div>`}
-        ${running && !partial && html`<div class="muted pad">…thinking</div>`}
+        ${running && !partial && !loading && html`<div class="muted pad">…thinking</div>`}
       </div>
       ${hasNew && html`<button class="new-msgs" onClick=${jumpToBottom}>↓ New messages</button>`}
       <footer class="composer">

--- a/create-katalystwp/server/ui/style.css
+++ b/create-katalystwp/server/ui/style.css
@@ -166,6 +166,10 @@ pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12.5px/1.5
   overflow-x: auto; white-space: pre; }
 .copyline .btn { flex: none; }
 
+/* MCP connect (Settings) */
+.mcpconnect { margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--line); }
+.mcpconnect h4 { margin: 0 0 4px; font-size: 13px; }
+
 /* warm pool (Settings) */
 .warmpool { margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--line); }
 .warmpool h4 { margin: 0 0 4px; font-size: 13px; }


### PR DESCRIPTION
## What

Adds an **MCP server** to the devbox control server: `POST /mcp` speaking the MCP Streamable HTTP transport (stateless JSON-RPC 2.0, hand-rolled — the server stays zero-dependency). Any MCP client (Claude Code, Cursor, claude.ai) can now drive everything the browser UI can:

```bash
claude mcp add --transport http katalyst http://<host>:4000/mcp \
  --header "Authorization: Bearer $DEVBOX_API_TOKEN"
```

## How

- **`src/mcp.js`** — JSON-RPC dispatcher + a single `TOOLS` table of 32 tools mirroring the JSON API: environments (create/wait/logs/start/stop/destroy/label/admin-login), presets CRUD, warm pool, host health, control, and full agent-session driving (`start_session` → `wait_for_turn` → `send_message`, plus list/get/transcript/interrupt/rename/archive/restore/delete).
  - `wait_for_environment` / `wait_for_turn` poll **server-side** so driving agents never hand-roll poll loops; `wait_for_turn` returns `lastResult` (the agent's final answer).
  - `get_transcript` strips `stream_event` token deltas by default.
  - **Self-syncing docs**: `tools/list`, the `initialize.instructions` guide, and the `get_instructions` tool are all generated from the same `TOOLS` table — agent-facing docs cannot drift from the callable surface.
- **`src/ops.js`** — shared ops layer extracted from `routes.js` (env lookup, env-create composition incl. the warm-pool fast path, admin-login mint, session shaping, validation). Both surfaces call one implementation; this also collapses the server's `ADMIN_LOGIN_PHP` handling into one module.
- **Auth** — same bearer token as the JSON API, enforced by the existing `http.js` layer. Deliberately **not** exposed over MCP: settings writes (credential rotation) and `/control/shutdown`.
- Docs: README MCP section + AGENT_USAGE pointer.

## Testing

- Scratch instance: initialize (protocol 2025-06-18), `notifications/initialized` → 202, `tools/list`, `tools/call` with `structuredContent` + `isError` shaping, 401 without token, −32601 for undeclared methods, 405 on GET/DELETE `/mcp`.
- Real client: `claude mcp add` + `claude mcp list` → ✔ Connected.
- HTTP routes regression-checked after the ops extraction (health, env create validation, presets validation, pool, sessions, UI shell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
