### PR TITLE
feat(server): organize environments — tags, search, and group-by

### DIFF
--- a/create-katalystwp/server/AGENT_USAGE.md
+++ b/create-katalystwp/server/AGENT_USAGE.md
@@ -75,6 +75,7 @@ running. If you pass `presetIds`, fetch the available ones from `GET /presets`.
 | `GET /environments/:id/logs?which=setup&tail=N` | Setup log (`tail` defaults 200, max 5000). |
 | `POST /environments/:id/admin-login` | Mint a **one-time, 5-min, passwordless** wp-admin login URL → `{loginUrl}`. |
 | `POST /environments/:id/duplicate` | Clone the env: full data copy (DB, files, plugins, checkouts) on a fresh name + port. Body: `{name?, prompt?, model?, agent?}`. → `202`; poll the **copy** until `running`. The source briefly stops during the copy (status `duplicating`), then restarts. Sessions don't carry over. |
+| `PATCH /environments/:id` | Update list metadata: `{displayName?, tags?}`. `displayName` is the list label (blank resets to the canonical name); `tags` is a full-replacement array of short labels for organizing/filtering (lowercased + deduped server-side, `[]` clears). Only fields present are touched. |
 | `POST /environments/:id/stop` | Stop the containers (data preserved). → `status:"stopped"`. |
 | `POST /environments/:id/start` | Bring a stopped env back up. → `status:"running"`. |
 | `DELETE /environments/:id` | Destroy: stop, remove containers, delete the dir; cascades to its sessions. |

--- a/create-katalystwp/server/src/mcp.js
+++ b/create-katalystwp/server/src/mcp.js
@@ -16,7 +16,7 @@
 import { route } from './http.js';
 import { systemHealth } from './health.js';
 import { AGENTS } from './claude.js';
-import { httpErr, validatePreset } from './ops.js';
+import { httpErr, validatePreset, normalizeTags } from './ops.js';
 
 const LATEST_PROTOCOL = '2025-06-18';
 const KNOWN_PROTOCOLS = new Set(['2025-06-18', '2025-03-26', '2024-11-05']);
@@ -179,6 +179,19 @@ export function buildMcpRoutes(config, registry, manager, sessions, presets, set
         const rec = ops.envByRef(env);
         const clean = String(label ?? '').replace(/\s+/g, ' ').trim();
         return manager.describe(await registry.update(rec.id, { displayName: clean ? clean.slice(0, 80) : null }));
+      },
+    },
+    {
+      name: 'set_environment_tags',
+      category: 'Environments',
+      description: 'Replace an environment\'s tags — short lowercase labels for organizing and filtering the env list (e.g. ["breakdance", "repro"]). Full replacement: pass the complete list; an empty array clears all tags. Tags are normalized (lowercased, deduped, max 20 of ≤32 chars).',
+      inputSchema: args({
+        env: ENV_ARG,
+        tags: { type: 'array', items: { type: 'string' }, description: 'The complete tag list to set.' },
+      }, ['env', 'tags']),
+      handler: async ({ env, tags }) => {
+        const rec = ops.envByRef(env);
+        return manager.describe(await registry.update(rec.id, { tags: normalizeTags(tags) }));
       },
     },
     {

--- a/create-katalystwp/server/src/ops.js
+++ b/create-katalystwp/server/src/ops.js
@@ -42,6 +42,20 @@ if (is_wp_error($r)) { fwrite(STDERR, $r->get_error_message()); exit(1); }
 echo $r['login_url'];
 `;
 
+// Normalize a user-supplied tag list (env organization labels): strings only,
+// whitespace-collapsed, lowercased, deduped, capped. Throws 400 on a non-array.
+// Shared by the HTTP PATCH route and the MCP tool so the rules can't drift.
+export function normalizeTags(input) {
+  if (!Array.isArray(input)) throw httpErr(400, 'tags must be an array of strings');
+  const out = [];
+  for (const t of input) {
+    if (typeof t !== 'string') continue;
+    const clean = t.replace(/\s+/g, ' ').trim().toLowerCase().slice(0, 32);
+    if (clean && !out.includes(clean)) out.push(clean);
+  }
+  return out.slice(0, 20);
+}
+
 const SLUG_RE = /^[a-z0-9][a-z0-9._-]*$/i; // plugin slug
 const CONST_RE = /^[A-Za-z_][A-Za-z0-9_]*$/; // PHP constant name
 

--- a/create-katalystwp/server/src/routes.js
+++ b/create-katalystwp/server/src/routes.js
@@ -8,7 +8,7 @@ import { systemHealth } from './health.js';
 import { AGENTS } from './claude.js';
 import { AllocationError } from './allocator.js';
 import { composeProvision } from './provision.js';
-import { httpErr, validatePreset } from './ops.js';
+import { httpErr, validatePreset, normalizeTags } from './ops.js';
 import { openSse } from './sse.js';
 import { makeStaticHandler } from './static.js';
 
@@ -94,12 +94,19 @@ export function buildRoutes(config, registry, manager, sessions, presets, settin
       }
     }),
 
-    // Rename the list label only — canonical name/dir/compose project are untouched.
-    // Blank resets to the canonical name (displayName -> null).
+    // Update list metadata: displayName (blank resets to the canonical name)
+    // and/or tags (full replacement; [] clears). Only fields present in the
+    // body are touched — canonical name/dir/compose project never change.
     route('PATCH', '/environments/:id', async (ctx) => {
       const env = envOr404(ctx);
-      const label = String(ctx.body.displayName ?? '').replace(/\s+/g, ' ').trim();
-      const updated = await registry.update(env.id, { displayName: label ? label.slice(0, 80) : null });
+      const patch = {};
+      if ('displayName' in ctx.body) {
+        const label = String(ctx.body.displayName ?? '').replace(/\s+/g, ' ').trim();
+        patch.displayName = label ? label.slice(0, 80) : null;
+      }
+      if ('tags' in ctx.body) patch.tags = normalizeTags(ctx.body.tags);
+      if (!Object.keys(patch).length) throw httpErr(400, 'nothing to update — pass displayName and/or tags');
+      const updated = await registry.update(env.id, patch);
       ctx.send(200, await manager.describe(updated));
     }),
     route('DELETE', '/environments/:id', async (ctx) => {

--- a/create-katalystwp/server/src/status.js
+++ b/create-katalystwp/server/src/status.js
@@ -67,6 +67,8 @@ export function publicView(record, { status, publicHost }) {
     wpUrl: `${record.scheme === 'https' ? 'https' : 'http'}://${publicHost || 'localhost'}:${record.port}`,
     status,
     preset: record.preset || null,
+    // User-set organization labels (normalizeTags in ops.js); [] when unset.
+    tags: record.tags ?? [],
     createdAt: record.createdAt,
     setupStartedAt: record.setupStartedAt,
     lastError: record.lastError,

--- a/create-katalystwp/server/ui/app.js
+++ b/create-katalystwp/server/ui/app.js
@@ -91,7 +91,7 @@ function StatusDot({ status }) {
 
 const TRANSIENT_ENV = ['scaffolding', 'setting-up', 'configuring', 'destroying', 'duplicating'];
 
-function EnvRow({ env, onAction }) {
+function EnvRow({ env, onAction, onTag }) {
   const building = TRANSIENT_ENV.includes(env.status);
   const up = env.status === 'running' || env.status === 'degraded';
   // Link to the WP site on the SAME host the UI was loaded from (not the
@@ -103,6 +103,7 @@ function EnvRow({ env, onAction }) {
       <div class="env-top">
         <${StatusDot} status=${env.status} /> <span class="env-name" title=${env.displayName ? `${env.displayName} · ${env.name}` : env.name}>${env.displayName || env.name}</span>
         ${env.preset && html`<span class="badge" title="provisioned from preset">${env.preset}</span>`}
+        ${(env.tags || []).map((t) => html`<button class="tag-chip" key=${t} title=${`Filter by tag "${t}"`} onClick=${(e) => { e.stopPropagation(); onTag && onTag(t); }}>#${t}</button>`)}
         <a class="env-port" href=${wpUrl} target="_blank" rel="noreferrer" title="Open the site front end" onClick=${(e) => e.stopPropagation()}>:${env.port}</a>
         ${(env.appPorts || []).map((p) => html`<a class="env-port" href=${envSiteUrl(env, p.host)} target="_blank" rel="noreferrer" title=${`App port → container :${p.container}`} onClick=${(e) => e.stopPropagation()}>:${p.host}<span class="muted small">→${p.container}</span></a>`)}
         ${up && html`<button class="env-admin lnk" title="One-click passwordless wp-admin login" onClick=${(e) => { e.stopPropagation(); onAction('admin-login', env); }}>admin ↗</button>`}
@@ -157,10 +158,63 @@ function Sidebar({ sessions, envs, selectedId, now, onSelect, onNewEnv, onEnvAct
   // Declutter long lists: stopped envs (data intact, just parked) are hidden by
   // default. "Active" = anything not stopped (running/degraded/building/failed).
   const [filter, setFilter] = useState('active');
+  // Free-text filter across name/displayName/preset/tags, and a grouping mode
+  // (persisted — it's a lasting preference, unlike the transient search).
+  const [query, setQuery] = useState('');
+  const [groupBy, setGroupBy] = useState(() => { try { return localStorage.getItem('devbox_env_groupby') || 'none'; } catch { return 'none'; } });
+  const pickGroupBy = (g) => { setGroupBy(g); try { localStorage.setItem('devbox_env_groupby', g); } catch { /* private mode */ } };
+  const [collapsed, setCollapsed] = useState(() => new Set()); // collapsed group keys
+  const toggleGroup = (k) => setCollapsed((prev) => {
+    const next = new Set(prev);
+    next.has(k) ? next.delete(k) : next.add(k);
+    return next;
+  });
   const activeCount = envs.filter((e) => e.status !== 'stopped').length;
   const stoppedCount = envs.length - activeCount;
-  const shown = envs.filter((e) =>
-    filter === 'all' ? true : filter === 'stopped' ? e.status === 'stopped' : e.status !== 'stopped');
+  const q = query.trim().toLowerCase().replace(/^#/, ''); // "#demo" ≡ "demo"
+  const matchesQuery = (e) => !q
+    || e.name.toLowerCase().includes(q)
+    || (e.displayName || '').toLowerCase().includes(q)
+    || (e.preset || '').toLowerCase().includes(q)
+    || (e.tags || []).some((t) => t.includes(q));
+  // Most-recently-used first: an env's recency is its newest session activity
+  // (fall back to createdAt) — so "the one I touched last week" floats up
+  // through a wall of stopped envs.
+  const lastTouched = {};
+  for (const s of sessions) {
+    const t = String(s.lastActivityAt || '');
+    if (t > (lastTouched[s.envId] || '')) lastTouched[s.envId] = t;
+  }
+  const recency = (e) => lastTouched[e.id] || String(e.createdAt || '');
+  const shown = envs
+    .filter((e) => (filter === 'all' ? true : filter === 'stopped' ? e.status === 'stopped' : e.status !== 'stopped'))
+    .filter(matchesQuery)
+    .sort((a, b) => recency(b).localeCompare(recency(a)));
+  // Grouping: 'preset' buckets by preset; 'tag' lists an env under EACH of its
+  // tags (untagged last). [key, envs] pairs; key null = flat list, no headers.
+  const groups = (() => {
+    if (groupBy === 'preset') {
+      const m = new Map();
+      for (const e of shown) {
+        const k = e.preset || 'no preset';
+        if (!m.has(k)) m.set(k, []);
+        m.get(k).push(e);
+      }
+      return [...m.entries()].sort(([a], [b]) => (a === 'no preset') - (b === 'no preset') || a.localeCompare(b));
+    }
+    if (groupBy === 'tag') {
+      const m = new Map();
+      for (const e of shown) {
+        const keys = (e.tags && e.tags.length) ? e.tags : ['untagged'];
+        for (const k of keys) {
+          if (!m.has(k)) m.set(k, []);
+          m.get(k).push(e);
+        }
+      }
+      return [...m.entries()].sort(([a], [b]) => (a === 'untagged') - (b === 'untagged') || a.localeCompare(b));
+    }
+    return [[null, shown]];
+  })();
   const toggle = (id) => setExpanded((prev) => {
     const next = new Set(prev);
     next.has(id) ? next.delete(id) : next.add(id);
@@ -192,42 +246,57 @@ function Sidebar({ sessions, envs, selectedId, now, onSelect, onNewEnv, onEnvAct
           <button class=${`seg ${filter === 'stopped' ? 'on' : ''}`} onClick=${() => setFilter('stopped')}>Stopped ${stoppedCount}</button>
           <button class=${`seg ${filter === 'all' ? 'on' : ''}`} onClick=${() => setFilter('all')}>All ${envs.length}</button>
         </div>
+        <div class="env-tools">
+          <input class="env-search" type="search" placeholder="Search name, preset, #tag…" value=${query} onInput=${(e) => setQuery(e.target.value)} />
+          <select class="env-groupby" value=${groupBy} onChange=${(e) => pickGroupBy(e.target.value)} title="Group environments">
+            <option value="none">flat</option>
+            <option value="preset">by preset</option>
+            <option value="tag">by tag</option>
+          </select>
+        </div>
         <div class="side-list">
           ${envs.length === 0 && html`<div class="muted pad small">No environments — create one.</div>`}
-          ${envs.length > 0 && shown.length === 0 && html`<div class="muted pad small">No ${filter} environments.</div>`}
-          ${shown.map((e) => {
-            const envSessions = sessions
-              .filter((s) => s.envId === e.id)
-              .sort((a, b) => String(b.lastActivityAt || '').localeCompare(String(a.lastActivityAt || '')));
-            // Archived sessions are kept but hidden behind a reveal, so a busy env
-            // (20 sessions) can show just the two you're working on.
-            const active = envSessions.filter((s) => !s.archived);
-            const archived = envSessions.filter((s) => s.archived);
-            const open = expanded.has(e.id) || e.id === selEnvId;
-            const showArch = archOpen.has(e.id);
-            const itemProps = { selectedId, now, onSelect, onDelete: onDeleteSession, onArchive: onArchiveSession, onRestore: onRestoreSession };
-            return html`
-              <div class="env-group" key=${e.id}>
-                <${EnvRow} env=${e} onAction=${onEnvAction} />
-                <button class="sess-toggle" onClick=${() => toggle(e.id)}>
-                  <span class="chev">${open ? '▾' : '▸'}</span>
-                  ${active.length} session${active.length === 1 ? '' : 's'}
-                  ${archived.length > 0 && html`<span class="muted small"> · ${archived.length} archived</span>`}
-                </button>
-                ${open && html`
-                  <div class="env-sessions">
-                    ${active.length === 0 && archived.length === 0 && html`<div class="muted pad small no-sess">No sessions yet.</div>`}
-                    ${active.length === 0 && archived.length > 0 && html`<div class="muted pad small no-sess">No active sessions.</div>`}
-                    ${active.map((s) => html`<${SessionItem} ...${itemProps} s=${s} key=${s.id} />`)}
-                    ${archived.length > 0 && html`
-                      <button class="arch-toggle" onClick=${() => toggleArch(e.id)}>
-                        <span class="chev">${showArch ? '▾' : '▸'}</span>
-                        Archived (${archived.length})
-                      </button>`}
-                    ${showArch && archived.map((s) => html`<${SessionItem} ...${itemProps} s=${s} key=${s.id} />`)}
-                  </div>`}
-              </div>`;
-          })}
+          ${envs.length > 0 && shown.length === 0 && html`<div class="muted pad small">${q ? `No matches for “${query.trim()}”.` : `No ${filter} environments.`}</div>`}
+          ${groups.map(([groupKey, groupEnvs]) => html`
+            ${groupKey !== null && html`
+              <button class="group-head" key=${`h:${groupKey}`} onClick=${() => toggleGroup(groupKey)}>
+                <span class="chev">${collapsed.has(groupKey) ? '▸' : '▾'}</span>
+                ${groupBy === 'tag' && groupKey !== 'untagged' ? `#${groupKey}` : groupKey}
+                <span class="muted small">${groupEnvs.length}</span>
+              </button>`}
+            ${(groupKey === null || !collapsed.has(groupKey)) && groupEnvs.map((e) => {
+              const envSessions = sessions
+                .filter((s) => s.envId === e.id)
+                .sort((a, b) => String(b.lastActivityAt || '').localeCompare(String(a.lastActivityAt || '')));
+              // Archived sessions are kept but hidden behind a reveal, so a busy env
+              // (20 sessions) can show just the two you're working on.
+              const active = envSessions.filter((s) => !s.archived);
+              const archived = envSessions.filter((s) => s.archived);
+              const open = expanded.has(e.id) || e.id === selEnvId;
+              const showArch = archOpen.has(e.id);
+              const itemProps = { selectedId, now, onSelect, onDelete: onDeleteSession, onArchive: onArchiveSession, onRestore: onRestoreSession };
+              return html`
+                <div class="env-group" key=${groupKey === null ? e.id : `${groupKey}:${e.id}`}>
+                  <${EnvRow} env=${e} onAction=${onEnvAction} onTag=${setQuery} />
+                  <button class="sess-toggle" onClick=${() => toggle(e.id)}>
+                    <span class="chev">${open ? '▾' : '▸'}</span>
+                    ${active.length} session${active.length === 1 ? '' : 's'}
+                    ${archived.length > 0 && html`<span class="muted small"> · ${archived.length} archived</span>`}
+                  </button>
+                  ${open && html`
+                    <div class="env-sessions">
+                      ${active.length === 0 && archived.length === 0 && html`<div class="muted pad small no-sess">No sessions yet.</div>`}
+                      ${active.length === 0 && archived.length > 0 && html`<div class="muted pad small no-sess">No active sessions.</div>`}
+                      ${active.map((s) => html`<${SessionItem} ...${itemProps} s=${s} key=${s.id} />`)}
+                      ${archived.length > 0 && html`
+                        <button class="arch-toggle" onClick=${() => toggleArch(e.id)}>
+                          <span class="chev">${showArch ? '▾' : '▸'}</span>
+                          Archived (${archived.length})
+                        </button>`}
+                      ${showArch && archived.map((s) => html`<${SessionItem} ...${itemProps} s=${s} key=${s.id} />`)}
+                    </div>`}
+                </div>`;
+            })}`)}
         </div>
       </div>
     </aside>`;
@@ -1046,15 +1115,23 @@ function TokenGate({ onSave }) {
 
 function RenameEnvModal({ env, onClose, onSave }) {
   const [val, setVal] = useState(env.displayName || env.name);
-  const save = () => onSave(env, val.trim());
+  const [tagsText, setTagsText] = useState((env.tags || []).join(', '));
+  // Tags are sent as a full-replacement list; the server lowercases + dedupes.
+  const save = () => onSave(env, val.trim(), tagsText.split(',').map((t) => t.trim()).filter(Boolean));
+  const onKeys = (e) => { if (e.key === 'Enter') save(); if (e.key === 'Escape') onClose(); };
   return html`
     <div class="modal-bg" onClick=${onClose}>
       <div class="modal" onClick=${(e) => e.stopPropagation()}>
-        <h3>Rename environment</h3>
+        <h3>Rename & tag environment</h3>
         <p class="muted small">List label only. The canonical name <code>${env.name}</code> (its directory and Docker project) is unchanged. Leave blank to reset to it.</p>
         <input autofocus value=${val} placeholder=${env.name}
           onInput=${(e) => setVal(e.target.value)}
-          onKeyDown=${(e) => { if (e.key === 'Enter') save(); if (e.key === 'Escape') onClose(); }} />
+          onKeyDown=${onKeys} />
+        <label>Tags <span class="muted small">— comma-separated; used for search and the "by tag" grouping</span>
+          <input value=${tagsText} placeholder="demo, breakdance, client-x"
+            onInput=${(e) => setTagsText(e.target.value)}
+            onKeyDown=${onKeys} />
+        </label>
         <div class="modal-foot">
           <button class="btn ghost" onClick=${onClose}>Cancel</button>
           <button class="btn" onClick=${save}>Save</button>
@@ -1167,9 +1244,9 @@ function App() {
     const s = await api(`/environments/${envId}/sessions`, { method: 'POST', body: JSON.stringify({ prompt, agent, model }) });
     setNewSession(null); await refresh(); setSelectedId(s.id);
   };
-  const renameEnvironment = async (env, displayName) => {
+  const renameEnvironment = async (env, displayName, tags) => {
     try {
-      await api(`/environments/${env.id}`, { method: 'PATCH', body: JSON.stringify({ displayName }) });
+      await api(`/environments/${env.id}`, { method: 'PATCH', body: JSON.stringify({ displayName, tags }) });
       setRenameEnv(null); await refresh();
     } catch (e) { alert(`Rename failed: ${e.message}`); }
   };

--- a/create-katalystwp/server/ui/style.css
+++ b/create-katalystwp/server/ui/style.css
@@ -32,6 +32,24 @@ pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12.5px/1.5
 .env-filter .seg:hover { color: var(--text); }
 .env-filter .seg.on { background: var(--accent); border-color: var(--accent); color: #07101f; font-weight: 600; }
 
+/* search + group-by controls under the filter segs */
+.env-tools { display: flex; gap: 4px; padding: 0 12px 8px; }
+.env-tools .env-search { flex: 1; min-width: 0; background: var(--bg); color: var(--text);
+  border: 1px solid var(--line); border-radius: 6px; padding: 4px 8px; font: inherit; font-size: 12px; }
+.env-tools .env-search::placeholder { color: var(--muted); }
+.env-tools .env-groupby { background: var(--panel2); color: var(--muted); border: 1px solid var(--line);
+  border-radius: 6px; font-size: 11px; padding: 4px; cursor: pointer; }
+.env-tools .env-groupby:hover { color: var(--text); }
+
+/* collapsible group headers (group-by preset/tag) */
+.group-head { display: flex; align-items: center; gap: 6px; width: 100%; background: var(--panel2);
+  border: 0; border-top: 1px solid var(--line); color: var(--text); cursor: pointer;
+  font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .04em;
+  text-align: left; padding: 5px 12px; position: sticky; top: 0; z-index: 1; }
+.group-head:hover { color: var(--accent); }
+.group-head .chev { width: 9px; display: inline-block; }
+.group-head .muted { margin-left: auto; font-weight: 400; text-transform: none; }
+
 /* environment rows */
 .env { padding: 7px 12px; border-top: 1px solid var(--line); }
 .env-top { display: flex; align-items: center; gap: 7px; }
@@ -191,6 +209,10 @@ pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12.5px/1.5
 /* preset badge on an env row */
 .badge { font-size: 10px; text-transform: uppercase; letter-spacing: .03em; color: var(--accent);
   background: var(--accent2); border-radius: 99px; padding: 1px 7px; flex: none; }
+/* user tags on an env row — click filters the list by that tag */
+.tag-chip { font-size: 10px; color: var(--muted); background: var(--panel2);
+  border: 1px solid var(--line); border-radius: 99px; padding: 1px 7px; flex: none; cursor: pointer; }
+.tag-chip:hover { color: var(--accent); border-color: var(--accent); }
 
 /* system health */
 .modal.health { width: 660px; }


### PR DESCRIPTION
Fixes the "wall of stopped environments" problem: ~47 envs with no way to find, group, or label anything.

## What's new

**Tags** — each env can carry short labels (`demo`, `repro`, `client-x`, …). Stored on the registry record, normalized server-side (lowercase, deduped, max 20 × 32 chars). No migration: old records just read as `[]`.

**One metadata PATCH** — `PATCH /environments/:id` now accepts `displayName` and/or `tags`, each optional, only present fields touched. Tags are full-replacement (`[]` clears). The rename modal became "Rename & tag" and submits both in one call.

**MCP** — new `set_environment_tags` tool (same normalize path as HTTP), so agents can label envs they create. Documented in AGENT_USAGE.md.

**Sidebar** —
- **Search box**: matches name, displayName, preset, and tags; `#demo` ≡ `demo`.
- **Group-by**: flat / by preset / by tag (persisted in localStorage). Sticky, collapsible group headers with counts. Under "by tag" an env appears under each of its tags; untagged envs collect in an `untagged` bucket at the end.
- **MRU sort**: envs order by their newest session activity (falling back to createdAt), so the env you touched last week floats to the top of the stopped pile.
- Env rows render clickable `#tag` chips — click one to filter the list by it.

## Notes

- Canonical identity (name / dir / compose project) remains immutable, as with rename.
- Deployed to the box from this branch and verified live: PATCH normalization + validation errors, MCP tool call, grouped/search UI served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wAFFJfN1MJvRqL9YyU3Zw
