### PR TITLE
feat(server): gpt-6-astra + @effort suffix for codex/claude sessions

### DIFF
--- a/create-katalystwp/server/AGENT_USAGE.md
+++ b/create-katalystwp/server/AGENT_USAGE.md
@@ -126,7 +126,7 @@ UI at `/`.
 - **Create is async** — poll until `running`, don't treat the `202` as ready.
 - **One WordPress port per env** is the only host port; returned as `wpUrl`. Inside the env's containers the site is `http://wordpress`.
 - **wp-admin:** `POST /environments/:id/admin-login` returns a one-time passwordless login URL — no need to know the admin password.
-- **Models:** `model` is optional wherever it appears. Omitted, a Claude session runs the server default (the `opus` alias — resolved by Claude Code to the **latest Opus**). Pass any Claude Code alias or id (`sonnet`, `haiku`, `claude-fable-5`, …) to override; the model is fixed for the session's lifetime.
+- **Models:** `model` is optional wherever it appears. Omitted, a Claude session runs the server default (the `opus` alias — resolved by Claude Code to the **latest Opus**). Pass any Claude Code alias or id (`sonnet`, `haiku`, `claude-fable-5`, …) to override; the model is fixed for the session's lifetime. For claude and codex agents the model may carry an `@effort` suffix — `low`/`medium`/`high`/`xhigh`/`max` — controlling reasoning depth (e.g. `opus@low`, `gpt-6-astra@xhigh`; bare `@max` = default model at that effort).
 - **Capacity:** each env is several containers and a few GB of RAM. Call `GET /host` before creating many (it estimates how many more fit); respect `503 at capacity`.
 - **Credentials are the operator's, server-side** (managed on the Settings page) — you never send GitHub/Claude tokens.
 - **Errors** are `{"error":"…"}` with a 4xx/5xx status: `401` bad/missing token, `404` unknown env, `409` name taken / turn in progress, `503` at capacity.

--- a/create-katalystwp/server/src/claude.js
+++ b/create-katalystwp/server/src/claude.js
@@ -22,6 +22,21 @@ import { log, redact } from './log.js';
 
 const AGENT_CWD = '/home/node'; // in-workspace.sh runs the agent here (container WORKDIR)
 
+// A session's model string may carry an @effort suffix — "opus@low",
+// "gpt-6-astra@xhigh", or bare "@max" (agent-default model at that effort).
+// claude (--effort) and codex (-c model_reasoning_effort=) speak the same five
+// levels. The suffix only splits when it names one of them, so a literal model
+// id containing @ still passes through verbatim.
+const EFFORT_LEVELS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
+export function splitModelEffort(spec) {
+  const s = String(spec || '');
+  const at = s.lastIndexOf('@');
+  if (at === -1) return { model: s || null, effort: null };
+  const effort = s.slice(at + 1).toLowerCase();
+  if (!EFFORT_LEVELS.has(effort)) return { model: s || null, effort: null };
+  return { model: s.slice(0, at) || null, effort };
+}
+
 // Per-agent specifics: how to build the command, which token to inject, and how
 // to turn one stdout line into { records[], sessionId?, result?, addCost?, errorText? }.
 // `records` are events in the UI's vocabulary (system/assistant/user/result/stderr/raw).
@@ -35,7 +50,9 @@ export const AGENTS = {
     resumeHint: (dir, sid) => `cd ${dir} && bash scripts/in-workspace.sh claude --resume ${sid}`,
     buildArgs(session, prompt) {
       const a = ['claude', '-p', prompt, '--output-format', 'stream-json', '--verbose', '--include-partial-messages', '--dangerously-skip-permissions'];
-      if (session.model) a.push('--model', session.model);
+      const { model, effort } = splitModelEffort(session.model);
+      if (model) a.push('--model', model);
+      if (effort) a.push('--effort', effort);
       if (session.claudeSessionId) a.push('--resume', session.claudeSessionId);
       return a;
     },
@@ -65,7 +82,9 @@ export const AGENTS = {
       // `resume` subcommand — `codex exec resume` has a narrow option set and
       // rejects them. So: codex exec <exec-flags> [resume <id>] <prompt>.
       const a = ['codex', 'exec', '--json', '--dangerously-bypass-approvals-and-sandbox', '--skip-git-repo-check', '-C', AGENT_CWD];
-      if (session.model) a.push('-m', session.model);
+      const { model, effort } = splitModelEffort(session.model);
+      if (model) a.push('-m', model);
+      if (effort) a.push('-c', `model_reasoning_effort=${effort}`);
       if (session.claudeSessionId) a.push('resume', session.claudeSessionId);
       a.push(prompt);
       return a;

--- a/create-katalystwp/server/src/mcp.js
+++ b/create-katalystwp/server/src/mcp.js
@@ -36,7 +36,8 @@ export function buildMcpRoutes(config, registry, manager, sessions, presets, set
   // Built from live config so the docs can never disagree with the default.
   const MODEL_ARG = str(
     `Model for the session (optional). Omit for the server default — "${config.claudeDefaultModel}", which Claude Code resolves to the latest Opus. ` +
-    'Accepts any Claude Code model alias or id (e.g. opus, sonnet, haiku, claude-fable-5), passed verbatim to the agent CLI. ' +
+    'Accepts any Claude Code model alias or id (e.g. opus, sonnet, haiku, claude-fable-5). ' +
+    'For claude and codex agents, append @low/@medium/@high/@xhigh/@max for reasoning effort (e.g. "opus@low", "gpt-6-astra@xhigh"; bare "@max" = default model at that effort). ' +
     'Fixed for the session\'s lifetime; codex/opencode agents have their own defaults.',
   );
   const args = (properties = {}, required = []) => ({ type: 'object', properties, required });
@@ -541,10 +542,12 @@ git, gh, and the agent CLIs. Environments are provisioned by composable
 Passing \`prompt\` to \`create_environment\` fuses the two flows: the session
 starts automatically the moment the env is ready.
 
-Both accept an optional \`model\` — any Claude Code alias or id, passed verbatim
-to the agent CLI. Omitted, a claude session runs the server default
-("${config.claudeDefaultModel}", resolved by Claude Code to the latest Opus).
-The model is fixed for the session's lifetime.
+Both accept an optional \`model\` — any Claude Code alias or id. Omitted, a
+claude session runs the server default ("${config.claudeDefaultModel}",
+resolved by Claude Code to the latest Opus). For claude and codex agents the
+model may carry an \`@effort\` suffix (low/medium/high/xhigh/max), e.g.
+\`opus@low\` or \`gpt-6-astra@xhigh\`. The model is fixed for the session's
+lifetime.
 
 \`duplicate_environment({ env })\` clones an existing environment — full DB +
 files copy on a fresh name and port (the source briefly stops during the copy,

--- a/create-katalystwp/server/ui/app.js
+++ b/create-katalystwp/server/ui/app.js
@@ -468,17 +468,23 @@ const AGENTS_ORDER = ['claude', 'codex', 'opencode'];
 // server default decide". A "Custom…" escape hatch lets you type any id, except
 // for agents in NO_CUSTOM_MODEL. Set only at session start. The OpenCode (Zen)
 // list is the subset verified usable with our Zen key (see its comment below).
+// Claude and codex ids may carry an @effort suffix (low/medium/high/xhigh/max) —
+// the server splits it into --effort / -c model_reasoning_effort= (claude.js).
 const MODELS = {
   claude: [
     { id: '', label: 'Default' },
     { id: 'fable', label: 'Fable 5' },
+    { id: 'fable@max', label: 'Fable 5 @max (hardest problems)' },
     { id: 'opus', label: 'Opus 4.8' },
+    { id: 'opus@low', label: 'Opus 4.8 @low (quick tasks)' },
     { id: 'sonnet', label: 'Sonnet 4.6' },
     { id: 'haiku', label: 'Haiku 4.5' },
   ],
   codex: [
     { id: '', label: 'Default' },
     { id: 'gpt-6-astra', label: 'gpt-6-astra (flagship)' }, // needs codex-cli ≥ 0.153 in the workspace
+    { id: 'gpt-6-astra@low', label: 'gpt-6-astra @low (quick tasks)' },
+    { id: 'gpt-6-astra@xhigh', label: 'gpt-6-astra @xhigh (hard problems)' },
     { id: 'gpt-5.6-sol', label: 'gpt-5.6-sol' },
     { id: 'gpt-5.6-terra', label: 'gpt-5.6-terra (balanced)' },
     { id: 'gpt-5.6-luna', label: 'gpt-5.6-luna (fast/cheap)' },
@@ -568,7 +574,7 @@ function AgentPicker({ agent, model, prompt, onAgent, onModel, onPrompt, promptL
       </label>
     </div>
     ${custom && html`<label>Custom model id
-      <input value=${model} placeholder=${agent === 'opencode' ? 'opencode/provider-model' : 'model id'} onInput=${(e) => onModel(e.target.value)} />
+      <input value=${model} placeholder=${agent === 'opencode' ? 'opencode/provider-model' : 'model id, optionally model@effort'} onInput=${(e) => onModel(e.target.value)} />
     </label>`}
     <label>${promptLabel}${promptHint && html` <span class="muted small">${promptHint}</span>`}
       <textarea value=${prompt} rows=${promptRows} placeholder=${promptPlaceholder} onInput=${(e) => onPrompt(e.target.value)}></textarea>

--- a/create-katalystwp/server/ui/app.js
+++ b/create-katalystwp/server/ui/app.js
@@ -478,7 +478,8 @@ const MODELS = {
   ],
   codex: [
     { id: '', label: 'Default' },
-    { id: 'gpt-5.6-sol', label: 'gpt-5.6-sol (flagship)' },
+    { id: 'gpt-6-astra', label: 'gpt-6-astra (flagship)' }, // needs codex-cli ≥ 0.153 in the workspace
+    { id: 'gpt-5.6-sol', label: 'gpt-5.6-sol' },
     { id: 'gpt-5.6-terra', label: 'gpt-5.6-terra (balanced)' },
     { id: 'gpt-5.6-luna', label: 'gpt-5.6-luna (fast/cheap)' },
     { id: 'gpt-5.5', label: 'gpt-5.5' },


### PR DESCRIPTION
Two related additions for codex/claude model control:

## gpt-6-astra in the Codex dropdown

Adds `gpt-6-astra` (OpenAI's GPT-6 Astra, released 2026-09-03) to the curated Codex model list as the flagship pick; `gpt-5.6-sol` loses its "(flagship)" tag.

- The server passes any model id through to `codex exec -m` verbatim — only the UI list needed the entry (Codex deliberately has no "Custom…" option).
- The model requires **codex-cli ≥ 0.153** in the workspace. The workspace image installs `@openai/codex` unpinned, so the image cache was rebuilt on the box (`--no-cache`) — new envs get 0.153.4. Envs built earlier still carry 0.150.1 and will error on it; pick an older model there.
- Paired live-box change (not in this PR): `CODEX_DEFAULT_MODEL=gpt-6-astra` in `/etc/devbox/devbox.env`.

## `@effort` suffix on session model ids (claude + codex)

A session's model may now carry an `@effort` suffix — `low`/`medium`/`high`/`xhigh`/`max`, the five levels both agents share: `opus@low`, `gpt-6-astra@xhigh`, bare `@max` (agent-default model at that effort).

- `splitModelEffort()` in `claude.js` does the split; a suffix that isn't a known level leaves the string untouched, so literal model ids containing `@` still work. Applied per invocation → resumes keep the session's effort.
- claude emits `--effort <level>` (`claude -p` supports it on both current and older workspace images); codex emits `-c model_reasoning_effort=<level>` before the `resume` subcommand (no `--reasoning-effort` on `codex exec`; the `-c` override validated against codex 0.153.4 with `--strict-config`). opencode untouched.
- UI dropdowns gain curated combos; MCP model-arg docs, `get_instructions`, and AGENT_USAGE.md updated.
- Fast/speed tiers deliberately unsupported — 2× price for pure latency that headless background sessions don't benefit from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReZ2Vgv5sRUdZxY6bg5gqs
