### PR TITLE
fix(server/ui): phantom concatenated bubble after a turn ends

### DIFF
--- a/create-katalystwp/server/ui/app.js
+++ b/create-katalystwp/server/ui/app.js
@@ -70,6 +70,8 @@ function reduce(items, partialRef, evt) {
       break;
     }
     case 'result':
+      // The turn is over: whatever the live line held is now an assistant bubble.
+      partialRef.text = '';
       push({ kind: 'result', result: evt.result, cost: evt.total_cost_usd, ms: evt.duration_ms, isError: evt.is_error });
       break;
     case 'stderr':
@@ -77,6 +79,7 @@ function reduce(items, partialRef, evt) {
       break;
     case 'control':
       if (evt.subtype === 'turn-start') push({ kind: 'control', text: '— turn —' });
+      if (evt.subtype === 'turn-end') partialRef.text = '';
       break;
     case 'raw':
       push({ kind: 'raw', text: evt.text });
@@ -365,12 +368,27 @@ function SessionView({ session, now, onChanged, onMenu, onDelete, onArchive, onR
       if (cancelled) return;
       setLoading(false);
       es = new EventSource(streamUrl(id));
+      // The server replays its ring buffer (backlog) on every connect, then
+      // sends a `snapshot` control event before going live. Backlog token
+      // deltas must NOT feed the live line: the history load above already
+      // rebuilt it, and deltas of completed messages were filtered out of
+      // that response (partials=live) — so their uuids aren't in `seen`, while
+      // the assistant events that would reset the line ARE. Replaying them
+      // used to concatenate every message of the turn into a phantom bubble
+      // that outlived the "done" footer. Re-armed on each auto-reconnect.
+      let replaying = true;
+      es.onopen = () => { replaying = true; };
       es.onmessage = (m) => {
         let evt; try { evt = JSON.parse(m.data); } catch { return; }
-        if (evt.type === 'control' && evt.subtype === 'snapshot') return;
+        if (evt.type === 'control' && evt.subtype === 'snapshot') { replaying = false; return; }
         if (evt.uuid && seen.current.has(evt.uuid)) return;
         if (evt.uuid) seen.current.add(evt.uuid);
         if (evt.type === 'control' && evt.subtype === 'turn-end') { setBusy(false); onChanged && onChanged(); }
+        // Control events carry no uuid, so a replayed turn-start would also
+        // duplicate the "— turn —" divider history already drew; the turn-end
+        // side effect above still runs so a reconnect mid-turn can't leave the
+        // composer stuck disabled.
+        if (replaying && (evt.type === 'stream_event' || evt.type === 'control')) return;
         setItems((prev) => { const next = prev.slice(); reduce(next, partialRef.current, evt); return next; });
         setPartial(partialRef.current.text);
       };
@@ -454,7 +472,7 @@ function SessionView({ session, now, onChanged, onMenu, onDelete, onArchive, onR
         ${loading && !loadErr && html`<div class="muted pad">loading history…</div>`}
         ${loadErr && html`<div class="err-msg">could not load history: ${loadErr}</div>`}
         ${items.map((it, i) => html`<${Bubble} it=${it} key=${i} />`)}
-        ${partial && html`<div class="bubble assistant live"><pre>${partial}</pre><span class="cursor">▍</span></div>`}
+        ${running && partial && html`<div class="bubble assistant live"><pre>${partial}</pre><span class="cursor">▍</span></div>`}
         ${running && !partial && !loading && html`<div class="muted pad">…thinking</div>`}
       </div>
       ${hasNew && html`<button class="new-msgs" onClick=${jumpToBottom}>↓ New messages</button>`}


### PR DESCRIPTION
## Bug

After a turn finished, the session view showed an extra "live" bubble (with the typing cursor) below the ✓ done footer containing every assistant message of the turn concatenated, e.g. the "I'll check the sandbox…" preamble glued to the final answer. It looked like a second session or a headless-Claude quirk; it was neither — the transcript has one process, one Claude session id, and a `result` equal to the last message only.

## Cause (`ui/app.js`)

1. History loads with `partials=live`, which drops the token deltas of completed messages, so their uuids never enter `seen`.
2. On connect the stream route replays the ring-buffer backlog (`src/routes.js`), including those deltas. Unseen → appended to the live-partial string.
3. The `assistant` events that reset the string are in `seen` (from history) and get deduped away, so nothing ever clears it.
4. The live bubble rendered whenever the string was non-empty, running or not.

Control events have no uuid, so the replayed `turn-start` also drew a duplicate "— turn —" divider.

## Fix

- Track replay: everything before the `snapshot` control event is backlog; skip `stream_event` and `control` events during it (re-armed on each EventSource reconnect). The `turn-end` busy reset still runs so a reconnect mid-turn can't leave the composer disabled.
- Clear the live line on `result` and `turn-end`.
- Render the live bubble only while the session is running.

## Verified

Replayed the real `reduce()` from `ui/app.js` against session `sess_57c3c97c63`'s event log frozen at the end of turn 1, following the same history → backlog sequence the browser performs:

| | live-partial length | dividers | assistant bubbles |
|---|---|---|---|
| before | 2803 chars, starts `I'll check the sandbox…` | 2 | 2 |
| after | 0 | 1 | 2 |

UI-only change: served fresh per request, no server restart. Stacked on #81 (`fable-5-1`); retarget to master once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018puUXTJeSWdbG8ZMCFVqQL
